### PR TITLE
Set Italy starting resources

### DIFF
--- a/engine/src/maps/italy.ts
+++ b/engine/src/maps/italy.ts
@@ -224,5 +224,6 @@ export const map: GameMap = {
         { nodes: [Cities.Ferrara, Cities.Modena], cost: 4 },
     ],
     mapPosition: [-20, 320],
+    startingResources: [18, 15, 12, 2],
     mapSpecificRules: 'Stop resupplying uranium after power plant 39 has been bought.',
 };


### PR DESCRIPTION
From the rulebook: "The resource market is filled as follows: coal on spaces 3 to 8, oil on spaces 4 to 8, waste on space 5 to 8, and uranium on spaces 14 and 16."

https://www.riograndegames.com/wp-content/uploads/2013/02/Power-Grid-Italy-France-Rules.pdf