### PR TITLE
Fix extra coal supply in USA recharged

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -64,6 +64,7 @@
                 :isUsaRecharged="G.options.variant == 'recharged' && G.map.name == 'USA'"
                 :buyableResources="buyableResources()"
                 :resourceResupply="getResourceResupply()"
+                :coalSupply="G.coalSupply"
                 @buyResource="buyResource($event)"
             />
 

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -143,13 +143,16 @@
             >
                 8
             </text>
-            <Coal :pieceId="-1" :targetState="{ x: 840, y: 57 }" :scale="0.2"
-                :canClick="coalSupply && canBuyResource('coal')" :transparent="coalSupply == 0" @click="buyResource('coal')" />
-            <text text-anchor="middle"
-                style="font-size: 20px; font-family: monospace"
-                x="905"
-                y="80">
-                x{{coalSupply}}
+            <Coal
+                :pieceId="-1"
+                :targetState="{ x: 840, y: 57 }"
+                :scale="0.2"
+                :canClick="coalSupply && canBuyResource('coal')"
+                :transparent="coalSupply == 0"
+                @click="buyResource('coal')"
+            />
+            <text text-anchor="middle" style="font-size: 20px; font-family: monospace" x="905" y="80">
+                x{{ coalSupply }}
             </text>
         </template>
 

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -143,7 +143,14 @@
             >
                 8
             </text>
-            <Coal :pieceId="-1" :targetState="{ x: 858, y: 57 }" :canClick="false" :transparent="true" :scale="0.2" />
+            <Coal :pieceId="-1" :targetState="{ x: 840, y: 57 }" :scale="0.2"
+                :canClick="coalSupply && canBuyResource('coal')" :transparent="coalSupply == 0" @click="buyResource('coal')" />
+            <text text-anchor="middle"
+                style="font-size: 20px; font-family: monospace"
+                x="905"
+                y="80">
+                x{{coalSupply}}
+            </text>
         </template>
 
         <template v-if="!preferences.disableHelp">
@@ -177,6 +184,7 @@ import { range } from 'lodash';
 export default class Resources extends Vue {
     @Prop() resourceResupply?: number[];
     @Prop() isUsaRecharged?: boolean;
+    @Prop() coalSupply?: number;
     @Prop() buyableResources?: string[];
 
     @Inject() preferences!: Preferences;


### PR DESCRIPTION
The large icon for buying coal from the supply on the USA recharged map is not actually clickable. This enables it whenever there is coal available in the supply.

This also adds a counter showing the number of coal in the supply.