### PR TITLE
Fix fast bidding for discount plant in recharged variant

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -85,9 +85,8 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                         }
                     } else {
                         if (G.options.fastBid) {
-                            const minimunBid = G.chosenPowerPlant.number;
-                            if (minimunBid <= player.money) {
-                                moves[MoveName.Bid] = range(minimunBid, player.money + 1);
+                            if (G.minimunBid <= player.money) {
+                                moves[MoveName.Bid] = range(G.minimunBid, player.money + 1);
                             }
                         } else {
                             if (G.currentBid) {


### PR DESCRIPTION
Fixes https://github.com/boardgamers/powergrid/issues/25. In the recharged variant, the minimum bid is not always the power plant number, because of the discount token.