### PR TITLE
Fix recharged deck setup

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -21,10 +21,10 @@ describe('Engine', () => {
             map: game.options.map as MapName,
             showMoney: game.options.showMoney,
             variant: game.options.variant as Variant,
-            useOldRechargedSetup: game.options.useOldRechargedSetup,
+            useNewRechargedSetup: game.options.useNewRechargedSetup,
         };
 
-        expect(options.useOldRechargedSetup).to.be.true;
+        expect(options.useNewRechargedSetup).to.be.false;
 
         let G = setup(game.players.length, options, game.seed);
 
@@ -41,7 +41,7 @@ describe('Engine', () => {
     it('should replay game Germany recharged', () => {
         const game = GermanyRecharged;
 
-        expect(game.options.useOldRechargedSetup).to.be.true;
+        expect(game.options.useNewRechargedSetup).to.be.false;
 
         const G = reconstructState(game as any, game.log.length - 1);
 
@@ -55,10 +55,10 @@ describe('Engine', () => {
             map: game.options.map as MapName,
             showMoney: game.options.showMoney,
             variant: game.options.variant as Variant,
-            useOldRechargedSetup: game.options.useOldRechargedSetup,
+            useNewRechargedSetup: game.options.useNewRechargedSetup,
         };
 
-        expect(options.useOldRechargedSetup).to.be.true;
+        expect(options.useNewRechargedSetup).to.be.false;
 
         let G = setup(game.players.length, options, game.seed);
 

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -21,7 +21,10 @@ describe('Engine', () => {
             map: game.options.map as MapName,
             showMoney: game.options.showMoney,
             variant: game.options.variant as Variant,
+            useOldRechargedSetup: game.options.useOldRechargedSetup,
         };
+
+        expect(options.useOldRechargedSetup).to.be.true;
 
         let G = setup(game.players.length, options, game.seed);
 
@@ -38,6 +41,8 @@ describe('Engine', () => {
     it('should replay game Germany recharged', () => {
         const game = GermanyRecharged;
 
+        expect(game.options.useOldRechargedSetup).to.be.true;
+
         const G = reconstructState(game as any, game.log.length - 1);
 
         expect(ended(G)).to.be.true;
@@ -50,7 +55,10 @@ describe('Engine', () => {
             map: game.options.map as MapName,
             showMoney: game.options.showMoney,
             variant: game.options.variant as Variant,
+            useOldRechargedSetup: game.options.useOldRechargedSetup,
         };
+
+        expect(options.useOldRechargedSetup).to.be.true;
 
         let G = setup(game.players.length, options, game.seed);
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -21,7 +21,7 @@ export function defaultSetupDeck(
     numPlayers: number,
     variant: string,
     rng: seedrandom.prng,
-    useOldRechargedSetup: boolean
+    useNewRechargedSetup: boolean
 ) {
     let actualMarket: PowerPlant[];
     let futureMarket: PowerPlant[];
@@ -62,7 +62,7 @@ export function defaultSetupDeck(
         } else if (numPlayers == 4) {
             initialPowerPlants = initialPowerPlants.slice(1);
             powerPlantsDeck = shuffle(powerPlantsDeck.slice(3).concat(initialPowerPlants), rng() + '');
-        } else if (!useOldRechargedSetup) {
+        } else if (useNewRechargedSetup) {
             // TODO: This flag exists solely to make old tests pass. We should eventually
             // fix the test and remove the flag.
             powerPlantsDeck = shuffle(powerPlantsDeck.concat(initialPowerPlants), rng() + '');
@@ -82,7 +82,7 @@ export function setup(
         map = 'USA',
         variant = 'original',
         showMoney = false,
-        useOldRechargedSetup = false,
+        useNewRechargedSetup = true,
     }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
@@ -135,7 +135,7 @@ export function setup(
                 numPlayers,
                 variant,
                 rng,
-                useOldRechargedSetup
+                useNewRechargedSetup
             ));
         }
     }

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -17,7 +17,7 @@ const citiesToEndGame = [21, 17, 17, 15, 14];
 const cityIncome = [10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150];
 const regionsInPlay = [3, 3, 4, 5, 5];
 
-export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedrandom.prng) {
+export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedrandom.prng, useOldRechargedSetup: boolean) {
     let actualMarket: PowerPlant[];
     let futureMarket: PowerPlant[];
     let powerPlantsDeck: PowerPlant[];
@@ -50,16 +50,19 @@ export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedr
         const first = initialPowerPlants.shift()!;
         const step3 = powerPlantsDeck.pop()!;
 
+        powerPlantsDeck = shuffle(powerPlantsDeck, rng() + '');
         if (numPlayers == 2 || numPlayers == 3) {
             initialPowerPlants = initialPowerPlants.slice(2);
             powerPlantsDeck = shuffle(powerPlantsDeck.slice(6).concat(initialPowerPlants), rng() + '');
         } else if (numPlayers == 4) {
             initialPowerPlants = initialPowerPlants.slice(1);
             powerPlantsDeck = shuffle(powerPlantsDeck.slice(3).concat(initialPowerPlants), rng() + '');
-        } else {
+        } else if (!useOldRechargedSetup) {
+            // TODO: This flag exists solely to make old tests pass. We should eventually
+            // fix the test and remove the flag.
             powerPlantsDeck = shuffle(powerPlantsDeck.concat(initialPowerPlants), rng() + '');
         }
-
+        
         powerPlantsDeck.unshift(first);
         powerPlantsDeck.push(step3);
     }
@@ -69,10 +72,10 @@ export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedr
 
 export function setup(
     numPlayers: number,
-    { fastBid = false, map = 'USA', variant = 'original', showMoney = false }: GameOptions,
+    { fastBid = false, map = 'USA', variant = 'original', showMoney = false, useOldRechargedSetup = false }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
-    forceMap?: GameMap
+    forceMap?: GameMap,
 ): GameState {
     seed = seed ?? Math.random().toString();
     const rng = seedrandom(seed);
@@ -117,7 +120,7 @@ export function setup(
         if (chosenMap.setupDeck) {
             ({ actualMarket, futureMarket, powerPlantsDeck } = chosenMap.setupDeck(numPlayers, variant, rng));
         } else {
-            ({ actualMarket, futureMarket, powerPlantsDeck } = defaultSetupDeck(numPlayers, variant, rng));
+            ({ actualMarket, futureMarket, powerPlantsDeck } = defaultSetupDeck(numPlayers, variant, rng, useOldRechargedSetup));
         }
     }
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -17,7 +17,12 @@ const citiesToEndGame = [21, 17, 17, 15, 14];
 const cityIncome = [10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150];
 const regionsInPlay = [3, 3, 4, 5, 5];
 
-export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedrandom.prng, useOldRechargedSetup: boolean) {
+export function defaultSetupDeck(
+    numPlayers: number,
+    variant: string,
+    rng: seedrandom.prng,
+    useOldRechargedSetup: boolean
+) {
     let actualMarket: PowerPlant[];
     let futureMarket: PowerPlant[];
     let powerPlantsDeck: PowerPlant[];
@@ -62,7 +67,7 @@ export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedr
             // fix the test and remove the flag.
             powerPlantsDeck = shuffle(powerPlantsDeck.concat(initialPowerPlants), rng() + '');
         }
-        
+
         powerPlantsDeck.unshift(first);
         powerPlantsDeck.push(step3);
     }
@@ -72,10 +77,16 @@ export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedr
 
 export function setup(
     numPlayers: number,
-    { fastBid = false, map = 'USA', variant = 'original', showMoney = false, useOldRechargedSetup = false }: GameOptions,
+    {
+        fastBid = false,
+        map = 'USA',
+        variant = 'original',
+        showMoney = false,
+        useOldRechargedSetup = false,
+    }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
-    forceMap?: GameMap,
+    forceMap?: GameMap
 ): GameState {
     seed = seed ?? Math.random().toString();
     const rng = seedrandom(seed);
@@ -120,7 +131,12 @@ export function setup(
         if (chosenMap.setupDeck) {
             ({ actualMarket, futureMarket, powerPlantsDeck } = chosenMap.setupDeck(numPlayers, variant, rng));
         } else {
-            ({ actualMarket, futureMarket, powerPlantsDeck } = defaultSetupDeck(numPlayers, variant, rng, useOldRechargedSetup));
+            ({ actualMarket, futureMarket, powerPlantsDeck } = defaultSetupDeck(
+                numPlayers,
+                variant,
+                rng,
+                useOldRechargedSetup
+            ));
         }
     }
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -50,13 +50,14 @@ export function defaultSetupDeck(numPlayers: number, variant: string, rng: seedr
         const first = initialPowerPlants.shift()!;
         const step3 = powerPlantsDeck.pop()!;
 
-        powerPlantsDeck = shuffle(powerPlantsDeck, rng() + '');
         if (numPlayers == 2 || numPlayers == 3) {
             initialPowerPlants = initialPowerPlants.slice(2);
             powerPlantsDeck = shuffle(powerPlantsDeck.slice(6).concat(initialPowerPlants), rng() + '');
         } else if (numPlayers == 4) {
             initialPowerPlants = initialPowerPlants.slice(1);
             powerPlantsDeck = shuffle(powerPlantsDeck.slice(3).concat(initialPowerPlants), rng() + '');
+        } else {
+            powerPlantsDeck = shuffle(powerPlantsDeck.concat(initialPowerPlants), rng() + '');
         }
 
         powerPlantsDeck.unshift(first);

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -77,13 +77,7 @@ export function defaultSetupDeck(
 
 export function setup(
     numPlayers: number,
-    {
-        fastBid = false,
-        map = 'USA',
-        variant = 'original',
-        showMoney = false,
-        useNewRechargedSetup = true,
-    }: GameOptions,
+    { fastBid = false, map = 'USA', variant = 'original', showMoney = false, useNewRechargedSetup = true }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
     forceMap?: GameMap

--- a/engine/src/fixtures/GermanyRecharged.json
+++ b/engine/src/fixtures/GermanyRecharged.json
@@ -845,7 +845,8 @@
         "fastBid": false,
         "map": "Germany",
         "variant": "recharged",
-        "showMoney": true
+        "showMoney": true,
+        "useOldRechargedSetup": true
     },
     "log": [
         {

--- a/engine/src/fixtures/GermanyRecharged.json
+++ b/engine/src/fixtures/GermanyRecharged.json
@@ -846,7 +846,7 @@
         "map": "Germany",
         "variant": "recharged",
         "showMoney": true,
-        "useOldRechargedSetup": true
+        "useNewRechargedSetup": false
     },
     "log": [
         {

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -23,7 +23,7 @@ export interface GameOptions {
     map?: MapName;
     variant?: Variant;
     showMoney?: boolean;
-    useOldRechargedSetup?: boolean;
+    useNewRechargedSetup?: boolean;
 }
 
 export enum ResourceType {

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -23,6 +23,7 @@ export interface GameOptions {
     map?: MapName;
     variant?: Variant;
     showMoney?: boolean;
+    useOldRechargedSetup?: boolean;
 }
 
 export enum ResourceType {


### PR DESCRIPTION
The default deck setup for recharged rules is accidentally missing four plants from 3-15 that are supposed to be shuffled into the rest of the deck.