### PR TITLE
Fix middle east

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1534,15 +1534,20 @@ function removePlantsForMiddleEastStep1(G: GameState) {
         }
 
         // Prevent infinite loop cycling through power plants.
-        let availableFuturePlants = G.futureMarket.filter(pp => pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium);
-        let nextFuturePlantNumber = availableFuturePlants.length > 0 ? availableFuturePlants[0].number : 100;
-        if (G.powerPlantsDeck.filter(pp =>
-                (pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium)
-                || pp.number > nextFuturePlantNumber
-            ).length == 0) {
+        const availableFuturePlants = G.futureMarket.filter(
+            (pp) => pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium
+        );
+        const nextFuturePlantNumber = availableFuturePlants.length > 0 ? availableFuturePlants[0].number : 100;
+        if (
+            G.powerPlantsDeck.filter(
+                (pp) =>
+                    (pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium) ||
+                    pp.number > nextFuturePlantNumber
+            ).length == 0
+        ) {
             G.log.push({
                 type: 'event',
-                event: 'No suitable power plants available to draw.'
+                event: 'No suitable power plants available to draw.',
             });
             break;
         }

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1533,7 +1533,13 @@ function removePlantsForMiddleEastStep1(G: GameState) {
             });
         }
 
-        if (G.powerPlantsDeck.filter(pp => pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium).length == 0) {
+        // Prevent infinite loop cycling through power plants.
+        let availableFuturePlants = G.futureMarket.filter(pp => pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium);
+        let nextFuturePlantNumber = availableFuturePlants.length > 0 ? availableFuturePlants[0].number : 100;
+        if (G.powerPlantsDeck.filter(pp =>
+                (pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium)
+                || pp.number > nextFuturePlantNumber
+            ).length == 0) {
             G.log.push({
                 type: 'event',
                 event: 'No suitable power plants available to draw.'

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -634,6 +634,10 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                         let oilResupplyValue: number;
                         if (G.map.name == 'Middle East') {
+                            if (G.oilMarket == 0) {
+                                G.oilPrices = prices[ResourceType.Oil];
+                            }
+
                             oilResupplyValue = G.oilResupply![G.players.length - 2][G.step - 1];
                             for (let i = 0; i < oilResupplyValue; i++) {
                                 if (G.oilSupply > 0) {
@@ -1512,6 +1516,7 @@ function removePlantsForMiddleEastStep1(G: GameState) {
     let plantToRemove: PowerPlant | undefined = G.actualMarket.find(
         (pp: PowerPlant) => pp.type == PowerPlantType.Garbage || pp.type == PowerPlantType.Uranium
     );
+
     while (plantToRemove) {
         removePowerPlant(G, plantToRemove);
 
@@ -1526,6 +1531,14 @@ function removePlantsForMiddleEastStep1(G: GameState) {
                 type: 'event',
                 event: `Sending Power Plant ${plantToRemove.number} to the bottom of the deck.`,
             });
+        }
+
+        if (G.powerPlantsDeck.filter(pp => pp.type != PowerPlantType.Garbage && pp.type != PowerPlantType.Uranium).length == 0) {
+            G.log.push({
+                type: 'event',
+                event: 'No suitable power plants available to draw.'
+            });
+            break;
         }
 
         addPowerPlant(G);

--- a/engine/src/maps/middleeast.ts
+++ b/engine/src/maps/middleeast.ts
@@ -221,5 +221,5 @@ export const map: GameMap = {
     startingResources: [21, 21, 3, 3],
     startingSupply: [24, 24, 21, 11],
     mapSpecificRules:
-        'Only coal and oil can be bought for $1, and any number of oil can restock at $1. During step 1, garbage and nuclear plants will be removed from the current market. Step 2 will be triggered after going through the deck once rather than by a specific number of cities. Step 3 will be triggered after going through the deck a second time.',
+        'Only coal and oil can be bought for $1, and any number of oil can restock at $1.\nDuring step 1, garbage and uranium plants will be removed from the current market.\nStep 2 will be triggered after going through the deck once rather than by a specific number of cities.\nStep 3 will be triggered after going through the deck a second time.',
 };


### PR DESCRIPTION
This fixes three issues with the Middle East map:
1. The map-specific rules are all on one line, which is far too wide. This adds newlines between each rule.
2. The oil prices are now reset to fill from the top if all oil in the market has been purchased.
3. If we reach the rare state in which all of the plants in the deck are either garbage or uranium, and all of them cost more than the next plant in the future market that is not garbage or uranium, then we currently enter an infinite loop. This breaks from the loop and skips adding new plants to the actual market instead.