### PR TITLE
Add analysis

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -637,6 +637,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 G.players.forEach((player) => {
                                     const payment = G.paymentTable[player.citiesPowered] - 3 * player.cities.length;
                                     player.money += Math.max(payment, 0);
+                                    player.totalIncome += Math.max(payment, 0);
                                 });
                             }
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1725,7 +1725,6 @@ function playerNameHTML(player) {
 }
 
 export function playersSortedByScore(G: GameState): Player[] {
-    console.log(G.players);
     return cloneDeep(G.players)
         .sort((p1, p2) => {
             if (p1.citiesPowered == p2.citiesPowered) {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -82,7 +82,7 @@ export function setup(
         variant = 'original',
         showMoney = false,
         useNewRechargedSetup = true,
-        trackTotals: trackTotalSpent = true,
+        trackTotalSpent = true,
     }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
@@ -300,7 +300,7 @@ export function setup(
         auctioningPlayer: undefined,
         step: 1,
         phase: Phase.Auction,
-        options: { fastBid, map, variant, showMoney },
+        options: { fastBid, map, variant, showMoney, useNewRechargedSetup, trackTotalSpent },
         log: [],
         hiddenLog: [],
         seed,
@@ -690,7 +690,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     }
                     player.money += payment;
 
-                    if (G.options.trackTotals) {
+                    if (G.options.trackTotalSpent) {
                         player.totalIncome += payment;
                     }
 
@@ -1075,7 +1075,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
             player.money -= price;
 
-            if (G.options.trackTotals) {
+            if (G.options.trackTotalSpent) {
                 player.totalSpentResources += price;
             }
 
@@ -1099,7 +1099,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
             player.cities.push({ name: move.data.name, position });
             player.money -= move.data.price;
 
-            if (G.options.trackTotals) {
+            if (G.options.trackTotalSpent) {
                 player.totalSpentCities += 10 + position * 5;
                 player.totalSpentConnections += move.data.price - (10 + position * 5);
             }
@@ -1237,7 +1237,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                     player.money += price;
 
-                    if (G.options.trackTotals) {
+                    if (G.options.trackTotalSpent) {
                         player.totalSpentResources -= price;
                     }
 
@@ -1255,7 +1255,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                     const position = G.players.filter((p) => p.cities.find((c) => c.name == lastMove.data.name)).length;
 
-                    if (G.options.trackTotals) {
+                    if (G.options.trackTotalSpent) {
                         player.totalSpentCities -= 10 + position * 5;
                         player.totalSpentConnections -= lastMove.data.price - (10 + position * 5);
                     }
@@ -1854,7 +1854,7 @@ function endAuction(G: GameState, winningPlayer: Player, bid: number) {
     winningPlayer.powerPlants.push(G.chosenPowerPlant!);
     winningPlayer.money -= bid;
 
-    if (G.options.trackTotals) {
+    if (G.options.trackTotalSpent) {
         winningPlayer.totalSpentPlants += bid;
     }
 

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -81,6 +81,11 @@ export interface Player {
     skipAuction: boolean;
     citiesPowered: number;
     resourcesUsed: ResourceType[];
+    totalIncome: number;
+    totalSpentCities: number;
+    totalSpentConnections: number;
+    totalSpentPlants: number;
+    totalSpentResources: number;
 }
 
 export enum Phase {

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -80,7 +80,7 @@
                         :text="'Final Score'"
                         @click="endScoreVisible = true"
                     />
-                    <template v-if="G.options.trackTotals">
+                    <template v-if="G.options.trackTotalSpent">
                         <Button
                             :transform="`translate(180, 50)`"
                             :width="120"

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -79,6 +79,12 @@
                         :text="'Final Score'"
                         @click="endScoreVisible = true"
                     />
+                    <Button
+                        :transform="`translate(180, 50)`"
+                        :width="120"
+                        :text="'Game Stats'"
+                        @click="spendingVisible = true"
+                    />
                 </template>
                 <template v-else>
                     <text x="10" y="20" font-weight="600" fill="black" style="font-size: 32px">
@@ -190,6 +196,48 @@
                         <td v-for="player in sortedPlayers" :key="'FS' + player.id + i">
                             <div>
                                 {{ i == 0 ? player.citiesPowered : i == 1 ? player.money : player.cities.length }}
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+
+        <div v-if="G && gameEnded(G)" :class="['modal', { visible: spendingVisible }]">
+            <div class="modal-content">
+                <span class="close" @click="spendingVisible = false">&times;</span>
+                <div class="modal-title">Spending</div>
+                <table class="spending-table">
+                    <tr>
+                        <th><div>Player</div></th>
+                        <th v-for="player in sortedPlayers" :key="'FS' + player.id">
+                            <div :style="'background-color: ' + playerColors[player.id]">{{ player.name }}</div>
+                        </th>
+                    </tr>
+                    <tr
+                        v-for="(cat, i) in [
+                            'Income',
+                            'Spending: Cities',
+                            'Spending: Connections',
+                            'Spending: Plants',
+                            'Spending: Resources',
+                        ]"
+                        :key="'FC_' + cat"
+                    >
+                        <td>{{ cat }}</td>
+                        <td v-for="player in sortedPlayers" :key="'FS' + player.id + i">
+                            <div>
+                                {{
+                                    i == 0
+                                        ? player.totalIncome
+                                        : i == 1
+                                        ? player.totalSpentCities
+                                        : i == 2
+                                        ? player.totalSpentConnections
+                                        : i == 3
+                                        ? player.totalSpentPlants
+                                        : player.totalSpentResources
+                                }}
                             </div>
                         </td>
                     </tr>
@@ -413,6 +461,7 @@ export default class Game extends Vue {
 
     logVisible = false;
     endScoreVisible = false;
+    spendingVisible = false;
     rulesVisible = false;
 
     totalBid: number = 0;
@@ -1197,7 +1246,8 @@ text {
     }
 }
 
-.final-score-table {
+.final-score-table,
+.spending-table {
     margin: auto;
     border: 1px solid black;
 


### PR DESCRIPTION
This adds an analysis screen at the end of the game for how each player spent their money. It's sorted in the same order as the final score screen.

<img width="1051" alt="Screen Shot 2022-04-22 at 10 45 17 PM" src="https://user-images.githubusercontent.com/7157281/164879669-b8d19f5b-7983-48dd-9390-c7fc0966e1f3.png">

