### PR TITLE
Enable China, original variant

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -427,7 +427,10 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     winningPlayer.powerPlants.length <= 3 ||
                     (G.players.length == 2 && winningPlayer.powerPlants.length == 4)
                 ) {
-                    addPowerPlant(G);
+                    if (G.map.name != 'China' || G.step == 3) {
+                        addPowerPlant(G);
+                    }
+
                     toResourcesPhase(G);
                 }
             } else {
@@ -501,11 +504,16 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         if (G.players.some((p) => !p.skipAuction && !p.isDropped)) {
                             nextPlayerAuction(G);
                         } else {
-                            if (G.auctionSkips == G.players.length && G.options.variant == 'original') {
+                            if (
+                                G.auctionSkips == G.players.length &&
+                                G.options.variant == 'original' &&
+                                G.map.name != 'China'
+                            ) {
                                 G.log.push({
                                     type: 'event',
                                     event: `Everyone passed, removing lowest numbered Power Plant (${G.actualMarket[0].number}).`,
                                 });
+
                                 G.actualMarket.shift();
                                 addPowerPlant(G);
                             }
@@ -538,7 +546,9 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 ) {
                                     setCurrentPlayer(G, winningPlayer.id);
                                 } else {
-                                    addPowerPlant(G);
+                                    if (G.map.name != 'China' || G.step == 3) {
+                                        addPowerPlant(G);
+                                    }
 
                                     if (G.players.some((p) => !p.skipAuction)) {
                                         G.players.forEach((p) => {
@@ -667,7 +677,9 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 }
                             }
 
-                            if (G.futureMarket.length == 0) {
+                            if (G.map.name == 'China' && G.step <= 2) {
+                                rebuildPlantMarketForChina(G);
+                            } else if (G.futureMarket.length == 0) {
                                 G.step = 3;
                             }
                         }
@@ -800,7 +812,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 G.powerPlantsDeck.push(powerPlantToPush);
                                 addPowerPlant(G);
                             }
-                        } else if (G.actualMarket.length > 0) {
+                        } else if (G.actualMarket.length > 0 && (G.map.name != 'China' || G.step == 3)) {
                             G.log.push({ type: 'event', event: `Discarding Power Plant ${G.actualMarket[0].number}.` });
                             G.actualMarket.shift();
                             addPowerPlant(G);
@@ -818,7 +830,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         if (G.actualMarket.length > 0) {
                             G.phase = Phase.Auction;
 
-                            if (G.futureMarket.length == 0) {
+                            if (G.futureMarket.length == 0 && G.map.name != 'China') {
                                 G.step = 3;
                             }
 
@@ -909,7 +921,10 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     )}.`,
                 });
 
-                addPowerPlant(G);
+                if (G.map.name != 'China' || G.step == 3) {
+                    addPowerPlant(G);
+                }
+
                 G.players.forEach((p) => {
                     p.bid = 0;
                     p.passed = p.isDropped;
@@ -956,7 +971,9 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }
 
                 if (toDiscard.length == 0) {
-                    addPowerPlant(G);
+                    if (G.map.name != 'China' || G.step == 3) {
+                        addPowerPlant(G);
+                    }
                     G.players.forEach((p) => {
                         p.bid = 0;
                         p.passed = p.isDropped;
@@ -1014,7 +1031,9 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
             }
 
             if (toDiscard.length == 0) {
-                addPowerPlant(G);
+                if (G.map.name != 'China' || G.step == 3) {
+                    addPowerPlant(G);
+                }
                 G.players.forEach((p) => {
                     p.bid = 0;
                     p.passed = p.isDropped;
@@ -1123,7 +1142,11 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
             }
 
             if (G.options.variant == 'original') {
-                if (G.actualMarket.length > 0 && player.cities.length >= G.actualMarket[0].number) {
+                if (
+                    G.actualMarket.length > 0 &&
+                    player.cities.length >= G.actualMarket[0].number &&
+                    G.map.name != 'China'
+                ) {
                     G.actualMarket.shift();
                     addPowerPlant(G);
                 }
@@ -1531,7 +1554,7 @@ function addPowerPlant(G: GameState) {
             }
         }
 
-        if (G.options.variant == 'original') {
+        if (G.options.variant == 'original' && G.map.name != 'China') {
             const maxCities = Math.max(...G.players.map((p) => p.cities.length));
             while (powerPlant.number <= maxCities) {
                 G.log.push({
@@ -1560,6 +1583,8 @@ function addPowerPlant(G: GameState) {
         if (powerPlant.number == 99) {
             if (G.powerPlantDeckAfterStep3) {
                 G.powerPlantsDeck = G.powerPlantDeckAfterStep3;
+            } else if (G.map.name == 'China') {
+                G.step = 3;
             } else {
                 G.powerPlantsDeck = shuffle(G.powerPlantsDeck, G.seed);
             }
@@ -1599,18 +1624,24 @@ function addPowerPlant(G: GameState) {
             }
         }
 
-        const market = [...G.actualMarket, ...G.futureMarket, powerPlant];
-        market.sort((a, b) => a.number - b.number);
-        if (G.futureMarket.length == 0) {
-            G.actualMarket = market.slice(0, 6);
-            G.futureMarket = [];
+        if (G.map.name == 'China' && powerPlant.type != PowerPlantType.Step3) {
+            const market = [...G.actualMarket, powerPlant];
+            market.sort((a, b) => a.number - b.number);
+            G.actualMarket = market;
         } else {
-            G.actualMarket = market.slice(0, 4);
-            G.futureMarket = market.slice(4);
-        }
+            const market = [...G.actualMarket, ...G.futureMarket, powerPlant];
+            market.sort((a, b) => a.number - b.number);
+            if (G.futureMarket.length == 0) {
+                G.actualMarket = market.slice(0, 6);
+                G.futureMarket = [];
+            } else {
+                G.actualMarket = market.slice(0, 4);
+                G.futureMarket = market.slice(4);
+            }
 
-        if (G.map.name == 'Middle East' && G.step == 1) {
-            removePlantsForMiddleEastStep1(G);
+            if (G.map.name == 'Middle East' && G.step == 1) {
+                removePlantsForMiddleEastStep1(G);
+            }
         }
     }
 }
@@ -1696,6 +1727,50 @@ function enterStepTwoMiddleEast(G: GameState) {
             event: `Power Plant ${powerPlantDiscarded2.number} discarded to start step 2.`,
         });
         addPowerPlant(G);
+    }
+}
+
+function rebuildPlantMarketForChina(G: GameState) {
+    /*At the beginning of phase 5, the players fill the power plant market with new power plants. Depending on the 
+number of players, the players always add a minimum of 1, 2, or 3 power plants to the market from the supply:
+with 2 and 3 players, add at least 1 power plant.
+with 4 and 5 players, add at least 2 power plants.
+with 6 players, add at least 3 power plants.
+The players add more than the minimum if the number of plants in the market is still more than 1 less than the number of players.
+Exception: with 2 players, add plants until there are 2 in the market.*/
+    let minPlantsToAdd = 0;
+    if (G.players.length == 2 || G.players.length == 3) {
+        minPlantsToAdd = 1;
+    } else if (G.players.length == 4 || G.players.length == 5) {
+        minPlantsToAdd = 2;
+    } else if (G.players.length == 6) {
+        minPlantsToAdd = 3;
+    }
+
+    let currentActualSize = G.actualMarket.length;
+    let minSize = G.players.length - 1;
+    let numPlantsToAdd = Math.max(minPlantsToAdd, minSize - currentActualSize);
+    for (let i = 0; i < numPlantsToAdd; i++) {
+        if (G.step == 3) {
+            break;
+        } else {
+            addPowerPlant(G);
+        }
+    }
+
+    // Special rule to move the market for two players
+    while (G.players.length == 2 && G.actualMarket.length <= 2 && G.step != 3) {
+        addPowerPlant(G);
+    }
+
+    if (G.step == 3) {
+        while (G.actualMarket.length < 4 && G.powerPlantsDeck.length > 0) {
+            addPowerPlant(G);
+        }
+    } else {
+        while (G.actualMarket.length >= G.players.length) {
+            G.actualMarket.shift();
+        }
     }
 }
 
@@ -2069,7 +2144,9 @@ function fastAuction(G: GameState, player: Player, bid: number) {
         ) {
             setCurrentPlayer(G, winningPlayer.id);
         } else {
-            addPowerPlant(G);
+            if (G.map.name != 'China' || G.step == 3) {
+                addPowerPlant(G);
+            }
 
             if (G.players.some((p) => !p.skipAuction)) {
                 G.players.forEach((p) => {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1747,9 +1747,9 @@ Exception: with 2 players, add plants until there are 2 in the market.*/
         minPlantsToAdd = 3;
     }
 
-    let currentActualSize = G.actualMarket.length;
-    let minSize = G.players.length - 1;
-    let numPlantsToAdd = Math.max(minPlantsToAdd, minSize - currentActualSize);
+    const currentActualSize = G.actualMarket.length;
+    const minSize = G.players.length - 1;
+    const numPlantsToAdd = Math.max(minPlantsToAdd, minSize - currentActualSize);
     for (let i = 0; i < numPlantsToAdd; i++) {
         if (G.step == 3) {
             break;

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -12,12 +12,12 @@ export type MapName =
     | 'Italy'
     | 'Quebec'
     | 'Middle East'
-    | 'India';
+    | 'India'
+    | 'China';
 // | 'Australia'
 // | 'Baden-Württemberg'
 // | 'Benelux'
 // | 'Central Europe'
-// | 'China'
 // | 'Japan'
 // | 'Korea'
 // | 'Northern Europe'

--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -2,6 +2,7 @@ import seedrandom from 'seedrandom';
 import { PowerPlant } from './gamestate';
 import { map as america, mapRecharged as americaRecharged } from './maps/america';
 import { map as brazil } from './maps/brazil';
+import { map as china } from './maps/china';
 import { map as france } from './maps/france';
 import { map as germany, mapRecharged as germanyRecharged } from './maps/germany';
 import { map as indian } from './maps/indian';
@@ -13,7 +14,6 @@ import { map as spainportugal } from './maps/spainportugal';
 // import { map as badenwurttemberg } from './maps/badenwurttemberg';
 // import { map as benelux } from './maps/benelux';
 // import { map as centraleurope } from './maps/centraleurope';
-// import { map as china } from './maps/china';
 // import { map as japan } from './maps/japan';
 // import { map as korea } from './maps/korea';
 // import { map as northerneurope } from './maps/northerneurope';
@@ -84,11 +84,11 @@ export const maps: GameMap[] = [
     italy,
     quebec,
     middleeast,
+    china,
     // australia,
     // badenwurttemberg,
     // benelux,
     // centraleurope,
-    // china,
     // japan,
     // korea,
     // northerneurope,

--- a/engine/src/maps/china.ts
+++ b/engine/src/maps/china.ts
@@ -235,7 +235,7 @@ export const map: GameMap = {
                 already placed on the supply
             plants 5 – 30: sort in ascending order with 30 on the bottom and 5 on the top and place face-down on the supply
         */
-        let allPlants = cloneDeep(powerPlants);
+        const allPlants = cloneDeep(powerPlants);
         let plantsToRemove: number[] = [];
         if (numPlayers == 2 || numPlayers == 3) {
             plantsToRemove = [3, 4, 9, 11, 16, 18, 20, 24, 30, 33, 46];
@@ -244,23 +244,25 @@ export const map: GameMap = {
         } else if (numPlayers == 5 || numPlayers == 6) {
             plantsToRemove = [3, 4, 33];
         }
-        let filteredPlants = allPlants.filter((p) => !plantsToRemove.includes(p.number));
+        const filteredPlants = allPlants.filter((p) => !plantsToRemove.includes(p.number));
 
-        let lowPlants = filteredPlants.filter((p) => p.number <= 30);
-        let middlePlants = shuffle(
+        const lowPlants = filteredPlants.filter((p) => p.number <= 30);
+        const middlePlants = shuffle(
             filteredPlants.filter((p) => p.number >= 31 && p.number <= 35),
             rng() + ''
         );
-        let step3Card = filteredPlants.filter((p) => p.type == PowerPlantType.Step3);
-        let highPlants = shuffle(
+        const step3Card = filteredPlants.filter((p) => p.type == PowerPlantType.Step3);
+        const highPlants = shuffle(
             filteredPlants.filter((p) => p.number >= 36 && p.number <= 50),
             rng() + ''
         );
 
         // In round 1, the number of plants available is equal to the number of players.
-        let actualMarket = lowPlants.splice(0, numPlayers);
-        let futureMarket: PowerPlant[] = [];
-        let powerPlantsDeck = lowPlants.concat(middlePlants).concat(step3Card).concat(highPlants);
+        const actualMarket = lowPlants.splice(0, numPlayers);
+        const futureMarket: PowerPlant[] = [];
+        const powerPlantsDeck = lowPlants.concat(middlePlants).concat(step3Card).concat(highPlants);
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
+    mapSpecificRules:
+        'The power plant deck is arranged as follows: plants from 3-30 in order, plants from 31-35 shuffled, step 3 card, plants from 36-50 shuffled.\nThe same set of plants are removed in every game.\nThere are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.',
 };

--- a/engine/src/maps/china.ts
+++ b/engine/src/maps/china.ts
@@ -256,15 +256,11 @@ export const map: GameMap = {
             filteredPlants.filter((p) => p.number >= 36 && p.number <= 50),
             rng() + ''
         );
-        console.log(lowPlants);
-        console.log(middlePlants);
-        console.log(highPlants);
 
         // In round 1, the number of plants available is equal to the number of players.
         let actualMarket = lowPlants.splice(0, numPlayers);
         let futureMarket: PowerPlant[] = [];
         let powerPlantsDeck = lowPlants.concat(middlePlants).concat(step3Card).concat(highPlants);
-        console.log(powerPlantsDeck);
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
 };

--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -280,10 +280,6 @@ export const map: GameMap = {
             powerPlantsDeck.push(step3);
         }
 
-        console.log(actualMarket);
-        console.log(futureMarket);
-        console.log(powerPlantsDeck);
-
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:


### PR DESCRIPTION
Rulebook: https://www.riograndegames.com/wp-content/uploads/2013/02/Power-Grid-China-Korea-Rules.pdf.

The China map has several changes for the power plant deck.