### PR TITLE
Remove duplicate template for USA recharged coal supply

### DIFF
--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -205,30 +205,6 @@
             />
         </template>
 
-        <template v-if="isUsaRecharged">
-            <rect
-                width="180"
-                height="70"
-                x="795"
-                y="45"
-                rx="2"
-                fill="chocolate"
-                stroke="sandybrown"
-                stroke-width="4px"
-            />
-            <circle r="10" cx="973" cy="45" fill="yellow" />
-            <text
-                text-anchor="middle"
-                style="font-size: 16px; font-family: monospace"
-                x="973"
-                y="45"
-                fill="darkgoldenrod"
-            >
-                8
-            </text>
-            <Coal :pieceId="-1" :targetState="{ x: 858, y: 57 }" :canClick="false" :transparent="true" :scale="0.2" />
-        </template>
-
         <template v-if="isMiddleEast">
             <rect width="80" height="50" x="20" y="70" rx="2" fill="gray" stroke="darkgray" stroke-width="4px" />
             <Oil
@@ -345,6 +321,9 @@ export default class Resources extends Vue {
                     });
                 });
             }
+
+            console.log(gameState.coalSupply)
+            console.log(this.coals[30])
 
             this.oils = [];
             if (gameState.map?.name == 'Middle East') {

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -322,9 +322,6 @@ export default class Resources extends Vue {
                 });
             }
 
-            console.log(gameState.coalSupply)
-            console.log(this.coals[30])
-
             this.oils = [];
             if (gameState.map?.name == 'Middle East') {
                 let maxRegularOil = gameState.oilPrices!.filter(p => p > 1).length;


### PR DESCRIPTION
The extra template is covering up the coal supply, preventing us from selecting the coal.