### PR TITLE
Fix power plant removal for Quebec

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -794,18 +794,24 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                             if (G.map.name == 'Quebec') {
                                 // For the Quebec map, ecological plants will never be put on the bottom of the deck.
                                 const nonEcoPlants = G.futureMarket.filter(
-                                    (pp) => pp.type != PowerPlantType.Wind && pp.type != PowerPlantType.Nuclear
+                                    (pp) => pp.type != PowerPlantType.Wind
                                 );
                                 powerPlantToPush = nonEcoPlants.pop();
 
-                                if (!powerPlantToPush) {
-                                    const nonEcoPlants = G.futureMarket.filter(
-                                        (pp) => pp.type != PowerPlantType.Wind && pp.type != PowerPlantType.Nuclear
+                                if (powerPlantToPush) {
+                                    G.futureMarket = G.futureMarket.filter((pp) => pp.number != powerPlantToPush?.number);
+                                }
+                                else
+                                {
+                                    const nonEcoPlants = G.actualMarket.filter(
+                                        (pp) => pp.type != PowerPlantType.Wind
                                     );
                                     powerPlantToPush = nonEcoPlants.pop();
-                                }
 
-                                G.futureMarket = G.futureMarket.filter((pp) => pp.number != powerPlantToPush?.number);
+                                    if (powerPlantToPush) {
+                                        G.actualMarket = G.actualMarket.filter((pp) => pp.number != powerPlantToPush?.number);
+                                    }
+                                }
                             } else {
                                 powerPlantToPush = G.futureMarket.pop()!;
                             }

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -797,6 +797,14 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                     (pp) => pp.type != PowerPlantType.Wind && pp.type != PowerPlantType.Nuclear
                                 );
                                 powerPlantToPush = nonEcoPlants.pop();
+
+                                if (!powerPlantToPush) {
+                                    const nonEcoPlants = G.futureMarket.filter(
+                                        (pp) => pp.type != PowerPlantType.Wind && pp.type != PowerPlantType.Nuclear
+                                    );
+                                    powerPlantToPush = nonEcoPlants.pop();
+                                }
+
                                 G.futureMarket = G.futureMarket.filter((pp) => pp.number != powerPlantToPush?.number);
                             } else {
                                 powerPlantToPush = G.futureMarket.pop()!;


### PR DESCRIPTION
For the Quebec map, we never remove ecological power plants. Instead, the highest non-ecological power plant is removed.

There are currently two bugs:
1. I had counted nuclear plants as ecological. I don't think this is correct.
2. I had only removed plants from the future market, and if the future market had no ecological plants I didn't remove anything. But if we can't remove from the future market, we should try to remove from the actual market instead.