### PR TITLE
Fix China deck rules for two players

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1797,7 +1797,7 @@ Exception: with 2 players, add plants until there are 2 in the market.*/
     }
 
     // Special rule to move the market for two players
-    while (G.players.length == 2 && G.actualMarket.length <= 2 && G.step != 3) {
+    while (G.players.length == 2 && G.actualMarket.length < 2 && G.step != 3) {
         addPowerPlant(G);
     }
 


### PR DESCRIPTION
The rules for the China map for two players say to keep adding plants until there are two plants in the market, then drop the lower one.

I accidentally used <= instead of <, so the game currently adds plants until there are three in the market, then drops the lowest two.