### PR TITLE
Have 2 plants in market for 2-player game on China map

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1808,7 +1808,7 @@ Exception: with 2 players, add plants until there are 2 in the market.*/
         }
     } else {
         // Target size is one less than number of players, or 2 for a 2-player game.
-        let targetSize = Math.max(2, G.players.length - 1);
+        const targetSize = Math.max(2, G.players.length - 1);
         while (G.actualMarket.length > targetSize) {
             G.actualMarket.shift();
         }

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1807,7 +1807,9 @@ Exception: with 2 players, add plants until there are 2 in the market.*/
             addPowerPlant(G);
         }
     } else {
-        while (G.actualMarket.length >= G.players.length) {
+        // Target size is one less than number of players, or 2 for a 2-player game.
+        let targetSize = Math.max(2, G.players.length - 1);
+        while (G.actualMarket.length > targetSize) {
             G.actualMarket.shift();
         }
     }


### PR DESCRIPTION
For games with more than 2 players, the number of plants in the market should be one less than the number of players during steps 1 and 2.

But for a 2-player game, we need to fix it so that each round starts with 2 plants in the market. This sets the correct target size.