### PR TITLE
Fix deck setup for France map

### DIFF
--- a/engine/src/maps/france.ts
+++ b/engine/src/maps/france.ts
@@ -246,6 +246,7 @@ export const map: GameMap = {
             powerPlantsDeck.splice(1, 1)[0];
             const step3 = powerPlantsDeck.pop()!;
 
+            powerPlantsDeck = shuffle(powerPlantsDeck, rng() + '');
             if (numPlayers == 2 || numPlayers == 3) {
                 powerPlantsDeck = powerPlantsDeck.slice(8);
             } else if (numPlayers == 4) {
@@ -272,6 +273,7 @@ export const map: GameMap = {
             const first = initialPowerPlants.shift()!;
             const step3 = powerPlantsDeck.pop()!;
 
+            powerPlantsDeck = shuffle(powerPlantsDeck, rng() + '');
             if (numPlayers == 2) {
                 powerPlantsDeck = shuffle(powerPlantsDeck.slice(6).concat(initialPowerPlants), rng() + '');
             } else if (numPlayers == 3) {


### PR DESCRIPTION
Both the original and recharged versions of the France map are missing a shuffle step in the deck setup.

For the original game, this means that the power plants will always be drawn in numerical order.

For the recharged version, the plants that are removed when there are fewer than 5 players will always be the same ones.