### PR TITLE
Fix deck setup for India map

### DIFF
--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -274,6 +274,8 @@ export const map: GameMap = {
             } else if (numPlayers == 4) {
                 initialPowerPlants = initialPowerPlants.slice(1);
                 powerPlantsDeck = shuffle(powerPlantsDeck.slice(3).concat(initialPowerPlants), rng() + '');
+            } else {
+                powerPlantsDeck = shuffle(powerPlantsDeck.concat(initialPowerPlants), rng() + '');
             }
 
             powerPlantsDeck.unshift(first);


### PR DESCRIPTION
There's a bug in the deck setup for the India map.

For five or six players, there are four power plants from 3-15 that need to be put back into the deck. Currently that doesn't happen. This fixes the bug.