### PR TITLE
Fix Central Europe map

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -123,6 +123,18 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                             }
                         }
 
+                        // Nuclear plants for Central Europe are only allowed for players with cities in:
+                        // Czechia (green), Slovakia (brown), Hungary (purple)
+                        if (G.map.name == 'Central Europe') {
+                            const validCities = player.cities
+                                .map((c) => G.map.cities.find((c_) => c_.name == c.name)!)
+                                .filter((c) => c.region == 'green' || c.region == 'brown' || c.region == 'purple');
+
+                            if (validCities.length == 0 && G.chosenPowerPlant.type == PowerPlantType.Uranium) {
+                                moves[MoveName.Bid] = undefined;
+                            }
+                        }
+
                         if (G.options.fastBid) {
                             if (player.id != G.auctioningPlayer) {
                                 moves[MoveName.Pass] = [true];

--- a/engine/src/maps/centraleurope.ts
+++ b/engine/src/maps/centraleurope.ts
@@ -201,6 +201,7 @@ export const map: GameMap = {
     layout: 'Portrait',
     mapPosition: [70, -60],
     adjustRatio: [1.15, 1.15],
+    startingResources: [24, 18, 6, 5],
     resupply: [
         [
             [4, 5, 3],


### PR DESCRIPTION
1. The current implementation does not allow putting a uranium plant up for auction unless the player has cities in the specific regions where it is allowed. But I forgot to restrict which players can bid in the auction as well, so this change fixes it.
2. This fixes the starting resource values as well.