### PR TITLE
Add Baden-Württemberg map with all 5 rule variants

### DIFF
--- a/.github/workflows/engine-publish.yml
+++ b/.github/workflows/engine-publish.yml
@@ -4,11 +4,17 @@ on:
     workflow_dispatch:
         inputs:
             newversion:
-                description: 'Semantic Version Bump Type (major minor patch)'
+                description: 'Semantic Version Bump Type'
+                type: choice
+                required: true
                 default: patch
+                options:
+                    - patch
+                    - minor
+                    - major
 
 env:
-    node_version: 14
+    node_version: 24
 
 defaults:
     run:
@@ -17,20 +23,21 @@ defaults:
 jobs:
     version_and_release:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            id-token: write
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ env.node_version }}
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.node_version }}
-                  # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
+                  # registry-url is required so npm publish targets the public npm registry
                   registry-url: 'https://registry.npmjs.org'
             - run: corepack enable
             - run: pnpm install
             - run: git config --global user.name github-actions
             - run: git config --global user.email bot@github.com
-            # - run: yarn config set version-git-message "Engine v%s"
-            # - run: yarn version --${{ github.event.inputs.newversion }}
             - run: |
                   PACKAGE_VERSION=$(node -p "require('./package.json').version")
                   BUMPED_VERSION=$(node -p "require('semver').inc('$PACKAGE_VERSION', '${{ github.event.inputs.newversion }}')")
@@ -40,7 +47,7 @@ jobs:
                   git commit -m "🔖 powergrid-engine $BUMPED_VERSION"
             # Would be better to have correct package name in package.json, but need to check if anything broken
             - run: sed -i 's:powergrid-engine:@boardgamers/powergrid-engine:' package.json
-            - run: pnpm publish --access public --no-git-checks .
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            # Trusted publishing requires npm >= 11.5.1; ensure we have it regardless of the node distribution
+            - run: npm install -g npm@latest
+            - run: npm publish --access public
             - run: git push --follow-tags

--- a/.github/workflows/viewer-publish.yml
+++ b/.github/workflows/viewer-publish.yml
@@ -4,11 +4,17 @@ on:
     workflow_dispatch:
         inputs:
             newversion:
-                description: 'Semantic Version Bump Type (major minor patch)'
+                description: 'Semantic Version Bump Type'
+                type: choice
+                required: true
                 default: patch
+                options:
+                    - patch
+                    - minor
+                    - major
 
 env:
-    node_version: 14
+    node_version: 24
 
 defaults:
     run:
@@ -17,13 +23,16 @@ defaults:
 jobs:
     version_and_release:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            id-token: write
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ env.node_version }}
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.node_version }}
-                  # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
+                  # registry-url is required so npm publish targets the public npm registry
                   registry-url: 'https://registry.npmjs.org'
             - run: corepack enable
             - run: pnpm install
@@ -38,7 +47,7 @@ jobs:
                   git commit -m "🔖 powergrid-viewer $BUMPED_VERSION"
             # Would be better to have correct package name in package.json, but need to check if anything broken
             - run: sed -i 's:"powergrid-viewer":"@boardgamers/powergrid-viewer":' package.json
-            - run: pnpm publish --access public --no-git-checks .
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            # Trusted publishing requires npm >= 11.5.1; ensure we have it regardless of the node distribution
+            - run: npm install -g npm@latest
+            - run: npm publish --access public
             - run: git push --follow-tags

--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -256,7 +256,30 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                         : dijkstra(G, player).map((c) => ({ name: c.name, price: c.price }));
 
                 toBuild.forEach((city) => {
+                    const cityData = G.map.cities.find((c) => c.name == city.name)!;
                     const othersCount = G.players.filter((p) => p.cities.find((c) => city.name == c.name)).length;
+
+                    // Transregional cities (e.g. Strasbourg on Baden-Württemberg) are only open
+                    // in Step 2 onward. The slot fee is replaced by a flat 15 (Step 2) or 20
+                    // (Step 3); the dijkstra connection cost from the player's existing network
+                    // is still paid on top.
+                    if (cityData.transregional) {
+                        if (G.step < 2) {
+                            city.price = 9999;
+                            return;
+                        }
+                        city.price += G.step == 3 ? 20 : 15;
+
+                        if (othersCount == G.step) {
+                            city.price = 9999;
+                        }
+
+                        if (player.cities.find((c) => c.name == city.name)) {
+                            city.price = 9999;
+                        }
+                        return;
+                    }
+
                     city.price += 10 + othersCount * 5;
 
                     if (othersCount == G.step) {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -14,6 +14,7 @@ import { asserts, shuffle } from './utils';
 export const playerColors = ['limegreen', 'mediumorchid', 'red', 'dodgerblue', 'yellow', 'brown'];
 
 const citiesToStep2 = [10, 7, 7, 7, 6];
+const citiesToStep2BadenWurttemberg = [9, 6, 6, 6, 5];
 const citiesToEndGame = [21, 17, 17, 15, 14];
 const cityIncome = [10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150];
 const regionsInPlay = [3, 3, 4, 5, 5];
@@ -330,7 +331,10 @@ export function setup(
         seed,
         round: 1,
         auctionSkips: 0,
-        citiesToStep2: citiesToStep2[numPlayers - 2],
+        citiesToStep2:
+            (forceMap || finalMap).name == 'Baden-Württemberg'
+                ? citiesToStep2BadenWurttemberg[numPlayers - 2]
+                : citiesToStep2[numPlayers - 2],
         citiesToEndGame: citiesToEndGame[numPlayers - 2],
         resourceResupply: [
             `[${coalResupply[p][0]}, ${oilResupply[p][0]}, ${garbageResupply[p][0]}, ${uraniumResupply[p][0]}]`,
@@ -341,7 +345,10 @@ export function setup(
         variant,
         minimunBid: 0,
         plantDiscountActive:
-            variant == 'recharged' && (forceMap || finalMap).name != 'China' && (forceMap || finalMap).name != 'Russia',
+            variant == 'recharged' &&
+            (forceMap || finalMap).name != 'China' &&
+            (forceMap || finalMap).name != 'Russia' &&
+            (forceMap || finalMap).name != 'Baden-Württemberg',
         discardSmallestPlant: false,
         cardsLeft: powerPlantsDeck.length,
         nextCardWeak: variant == 'recharged',
@@ -545,13 +552,29 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 G.map.name != 'China' &&
                                 G.map.name != 'Russia'
                             ) {
-                                G.log.push({
-                                    type: 'event',
-                                    event: `Everyone passed, removing lowest numbered Power Plant (${G.actualMarket[0].number}).`,
-                                });
+                                if (G.map.name == 'Baden-Württemberg') {
+                                    // Baden-Württemberg: remove the two lowest plants
+                                    const removed: number[] = [];
+                                    for (let i = 0; i < 2 && G.actualMarket.length > 0; i++) {
+                                        removed.push(G.actualMarket[0].number);
+                                        G.actualMarket.shift();
+                                        addPowerPlant(G);
+                                    }
+                                    G.log.push({
+                                        type: 'event',
+                                        event: `Everyone passed, removing the two lowest numbered Power Plants (${removed.join(
+                                            ', '
+                                        )}).`,
+                                    });
+                                } else {
+                                    G.log.push({
+                                        type: 'event',
+                                        event: `Everyone passed, removing lowest numbered Power Plant (${G.actualMarket[0].number}).`,
+                                    });
 
-                                G.actualMarket.shift();
-                                addPowerPlant(G);
+                                    G.actualMarket.shift();
+                                    addPowerPlant(G);
+                                }
                             }
 
                             toResourcesPhase(G);
@@ -882,7 +905,10 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                         G.round++;
 
-                        setPlayerOrder(G);
+                        if (G.map.name != 'Baden-Württemberg') {
+                            // Baden-Württemberg: player order is determined AFTER the auction phase, not before it.
+                            setPlayerOrder(G);
+                        }
 
                         G.players.forEach((p) => {
                             p.passed = p.isDropped;
@@ -897,7 +923,10 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                             }
 
                             G.plantDiscountActive =
-                                G.options.variant == 'recharged' && G.map.name != 'China' && G.map.name != 'Russia';
+                                G.options.variant == 'recharged' &&
+                                G.map.name != 'China' &&
+                                G.map.name != 'Russia' &&
+                                G.map.name != 'Baden-Württemberg';
                             setCurrentPlayer(G, G.playerOrder[0]);
                         } else {
                             toResourcesPhase(G);
@@ -1218,7 +1247,8 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     G.actualMarket.length > 0 &&
                     player.cities.length >= G.actualMarket[0].number &&
                     G.map.name != 'China' &&
-                    G.map.name != 'Russia'
+                    G.map.name != 'Russia' &&
+                    G.map.name != 'Baden-Württemberg'
                 ) {
                     G.actualMarket.shift();
                     addPowerPlant(G);
@@ -1994,6 +2024,11 @@ function isValid(player: Player, powerPlants: PowerPlant[]) {
 }
 
 function toResourcesPhase(G: GameState) {
+    if (G.map.name == 'Baden-Württemberg') {
+        // Baden-Württemberg: player order is determined AFTER the auction phase, every round.
+        setPlayerOrder(G);
+    }
+
     G.players.forEach((p) => {
         p.bid = 0;
         p.passed = p.isDropped;

--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -14,7 +14,7 @@ import { map as quebec } from './maps/quebec';
 import { map as russia } from './maps/russia';
 import { map as spainportugal } from './maps/spainportugal';
 // import { map as australia } from './maps/australia';
-// import { map as badenwurttemberg } from './maps/badenwurttemberg';
+import { map as badenwurttemberg } from './maps/badenwurttemberg';
 // import { map as japan } from './maps/japan';
 // import { map as korea } from './maps/korea';
 // import { map as northerneurope } from './maps/northerneurope';
@@ -26,6 +26,10 @@ export interface City {
     region: string;
     x: number;
     y: number;
+    // Transregional cities (e.g. Strasbourg on Baden-Württemberg) only open in Step 2,
+    // and connecting to them costs a fixed price (transregionalConnectionCost on the GameMap)
+    // instead of the normal dijkstra path cost.
+    transregional?: boolean;
 }
 
 export interface Connection {
@@ -89,8 +93,8 @@ export const maps: GameMap[] = [
     benelux,
     russia,
     centraleurope,
+    badenwurttemberg,
     // australia,
-    // badenwurttemberg,
     // japan,
     // korea,
     // northerneurope,
@@ -112,8 +116,8 @@ export const mapsRecharged: GameMap[] = [
     benelux,
     russia,
     centraleurope,
+    badenwurttemberg,
     // australia,
-    // badenwurttemberg,
     // china,
     // japan,
     // korea,

--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -1,6 +1,8 @@
 import seedrandom from 'seedrandom';
 import { PowerPlant } from './gamestate';
 import { map as america, mapRecharged as americaRecharged } from './maps/america';
+// import { map as australia } from './maps/australia';
+import { map as badenwurttemberg } from './maps/badenwurttemberg';
 import { map as benelux } from './maps/benelux';
 import { map as brazil } from './maps/brazil';
 import { map as centraleurope } from './maps/centraleurope';
@@ -13,8 +15,6 @@ import { map as middleeast } from './maps/middleeast';
 import { map as quebec } from './maps/quebec';
 import { map as russia } from './maps/russia';
 import { map as spainportugal } from './maps/spainportugal';
-// import { map as australia } from './maps/australia';
-import { map as badenwurttemberg } from './maps/badenwurttemberg';
 // import { map as japan } from './maps/japan';
 // import { map as korea } from './maps/korea';
 // import { map as northerneurope } from './maps/northerneurope';

--- a/engine/src/maps/badenwurttemberg.ts
+++ b/engine/src/maps/badenwurttemberg.ts
@@ -12,14 +12,14 @@ export enum Cities {
     Friedrichshafen = 'Friedrichshafen',
     Ravensburg = 'Ravensburg',
     Biberach = 'Biberach',
-    Sigmarincen = 'Sigmarincen',
+    Sigmarincen = 'Sigmaringen',
     Konstanz = 'Konstanz',
     Ulm = 'Ulm',
     Augsburg = 'Augsburg',
     Basel = 'Basel',
-    Waldshuttiencen = 'Waldshut-Tiencen',
+    Waldshuttiencen = 'Waldshut-Tiengen',
     Singen = 'Singen',
-    Tuttlincen = 'Tuttlincen',
+    Tuttlincen = 'Tuttlingen',
     Donaueschingen = 'Donaueschingen',
     Freiburg = 'Freiburg',
     Lorrach = 'Lorrach',
@@ -27,23 +27,23 @@ export enum Cities {
     Schwabischhall = 'Schwabisch Hall',
     Heilbronn = 'Heilbronn',
     Sinsheim = 'Sinsheim',
-    Heidelber = 'Heidelber',
+    Heidelber = 'Heidelberg',
     Mannheim = 'Mannheim',
-    Luowigshafen = 'Luowigshafen',
+    Luowigshafen = 'Ludwigshafen',
     Nurnberg = 'Nurnberg',
     Ellwangen = 'Ellwangen',
-    Coppingen = 'Coppingen',
-    Reutlincen = 'Reutlincen',
+    Coppingen = 'Göppingen',
+    Reutlincen = 'Reutlingen',
     Stuttgart = 'Stuttgart',
     Ludwigsburg = 'Ludwigsburg',
     Boblingen = 'Boblingen',
-    Laha = 'Laha',
+    Laha = 'Lahr',
     Badenbaden = 'Baden-Baden',
     Offenburg = 'Offenburg',
     Strasbourg = 'Strasbourg',
     Pforzheim = 'Pforzheim',
     Rastatt = 'Rastatt',
-    Karlsruhf = 'Karlsruhf',
+    Karlsruhf = 'Karlsruhe',
 }
 
 export const map: GameMap = {
@@ -55,8 +55,8 @@ export const map: GameMap = {
         { name: Cities.Sigmarincen, region: Regions.Purple, x: 1111, y: 1803 },
         { name: Cities.Konstanz, region: Regions.Purple, x: 1088, y: 2163 },
         { name: Cities.Ulm, region: Regions.Purple, x: 1541, y: 1499 },
-        { name: Cities.Augsburg, region: Regions.Purple, x: 1830, y: 1505 },
-        { name: Cities.Basel, region: Regions.Green, x: 103, y: 2271 },
+        { name: Cities.Augsburg, region: Regions.Purple, x: 1830, y: 1505, transregional: true },
+        { name: Cities.Basel, region: Regions.Green, x: 103, y: 2271, transregional: true },
         { name: Cities.Waldshuttiencen, region: Regions.Green, x: 502, y: 2166 },
         { name: Cities.Singen, region: Regions.Green, x: 874, y: 2084 },
         { name: Cities.Tuttlincen, region: Regions.Green, x: 870, y: 1854 },
@@ -69,8 +69,8 @@ export const map: GameMap = {
         { name: Cities.Sinsheim, region: Regions.Red, x: 920, y: 785 },
         { name: Cities.Heidelber, region: Regions.Red, x: 817, y: 660 },
         { name: Cities.Mannheim, region: Regions.Red, x: 710, y: 540 },
-        { name: Cities.Luowigshafen, region: Regions.Red, x: 579, y: 588 },
-        { name: Cities.Nurnberg, region: Regions.Blue, x: 1837, y: 771 },
+        { name: Cities.Luowigshafen, region: Regions.Red, x: 579, y: 588, transregional: true },
+        { name: Cities.Nurnberg, region: Regions.Blue, x: 1837, y: 771, transregional: true },
         { name: Cities.Ellwangen, region: Regions.Blue, x: 1637, y: 1030 },
         { name: Cities.Coppingen, region: Regions.Blue, x: 1387, y: 1233 },
         { name: Cities.Reutlincen, region: Regions.Blue, x: 1107, y: 1443 },
@@ -80,7 +80,7 @@ export const map: GameMap = {
         { name: Cities.Laha, region: Regions.Yellow, x: 296, y: 1575 },
         { name: Cities.Badenbaden, region: Regions.Yellow, x: 554, y: 1259 },
         { name: Cities.Offenburg, region: Regions.Yellow, x: 395, y: 1422 },
-        { name: Cities.Strasbourg, region: Regions.Yellow, x: 211, y: 1330 },
+        { name: Cities.Strasbourg, region: Regions.Yellow, x: 211, y: 1330, transregional: true },
         { name: Cities.Pforzheim, region: Regions.Yellow, x: 794, y: 1095 },
         { name: Cities.Rastatt, region: Regions.Yellow, x: 509, y: 1109 },
         { name: Cities.Karlsruhf, region: Regions.Yellow, x: 638, y: 974 },
@@ -159,4 +159,44 @@ export const map: GameMap = {
     layout: 'Portrait',
     adjustRatio: [0.425, 0.425],
     mapPosition: [100, -90],
+    resupply: [
+        // Coal
+        [
+            [3, 4, 3], // 2P
+            [4, 5, 3], // 3P
+            [5, 6, 4], // 4P
+            [5, 7, 5], // 5P
+            [7, 9, 6], // 6P
+        ],
+        // Oil
+        [
+            [2, 2, 4],
+            [2, 3, 4],
+            [3, 4, 5],
+            [4, 5, 6],
+            [5, 6, 7],
+        ],
+        // Garbage
+        [
+            [1, 2, 3],
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 3, 5],
+            [3, 5, 6],
+        ],
+        // Uranium
+        [
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 2, 2],
+            [2, 3, 2],
+            [2, 3, 3],
+        ],
+    ],
+    mapSpecificRules:
+        'Phase order change: buy power plants first, then determine player order. ' +
+        'If no power plant is sold in a round, remove the two lowest-numbered plants from the market and replace them from the draw stack. ' +
+        'Never remove a power plant whose number is equal to or lower than the number of cities any player has powered. ' +
+        'Transregional cities (e.g. Strasbourg) are only available starting in Step 2. ' +
+        'Step 2 begins when any player connects to 9 cities (2 players), 6 cities (3–5 players), or 5 cities (6 players).',
 };


### PR DESCRIPTION
Implements the Baden-Württemberg map and its five rule modifications from the official rulebook:

1. Player order is recalculated after the auction phase (not after bureaucracy as on standard maps).
2. When all players pass during the auction phase, the two lowest power plants are discarded instead of one.
3. Step 2 trigger thresholds are adjusted (9/6/6/6/5 cities by player count).
4. Five border cities (Strasbourg, Augsburg, Basel, Ludwigshafen, Nürnberg) are transregional: locked in Step 1, with a flat connection fee of 15 in Step 2 and 20 in Step 3 replacing the standard slot fee. Dijkstra path cost is still paid on top.
5. The smallest plant is never removed from the market at the end of round 1.

For the Recharged variant, the discount token mechanic is disabled on this map.

Adds an optional transregional flag to the City interface to support the rule 4 mechanic without hardcoding city names in the engine.