### PR TITLE
Add Northern Europe and Korea maps

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -11,6 +11,9 @@ export interface AvailableMoves {
     [MoveName.BuyResource]?: {
         resource: ResourceType;
         price: number;
+        // Korea: which side's market this buy option draws from.
+        // Omitted on all other maps.
+        side?: 'north' | 'south';
     }[];
     [MoveName.Build]?: { name: string; price: number }[];
     [MoveName.UsePowerPlant]?: {
@@ -157,7 +160,7 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                 break;
             }
 
-            const toBuy: { resource: ResourceType }[] = [];
+            const toBuy: { resource: ResourceType; side?: 'north' | 'south' }[] = [];
             let maxPriceAvailable: number;
             if (G.map.maxPriceAvailable) {
                 maxPriceAvailable = G.map.maxPriceAvailable[G.step - 1];
@@ -165,7 +168,13 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                 maxPriceAvailable = 16;
             }
 
-            if (G.coalMarket > 0) {
+            // Korea: each side is offered separately, tagged with the side. The
+            // player's chosenSide locks them to one side once they make a buy.
+            const isKorea = G.coalResupplyNorth !== undefined;
+            const allowSouth = !isKorea || G.chosenSide !== 'north';
+            const allowNorth = isKorea && G.chosenSide !== 'south';
+
+            if (allowSouth && G.coalMarket > 0) {
                 const hybridCapacityUsed =
                     player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
                 const coalPrices = G.coalPrices ?? prices[ResourceType.Coal];
@@ -176,9 +185,11 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                     player.coalCapacity + player.hybridCapacity > hybridCapacityUsed + player.coalLeft &&
                     price <= maxPriceAvailable
                 ) {
-                    toBuy.push({ resource: ResourceType.Coal });
+                    toBuy.push(
+                        isKorea ? { resource: ResourceType.Coal, side: 'south' } : { resource: ResourceType.Coal }
+                    );
                 }
-            } else {
+            } else if (allowSouth) {
                 if (G.options.variant == 'recharged' && G.map.name == 'USA' && G.coalSupply > 0) {
                     const hybridCapacityUsed =
                         player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
@@ -191,7 +202,22 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                 }
             }
 
-            if (G.oilMarket > 0) {
+            if (allowNorth && G.coalMarketNorth! > 0) {
+                const hybridCapacityUsed =
+                    player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
+                const coalPrices = G.coalPricesNorth!;
+                const price = coalPrices[coalPrices.length - G.coalMarketNorth!];
+
+                if (
+                    player.money >= price &&
+                    player.coalCapacity + player.hybridCapacity > hybridCapacityUsed + player.coalLeft &&
+                    price <= maxPriceAvailable
+                ) {
+                    toBuy.push({ resource: ResourceType.Coal, side: 'north' });
+                }
+            }
+
+            if (allowSouth && G.oilMarket > 0) {
                 const hybridCapacityUsed =
                     player.hybridCapacity > 0 ? Math.max(0, player.coalLeft - player.coalCapacity) : 0;
                 const oilPrices = G.oilPrices ?? prices[ResourceType.Oil];
@@ -202,11 +228,28 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                     player.oilCapacity + player.hybridCapacity > hybridCapacityUsed + player.oilLeft &&
                     price <= maxPriceAvailable
                 ) {
-                    toBuy.push({ resource: ResourceType.Oil });
+                    toBuy.push(
+                        isKorea ? { resource: ResourceType.Oil, side: 'south' } : { resource: ResourceType.Oil }
+                    );
                 }
             }
 
-            if (G.garbageMarket > 0) {
+            if (allowNorth && G.oilMarketNorth! > 0) {
+                const hybridCapacityUsed =
+                    player.hybridCapacity > 0 ? Math.max(0, player.coalLeft - player.coalCapacity) : 0;
+                const oilPrices = G.oilPricesNorth!;
+                const price = oilPrices[oilPrices.length - G.oilMarketNorth!];
+
+                if (
+                    player.money >= price &&
+                    player.oilCapacity + player.hybridCapacity > hybridCapacityUsed + player.oilLeft &&
+                    price <= maxPriceAvailable
+                ) {
+                    toBuy.push({ resource: ResourceType.Oil, side: 'north' });
+                }
+            }
+
+            if (allowSouth && G.garbageMarket > 0) {
                 const garbagePrices = G.garbagePrices ?? prices[ResourceType.Garbage];
                 let price = garbagePrices[garbagePrices.length - G.garbageMarket];
 
@@ -223,11 +266,27 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                     player.garbageCapacity > player.garbageLeft &&
                     price <= maxPriceAvailable
                 ) {
-                    toBuy.push({ resource: ResourceType.Garbage });
+                    toBuy.push(
+                        isKorea ? { resource: ResourceType.Garbage, side: 'south' } : { resource: ResourceType.Garbage }
+                    );
                 }
             }
 
-            if (G.uraniumMarket > 0) {
+            if (allowNorth && G.garbageMarketNorth! > 0) {
+                const garbagePrices = G.garbagePricesNorth!;
+                const price = garbagePrices[garbagePrices.length - G.garbageMarketNorth!];
+
+                if (
+                    player.money >= price &&
+                    player.garbageCapacity > player.garbageLeft &&
+                    price <= maxPriceAvailable
+                ) {
+                    toBuy.push({ resource: ResourceType.Garbage, side: 'north' });
+                }
+            }
+
+            // Uranium is South only (or non-Korea maps).
+            if (allowSouth && G.uraniumMarket > 0) {
                 const uraniumPrices = G.uraniumPrices ?? prices[ResourceType.Uranium];
                 const price = uraniumPrices[uraniumPrices.length - G.uraniumMarket];
                 if (
@@ -235,7 +294,9 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                     player.uraniumCapacity > player.uraniumLeft &&
                     price <= maxPriceAvailable
                 ) {
-                    toBuy.push({ resource: ResourceType.Uranium });
+                    toBuy.push(
+                        isKorea ? { resource: ResourceType.Uranium, side: 'south' } : { resource: ResourceType.Uranium }
+                    );
                 }
             }
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -273,6 +273,23 @@ export function setup(
         );
 
         finalMap = filteredMap;
+
+        if (chosenMap.regionalPowerPlants) {
+            for (const region of playRegions) {
+                const replacements = chosenMap.regionalPowerPlants[region];
+                if (replacements) {
+                    for (const newPlant of replacements) {
+                        const swapIn = (arr: PowerPlant[]) => {
+                            const idx = arr.findIndex((p) => p.number === newPlant.number);
+                            if (idx !== -1) arr[idx] = { ...newPlant };
+                        };
+                        swapIn(actualMarket);
+                        swapIn(futureMarket);
+                        swapIn(powerPlantsDeck);
+                    }
+                }
+            }
+        }
     }
 
     const coalMarket = chosenMap.startingResources ? chosenMap.startingResources[0] : 24;

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -829,29 +829,47 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     }
 
                     if (G.players.filter((p) => !p.passed && !p.isDropped).length == 0) {
+                        // Resupply is also capped by remaining market capacity (the
+                        // prices array length minus current market size). Without
+                        // this, smaller markets like Korea's can overflow past the
+                        // number of slots and break price lookups.
+                        const coalCapSouth = (G.coalPrices?.length ?? prices[ResourceType.Coal].length) - G.coalMarket;
+                        const oilCapSouth = (G.oilPrices?.length ?? prices[ResourceType.Oil].length) - G.oilMarket;
+                        const garbageCapSouth =
+                            (G.garbagePrices?.length ?? prices[ResourceType.Garbage].length) - G.garbageMarket;
+                        const uraniumCapSouth =
+                            (G.uraniumPrices?.length ?? prices[ResourceType.Uranium].length) - G.uraniumMarket;
+
                         // Korea: North restocks FIRST from the shared supply pool, then
                         // South takes whatever remains. If supply runs short, South gets less.
                         let coalResupplyNorthValue = 0;
                         let oilResupplyNorthValue = 0;
                         let garbageResupplyNorthValue = 0;
                         if (G.coalResupplyNorth) {
+                            const coalCapNorth = G.coalPricesNorth!.length - G.coalMarketNorth!;
+                            const oilCapNorth = G.oilPricesNorth!.length - G.oilMarketNorth!;
+                            const garbageCapNorth = G.garbagePricesNorth!.length - G.garbageMarketNorth!;
+
                             coalResupplyNorthValue = Math.min(
                                 G.coalSupply,
-                                G.coalResupplyNorth[G.players.length - 2][G.step - 1]
+                                G.coalResupplyNorth[G.players.length - 2][G.step - 1],
+                                coalCapNorth
                             );
                             G.coalMarketNorth! += coalResupplyNorthValue;
                             G.coalSupply -= coalResupplyNorthValue;
 
                             oilResupplyNorthValue = Math.min(
                                 G.oilSupply,
-                                G.oilResupplyNorth![G.players.length - 2][G.step - 1]
+                                G.oilResupplyNorth![G.players.length - 2][G.step - 1],
+                                oilCapNorth
                             );
                             G.oilMarketNorth! += oilResupplyNorthValue;
                             G.oilSupply -= oilResupplyNorthValue;
 
                             garbageResupplyNorthValue = Math.min(
                                 G.garbageSupply,
-                                G.garbageResupplyNorth![G.players.length - 2][G.step - 1]
+                                G.garbageResupplyNorth![G.players.length - 2][G.step - 1],
+                                garbageCapNorth
                             );
                             G.garbageMarketNorth! += garbageResupplyNorthValue;
                             G.garbageSupply -= garbageResupplyNorthValue;
@@ -859,7 +877,8 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                         const coalResupplyValue = Math.min(
                             G.coalSupply,
-                            G.coalResupply![G.players.length - 2][G.step - 1]
+                            G.coalResupply![G.players.length - 2][G.step - 1],
+                            coalCapSouth
                         );
                         G.coalMarket += coalResupplyValue;
                         G.coalSupply -= coalResupplyValue;
@@ -882,14 +901,19 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 }
                             }
                         } else {
-                            oilResupplyValue = Math.min(G.oilSupply, G.oilResupply![G.players.length - 2][G.step - 1]);
+                            oilResupplyValue = Math.min(
+                                G.oilSupply,
+                                G.oilResupply![G.players.length - 2][G.step - 1],
+                                oilCapSouth
+                            );
                             G.oilMarket += oilResupplyValue;
                             G.oilSupply -= oilResupplyValue;
                         }
 
                         const garbageResupplyValue = Math.min(
                             G.garbageSupply,
-                            G.garbageResupply![G.players.length - 2][G.step - 1]
+                            G.garbageResupply![G.players.length - 2][G.step - 1],
+                            garbageCapSouth
                         );
                         G.garbageMarket += garbageResupplyValue;
                         G.garbageSupply -= garbageResupplyValue;
@@ -902,7 +926,8 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         ) {
                             uraniumResupplyValue = Math.min(
                                 G.uraniumSupply,
-                                G.uraniumResupply![G.players.length - 2][G.step - 1]
+                                G.uraniumResupply![G.players.length - 2][G.step - 1],
+                                uraniumCapSouth
                             );
                             G.uraniumMarket += uraniumResupplyValue;
                             G.uraniumSupply -= uraniumResupplyValue;
@@ -1523,11 +1548,23 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         G.chosenResource = undefined;
                     }
 
-                    // Korea: clearing chosenSide on undo would let the player switch
-                    // sides mid-turn, which is incorrect when other buys from the same
-                    // side still stand. Leave it locked; it clears naturally on Pass.
-
                     G.log.pop();
+
+                    // Korea: keep chosenSide locked while the player still has
+                    // outstanding BuyResource moves this phase, but clear it once
+                    // the last one is undone so they can switch sides again.
+                    if (G.map.name == 'Korea' && G.chosenSide) {
+                        let stillCommitted = false;
+                        for (let i = G.log.length - 1; i >= 0; i--) {
+                            const entry = G.log[i];
+                            if (entry.type !== 'move') continue;
+                            stillCommitted = entry.player === playerNumber && entry.move.name === MoveName.BuyResource;
+                            break;
+                        }
+                        if (!stillCommitted) {
+                            G.chosenSide = undefined;
+                        }
+                    }
                     break;
                 }
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -161,6 +161,15 @@ export function setup(
     let oilResupply: number[][];
     let garbageResupply: number[][];
     let uraniumResupply: number[][];
+    // Korea: parallel North-side resupply tables (no uranium row).
+    let coalResupplyNorth: number[][] | undefined;
+    let oilResupplyNorth: number[][] | undefined;
+    let garbageResupplyNorth: number[][] | undefined;
+    if (chosenMap.resupplyNorth) {
+        coalResupplyNorth = chosenMap.resupplyNorth[0];
+        oilResupplyNorth = chosenMap.resupplyNorth[1];
+        garbageResupplyNorth = chosenMap.resupplyNorth[2];
+    }
     if (chosenMap.resupply) {
         coalResupply = chosenMap.resupply[0];
         oilResupply = chosenMap.resupply[1];
@@ -302,15 +311,27 @@ export function setup(
     const totalGarbage = chosenMap.startingSupply ? chosenMap.startingSupply[2] : 24;
     const totalUranium = chosenMap.startingSupply ? chosenMap.startingSupply[3] : 12;
 
-    const coalSupply = totalCoal - coalMarket;
-    const oilSupply = totalOil - oilMarket;
-    const garbageSupply = totalGarbage - garbageMarket;
+    // Korea: parallel North-side market and prices. Supply is shared — see below.
+    const coalMarketNorth = chosenMap.startingResourcesNorth?.[0];
+    const oilMarketNorth = chosenMap.startingResourcesNorth?.[1];
+    const garbageMarketNorth = chosenMap.startingResourcesNorth?.[2];
+
+    // Supply pools are shared between both sides for Korea. `startingSupply`
+    // represents the TOTAL cubes in the game; the supply pool is whatever is
+    // left after both markets are filled.
+    const coalSupply = totalCoal - coalMarket - (coalMarketNorth ?? 0);
+    const oilSupply = totalOil - oilMarket - (oilMarketNorth ?? 0);
+    const garbageSupply = totalGarbage - garbageMarket - (garbageMarketNorth ?? 0);
     const uraniumSupply = totalUranium - uraniumMarket;
 
     const coalPrices = cloneDeep(chosenMap.coalPrices ?? prices.coal);
     const oilPrices = cloneDeep(chosenMap.oilPrices ?? prices.oil);
     const garbagePrices = cloneDeep(chosenMap.garbagePrices ?? prices.garbage);
     const uraniumPrices = cloneDeep(chosenMap.uraniumPrices ?? prices.uranium);
+
+    const coalPricesNorth = chosenMap.coalPricesNorth ? cloneDeep(chosenMap.coalPricesNorth) : undefined;
+    const oilPricesNorth = chosenMap.oilPricesNorth ? cloneDeep(chosenMap.oilPricesNorth) : undefined;
+    const garbagePricesNorth = chosenMap.garbagePricesNorth ? cloneDeep(chosenMap.garbagePricesNorth) : undefined;
 
     const G: GameState = {
         map: forceMap || finalMap,
@@ -334,6 +355,17 @@ export function setup(
         oilPrices,
         garbagePrices,
         uraniumPrices,
+        // Korea: parallel North-side fields. Undefined for non-Korea maps.
+        // Supply is shared with the primary `*Supply` fields above.
+        coalMarketNorth,
+        oilMarketNorth,
+        garbageMarketNorth,
+        coalResupplyNorth,
+        oilResupplyNorth,
+        garbageResupplyNorth,
+        coalPricesNorth,
+        oilPricesNorth,
+        garbagePricesNorth,
         actualMarket,
         futureMarket,
         chosenPowerPlant: undefined,
@@ -657,6 +689,12 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         player.passed = true;
                     }
 
+                    // Korea: end of this player's buying turn — clear the side lock
+                    // so the next player can pick freely.
+                    if (G.map.name == 'Korea') {
+                        G.chosenSide = undefined;
+                    }
+
                     if (G.players.filter((p) => !p.passed && !p.isDropped).length == 0) {
                         G.players.forEach((p) => {
                             p.passed = p.isDropped;
@@ -791,6 +829,34 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     }
 
                     if (G.players.filter((p) => !p.passed && !p.isDropped).length == 0) {
+                        // Korea: North restocks FIRST from the shared supply pool, then
+                        // South takes whatever remains. If supply runs short, South gets less.
+                        let coalResupplyNorthValue = 0;
+                        let oilResupplyNorthValue = 0;
+                        let garbageResupplyNorthValue = 0;
+                        if (G.coalResupplyNorth) {
+                            coalResupplyNorthValue = Math.min(
+                                G.coalSupply,
+                                G.coalResupplyNorth[G.players.length - 2][G.step - 1]
+                            );
+                            G.coalMarketNorth! += coalResupplyNorthValue;
+                            G.coalSupply -= coalResupplyNorthValue;
+
+                            oilResupplyNorthValue = Math.min(
+                                G.oilSupply,
+                                G.oilResupplyNorth![G.players.length - 2][G.step - 1]
+                            );
+                            G.oilMarketNorth! += oilResupplyNorthValue;
+                            G.oilSupply -= oilResupplyNorthValue;
+
+                            garbageResupplyNorthValue = Math.min(
+                                G.garbageSupply,
+                                G.garbageResupplyNorth![G.players.length - 2][G.step - 1]
+                            );
+                            G.garbageMarketNorth! += garbageResupplyNorthValue;
+                            G.garbageSupply -= garbageResupplyNorthValue;
+                        }
+
                         const coalResupplyValue = Math.min(
                             G.coalSupply,
                             G.coalResupply![G.players.length - 2][G.step - 1]
@@ -842,10 +908,17 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                             G.uraniumSupply -= uraniumResupplyValue;
                         }
 
-                        G.log.push({
-                            type: 'event',
-                            event: `Resupplying resources: [${coalResupplyValue}, ${oilResupplyValue}, ${garbageResupplyValue}, ${uraniumResupplyValue}].`,
-                        });
+                        if (G.coalResupplyNorth) {
+                            G.log.push({
+                                type: 'event',
+                                event: `Resupplying resources — North: [${coalResupplyNorthValue}, ${oilResupplyNorthValue}, ${garbageResupplyNorthValue}], South: [${coalResupplyValue}, ${oilResupplyValue}, ${garbageResupplyValue}, ${uraniumResupplyValue}].`,
+                            });
+                        } else {
+                            G.log.push({
+                                type: 'event',
+                                event: `Resupplying resources: [${coalResupplyValue}, ${oilResupplyValue}, ${garbageResupplyValue}, ${uraniumResupplyValue}].`,
+                            });
+                        }
 
                         if (G.map.name == 'Middle East' && G.step == 2 && G.futureMarket.length > 0) {
                             // If we aren't about to enter step 3, discard top two plants instead of one.
@@ -1162,10 +1235,23 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
             asserts<Moves.MoveBuyResource>(move);
             G.chosenResource = move.data.resource;
 
+            // Korea: lock the player to the side of their first buy this turn.
+            // Subsequent buys must come from the same side until they pass.
+            if (move.data.side) {
+                G.chosenSide = move.data.side;
+            }
+
+            const isNorth = move.data.side === 'north';
+
             let price: number;
             switch (move.data.resource) {
                 case ResourceType.Coal: {
-                    if (G.coalMarket == 0) {
+                    if (isNorth) {
+                        const coalPrices = G.coalPricesNorth!;
+                        price = coalPrices[coalPrices.length - G.coalMarketNorth!];
+                        player.coalLeft++;
+                        G.coalMarketNorth!--;
+                    } else if (G.coalMarket == 0) {
                         price = 8;
                         player.coalLeft++;
                         G.coalSupply--;
@@ -1181,31 +1267,46 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }
 
                 case ResourceType.Oil: {
-                    const oilPrices = G.oilPrices ?? prices[ResourceType.Oil];
-                    price = oilPrices[oilPrices.length - G.oilMarket];
-                    player.oilLeft++;
-                    G.oilMarket--;
+                    if (isNorth) {
+                        const oilPrices = G.oilPricesNorth!;
+                        price = oilPrices[oilPrices.length - G.oilMarketNorth!];
+                        player.oilLeft++;
+                        G.oilMarketNorth!--;
+                    } else {
+                        const oilPrices = G.oilPrices ?? prices[ResourceType.Oil];
+                        price = oilPrices[oilPrices.length - G.oilMarket];
+                        player.oilLeft++;
+                        G.oilMarket--;
+                    }
                     break;
                 }
 
                 case ResourceType.Garbage: {
-                    const garbagePrices = G.garbagePrices ?? prices[ResourceType.Garbage];
-                    price = garbagePrices[garbagePrices.length - G.garbageMarket];
+                    if (isNorth) {
+                        const garbagePrices = G.garbagePricesNorth!;
+                        price = garbagePrices[garbagePrices.length - G.garbageMarketNorth!];
+                        player.garbageLeft++;
+                        G.garbageMarketNorth!--;
+                    } else {
+                        const garbagePrices = G.garbagePrices ?? prices[ResourceType.Garbage];
+                        price = garbagePrices[garbagePrices.length - G.garbageMarket];
 
-                    // $1 cheaper for players in Wien in Central Europe
-                    if (G.map.name == 'Central Europe') {
-                        const wienCity = player.cities.filter((c) => c.name == 'Wien');
-                        if (wienCity?.length > 0) {
-                            price--;
+                        // $1 cheaper for players in Wien in Central Europe
+                        if (G.map.name == 'Central Europe') {
+                            const wienCity = player.cities.filter((c) => c.name == 'Wien');
+                            if (wienCity?.length > 0) {
+                                price--;
+                            }
                         }
-                    }
 
-                    player.garbageLeft++;
-                    G.garbageMarket--;
+                        player.garbageLeft++;
+                        G.garbageMarket--;
+                    }
                     break;
                 }
 
                 case ResourceType.Uranium: {
+                    // Uranium is only available from the South market (or non-Korea maps).
                     const uraniumPrices = G.uraniumPrices ?? prices[ResourceType.Uranium];
                     price = uraniumPrices[uraniumPrices.length - G.uraniumMarket];
                     player.uraniumLeft++;
@@ -1341,10 +1442,16 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }
 
                 case MoveName.BuyResource: {
+                    const undoIsNorth = lastMove.data.side === 'north';
                     let price: number;
                     switch (lastMove.data.resource) {
                         case ResourceType.Coal:
-                            if (lastMove.fromSupply) {
+                            if (undoIsNorth) {
+                                player.coalLeft--;
+                                G.coalMarketNorth!++;
+                                const coalPrices = G.coalPricesNorth!;
+                                price = coalPrices[coalPrices.length - G.coalMarketNorth!];
+                            } else if (lastMove.fromSupply) {
                                 price = 8;
                                 player.coalLeft--;
                                 G.coalSupply++;
@@ -1358,24 +1465,38 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                             break;
 
                         case ResourceType.Oil: {
-                            player.oilLeft--;
-                            G.oilMarket++;
-                            const oilPrices = G.oilPrices ?? prices[ResourceType.Oil];
-                            price = oilPrices[oilPrices.length - G.oilMarket];
+                            if (undoIsNorth) {
+                                player.oilLeft--;
+                                G.oilMarketNorth!++;
+                                const oilPrices = G.oilPricesNorth!;
+                                price = oilPrices[oilPrices.length - G.oilMarketNorth!];
+                            } else {
+                                player.oilLeft--;
+                                G.oilMarket++;
+                                const oilPrices = G.oilPrices ?? prices[ResourceType.Oil];
+                                price = oilPrices[oilPrices.length - G.oilMarket];
+                            }
                             break;
                         }
 
                         case ResourceType.Garbage: {
-                            player.garbageLeft--;
-                            G.garbageMarket++;
-                            const garbagePrices = G.garbagePrices ?? prices[ResourceType.Garbage];
-                            price = garbagePrices[garbagePrices.length - G.garbageMarket];
+                            if (undoIsNorth) {
+                                player.garbageLeft--;
+                                G.garbageMarketNorth!++;
+                                const garbagePrices = G.garbagePricesNorth!;
+                                price = garbagePrices[garbagePrices.length - G.garbageMarketNorth!];
+                            } else {
+                                player.garbageLeft--;
+                                G.garbageMarket++;
+                                const garbagePrices = G.garbagePrices ?? prices[ResourceType.Garbage];
+                                price = garbagePrices[garbagePrices.length - G.garbageMarket];
 
-                            // $1 cheaper for players in Wien in Central Europe
-                            if (G.map.name == 'Central Europe') {
-                                const wienCity = player.cities.filter((c) => c.name == 'Wien');
-                                if (wienCity?.length > 0) {
-                                    price--;
+                                // $1 cheaper for players in Wien in Central Europe
+                                if (G.map.name == 'Central Europe') {
+                                    const wienCity = player.cities.filter((c) => c.name == 'Wien');
+                                    if (wienCity?.length > 0) {
+                                        price--;
+                                    }
                                 }
                             }
 
@@ -1383,6 +1504,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         }
 
                         case ResourceType.Uranium: {
+                            // Uranium is only available from the South market (or non-Korea maps).
                             player.uraniumLeft--;
                             G.uraniumMarket++;
                             const uraniumPrices = G.uraniumPrices ?? prices[ResourceType.Uranium];
@@ -1400,6 +1522,10 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     if (G.map.name == 'India') {
                         G.chosenResource = undefined;
                     }
+
+                    // Korea: clearing chosenSide on undo would let the player switch
+                    // sides mid-turn, which is incorrect when other buys from the same
+                    // side still stand. Leave it locked; it clears naturally on Pass.
 
                     G.log.pop();
                     break;

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -390,6 +390,14 @@ export function setup(
             `[${coalResupply[p][1]}, ${oilResupply[p][1]}, ${garbageResupply[p][1]}, ${uraniumResupply[p][1]}]`,
             `[${coalResupply[p][2]}, ${oilResupply[p][2]}, ${garbageResupply[p][2]}, ${uraniumResupply[p][2]}]`,
         ],
+        resourceResupplyNorth:
+            coalResupplyNorth && oilResupplyNorth && garbageResupplyNorth
+                ? [
+                      `[${coalResupplyNorth[p][0]}, ${oilResupplyNorth[p][0]}, ${garbageResupplyNorth[p][0]}]`,
+                      `[${coalResupplyNorth[p][1]}, ${oilResupplyNorth[p][1]}, ${garbageResupplyNorth[p][1]}]`,
+                      `[${coalResupplyNorth[p][2]}, ${oilResupplyNorth[p][2]}, ${garbageResupplyNorth[p][2]}]`,
+                  ]
+                : undefined,
         paymentTable: cityIncome,
         variant,
         minimunBid: 0,
@@ -2409,6 +2417,13 @@ function updateGameState(G: GameState) {
             `[${G.coalResupply[p][1]}, ${G.oilResupply[p][1]}, ${G.garbageResupply[p][1]}, ${G.uraniumResupply[p][1]}]`,
             `[${G.coalResupply[p][2]}, ${G.oilResupply[p][2]}, ${G.garbageResupply[p][2]}, ${G.uraniumResupply[p][2]}]`,
         ];
+        if (G.coalResupplyNorth && G.oilResupplyNorth && G.garbageResupplyNorth) {
+            G.resourceResupplyNorth = [
+                `[${G.coalResupplyNorth[p][0]}, ${G.oilResupplyNorth[p][0]}, ${G.garbageResupplyNorth[p][0]}]`,
+                `[${G.coalResupplyNorth[p][1]}, ${G.oilResupplyNorth[p][1]}, ${G.garbageResupplyNorth[p][1]}]`,
+                `[${G.coalResupplyNorth[p][2]}, ${G.oilResupplyNorth[p][2]}, ${G.garbageResupplyNorth[p][2]}]`,
+            ];
+        }
     }
 }
 

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -170,6 +170,7 @@ export interface GameState {
     citiesToEndGame: number;
     citiesBuiltInCurrentRound?: number; // In India, if the players build too many cities in a single round, a power outage will occur.
     resourceResupply: string[];
+    resourceResupplyNorth?: string[]; // Korea: per-step North resupply, parallel to resourceResupply (no uranium).
     paymentTable: number[];
     minimunBid: number;
     plantDiscountActive: boolean;

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -18,10 +18,10 @@ export type MapName =
     | 'Russia'
     | 'Central Europe'
     | 'Baden-Württemberg'
-    | 'Northern Europe';
+    | 'Northern Europe'
+    | 'Korea';
 // | 'Australia'
 // | 'Japan'
-// | 'Korea'
 // | 'South Africa'
 // | 'UK & Ireland'
 export type Variant = 'original' | 'recharged';
@@ -129,6 +129,22 @@ export interface GameState {
     oilResupply?: number[][];
     garbageResupply?: number[][];
     uraniumResupply?: number[][];
+    // Korea: parallel North-side markets and resupply tables. The primary
+    // `*Market`/`*Resupply` fields above act as the South side. The supply pools
+    // (`coalSupply` etc.) are SHARED — used cubes return there and both sides
+    // restock from the same pool, with North restocking first.
+    // North has no uranium track (nuclear plants are banned on the North side).
+    coalMarketNorth?: number;
+    oilMarketNorth?: number;
+    garbageMarketNorth?: number;
+    coalResupplyNorth?: number[][];
+    oilResupplyNorth?: number[][];
+    garbageResupplyNorth?: number[][];
+    // Korea: per-side price arrays. Each side's market has different slot counts
+    // per price space, so the price arrays differ. (No uranium on the North side.)
+    coalPricesNorth?: number[];
+    oilPricesNorth?: number[];
+    garbagePricesNorth?: number[];
     coalPrices?: number[];
     oilPrices?: number[];
     garbagePrices?: number[];
@@ -137,6 +153,9 @@ export interface GameState {
     futureMarket: PowerPlant[];
     chosenPowerPlant: PowerPlant | undefined;
     chosenResource?: ResourceType | undefined; // Used for India map, where only one resource can be bought at a time.
+    // Korea: locked to the side a player bought their first resource from this turn.
+    // All subsequent buys this turn must be from the same side. Cleared when the player passes.
+    chosenSide?: 'north' | 'south';
     currentBid: number | undefined;
     auctioningPlayer: number | undefined;
     step: number;

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -16,12 +16,12 @@ export type MapName =
     | 'China'
     | 'Benelux'
     | 'Russia'
-    | 'Central Europe';
+    | 'Central Europe'
+    | 'Baden-Württemberg'
+    | 'Northern Europe';
 // | 'Australia'
-// | 'Baden-Württemberg'
 // | 'Japan'
 // | 'Korea'
-// | 'Northern Europe'
 // | 'South Africa'
 // | 'UK & Ireland'
 export type Variant = 'original' | 'recharged';

--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -11,9 +11,9 @@ import { map as france } from './maps/france';
 import { map as germany, mapRecharged as germanyRecharged } from './maps/germany';
 import { map as indian } from './maps/indian';
 import { map as italy } from './maps/italy';
-import { map as middleeast } from './maps/middleeast';
 // import { map as japan } from './maps/japan';
-// import { map as korea } from './maps/korea';
+import { map as korea } from './maps/korea';
+import { map as middleeast } from './maps/middleeast';
 import { map as northerneurope } from './maps/northerneurope';
 import { map as quebec } from './maps/quebec';
 import { map as russia } from './maps/russia';
@@ -62,6 +62,14 @@ export interface GameMap {
     resupply?: number[][][];
     startingResources?: number[];
     startingSupply?: number[];
+    // Korea: parallel North-side resupply / starting tables. Indexed as
+    // [resource][playerCount-2][step-1] for resupplyNorth, and [coal, oil, garbage]
+    // for the starting arrays (no uranium row — North bans nuclear).
+    resupplyNorth?: number[][][];
+    startingResourcesNorth?: number[];
+    coalPricesNorth?: number[];
+    oilPricesNorth?: number[];
+    garbagePricesNorth?: number[];
     maxPriceAvailable?: number[]; // For India, only limited sections of the supply are available in step 1 and 2.
     coalPrices?: number[];
     oilPrices?: number[];
@@ -96,9 +104,9 @@ export const maps: GameMap[] = [
     centraleurope,
     badenwurttemberg,
     northerneurope,
+    korea,
     // australia,
     // japan,
-    // korea,
     // southafrica,
     // ukireland,
 ];
@@ -119,10 +127,10 @@ export const mapsRecharged: GameMap[] = [
     centraleurope,
     badenwurttemberg,
     northerneurope,
+    korea,
     // australia,
     // china,
     // japan,
-    // korea,
     // southafrica,
     // ukireland,
 ];

--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -12,12 +12,12 @@ import { map as germany, mapRecharged as germanyRecharged } from './maps/germany
 import { map as indian } from './maps/indian';
 import { map as italy } from './maps/italy';
 import { map as middleeast } from './maps/middleeast';
+// import { map as japan } from './maps/japan';
+// import { map as korea } from './maps/korea';
+import { map as northerneurope } from './maps/northerneurope';
 import { map as quebec } from './maps/quebec';
 import { map as russia } from './maps/russia';
 import { map as spainportugal } from './maps/spainportugal';
-// import { map as japan } from './maps/japan';
-// import { map as korea } from './maps/korea';
-// import { map as northerneurope } from './maps/northerneurope';
 // import { map as southafrica } from './maps/southafrica';
 // import { map as ukireland } from './maps/ukireland';
 
@@ -76,6 +76,7 @@ export interface GameMap {
         futureMarket: PowerPlant[];
         powerPlantsDeck: PowerPlant[];
     };
+    regionalPowerPlants?: Record<string, PowerPlant[]>;
     mapSpecificRules?: string;
 }
 
@@ -94,10 +95,10 @@ export const maps: GameMap[] = [
     russia,
     centraleurope,
     badenwurttemberg,
+    northerneurope,
     // australia,
     // japan,
     // korea,
-    // northerneurope,
     // southafrica,
     // ukireland,
 ];
@@ -117,11 +118,11 @@ export const mapsRecharged: GameMap[] = [
     russia,
     centraleurope,
     badenwurttemberg,
+    northerneurope,
     // australia,
     // china,
     // japan,
     // korea,
-    // northerneurope,
     // southafrica,
     // ukireland,
 ];

--- a/engine/src/maps/korea.ts
+++ b/engine/src/maps/korea.ts
@@ -182,4 +182,105 @@ export const map: GameMap = {
         { nodes: [Cities.Seongjin, Cities.Hamheung], cost: 17 },
         { nodes: [Cities.Hamheung, Cities.Hyesan], cost: 23 },
     ],
+    layout: 'Portrait',
+    adjustRatio: [1.0, 1.0],
+    mapPosition: [80, 30],
+    // South-side resource market.
+    // Indexed [resource][playerCount-2][step-1].
+    // Verified from the Korea Recharged rulebook resource table (S rows).
+    resupply: [
+        // Coal (S)
+        [
+            [2, 2, 2], // 2P
+            [2, 3, 2], // 3P
+            [3, 3, 2], // 4P
+            [3, 4, 3], // 5P
+            [4, 5, 3], // 6P
+        ],
+        // Oil (S)
+        [
+            [1, 1, 3],
+            [1, 2, 3],
+            [2, 3, 3],
+            [3, 3, 4],
+            [3, 4, 4],
+        ],
+        // Garbage (S)
+        [
+            [1, 1, 2],
+            [1, 1, 2],
+            [1, 2, 2],
+            [2, 2, 3],
+            [2, 3, 3],
+        ],
+        // Uranium (S only — North bans nuclear resupply)
+        [
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 2, 2],
+            [2, 3, 2],
+            [2, 3, 3],
+        ],
+    ],
+    // North-side resource market. Three resources only (no uranium row).
+    // Verified from the Korea Recharged rulebook resource table (N rows).
+    resupplyNorth: [
+        // Coal (N)
+        [
+            [1, 2, 1],
+            [2, 2, 1],
+            [2, 3, 2],
+            [2, 3, 2],
+            [3, 4, 3],
+        ],
+        // Oil (N)
+        [
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 1, 2],
+            [1, 2, 2],
+            [2, 2, 3],
+        ],
+        // Garbage (N)
+        [
+            [0, 1, 1],
+            [0, 1, 1],
+            [1, 1, 2],
+            [1, 1, 2],
+            [1, 2, 3],
+        ],
+    ],
+    // Korea has custom slot counts per price space, different per side.
+    // Total resources (across both markets + supply) match standard Power Grid:
+    // 24 coal, 24 oil, 24 garbage, 12 uranium.
+    //
+    // North slots per price [1..8]:
+    //   coal [2,2,2,2,1,1,1,1] = 12 total
+    //   oil  [1,1,1,1,1,1,1,1] = 8 total
+    //   garbage [1,1,1,1,1,1,1,1] = 8 total
+    //
+    // South slots per price [1..8] (uranium prices [1..8,10,12,14,16]):
+    //   coal [1,1,1,1,2,2,2,2] = 12 total
+    //   oil  [2,2,2,2,2,2,2,2] = 16 total
+    //   garbage [2,2,2,2,2,2,2,2] = 16 total
+    //   uranium [1,1,1,1,1,1,1,1,1,1,1,1] = 12 total
+    //
+    // Initial market fill per rulebook:
+    //   North: coal 1–8 (12), oil 3–8 (6), garbage 7–8 (2).
+    //   South: coal 1–8 (12), oil 3–8 (12), garbage 7–8 (4), uranium 14–16 (2).
+    startingResources: [12, 12, 4, 2], // South initial market: coal, oil, garbage, uranium
+    startingResourcesNorth: [12, 6, 2], // North initial market: coal, oil, garbage
+    // Total cubes in the game across BOTH markets + shared supply.
+    // Used cubes return to the shared supply; on bureaucracy, North restocks
+    // first, then South from whatever remains.
+    startingSupply: [24, 24, 24, 12],
+    coalPrices: [1, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8],
+    oilPrices: [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8],
+    garbagePrices: [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8],
+    uraniumPrices: [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16],
+    coalPricesNorth: [1, 1, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8],
+    oilPricesNorth: [1, 2, 3, 4, 5, 6, 7, 8],
+    garbagePricesNorth: [1, 2, 3, 4, 5, 6, 7, 8],
+    mapSpecificRules:
+        'Korea has two separate resource markets: North and South. On your buying turn, choose one side — all resources you buy that turn must come from that side. The next turn you may choose the other side. The North market has no uranium track; uranium is only available from the South market. Each market restocks independently from its own supply pool during the bureaucracy phase.',
 };

--- a/engine/src/maps/korea.ts
+++ b/engine/src/maps/korea.ts
@@ -1,3 +1,4 @@
+// by John and Cici
 import { GameMap } from './../maps';
 
 export enum Regions {
@@ -286,5 +287,8 @@ export const map: GameMap = {
     oilPricesNorth: [1, 2, 3, 4, 5, 6, 7, 8],
     garbagePricesNorth: [1, 2, 3, 4, 5, 6, 7, 8],
     mapSpecificRules:
-        'Korea has two separate resource markets: North and South. On your buying turn, choose one side — all resources you buy that turn must come from that side. The next turn you may choose the other side. The North market has no uranium track; uranium is only available from the South market. Each market restocks independently from its own supply pool during the bureaucracy phase.',
+        'Korea has two separate resource markets: North and South.\n' +
+        'On your buying turn, choose one side — all resources you buy that turn must come from that side. The next turn you may choose the other side.\n' +
+        'The North market has no uranium track; uranium is only available from the South.\n' +
+        'Both markets share a single supply pool. During bureaucracy, North restocks first, then South from whatever remains.',
 };

--- a/engine/src/maps/korea.ts
+++ b/engine/src/maps/korea.ts
@@ -183,8 +183,12 @@ export const map: GameMap = {
         { nodes: [Cities.Hamheung, Cities.Hyesan], cost: 23 },
     ],
     layout: 'Portrait',
-    adjustRatio: [1.0, 1.0],
+    adjustRatio: [0.22, 0.22],
     mapPosition: [80, 30],
+    // Taller than the default Portrait viewBox to make room for Korea's stacked
+    // dual resource markets (North above South).
+    viewBox: [1480, 1180],
+    supplyPosition: [675, 1040],
     // South-side resource market.
     // Indexed [resource][playerCount-2][step-1].
     // Verified from the Korea Recharged rulebook resource table (S rows).

--- a/engine/src/maps/northerneurope.ts
+++ b/engine/src/maps/northerneurope.ts
@@ -1,3 +1,5 @@
+// by John and Cici
+import { PowerPlantType } from './../gamestate';
 import { GameMap } from './../maps';
 
 export enum Regions {
@@ -100,6 +102,80 @@ export const map: GameMap = {
         { name: Cities.Bergen, region: Regions.Red, x: 68, y: 586 },
         { name: Cities.Stavanger, region: Regions.Red, x: 72, y: 647 },
     ],
+    layout: 'Portrait',
+    adjustRatio: [1.2, 1.0],
+    mapPosition: [80, 30],
+    startingResources: [18, 18, 12, 6],
+    resupply: [
+        // Coal
+        [
+            [2, 4, 3], // 2P
+            [3, 4, 4], // 3P
+            [4, 5, 5], // 4P
+            [4, 5, 6], // 5P
+            [6, 8, 5], // 6P
+        ],
+        // Oil
+        [
+            [1, 2, 3],
+            [2, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+            [4, 5, 6],
+        ],
+        // Garbage
+        [
+            [1, 2, 3],
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 3, 5],
+            [3, 5, 6],
+        ],
+        // Uranium
+        [
+            [1, 2, 2],
+            [1, 2, 2],
+            [2, 3, 2],
+            [2, 4, 3],
+            [2, 4, 4],
+        ],
+    ],
+    regionalPowerPlants: {
+        [Regions.Orange]: [
+            // Denmark
+            { number: 19, type: PowerPlantType.Oil, cost: 2, citiesPowered: 4 },
+            { number: 26, type: PowerPlantType.Coal, cost: 3, citiesPowered: 5 },
+        ],
+        [Regions.Red]: [
+            // Norway
+            { number: 7, type: PowerPlantType.Wind, cost: 0, citiesPowered: 1 },
+            { number: 46, type: PowerPlantType.Wind, cost: 0, citiesPowered: 6 },
+        ],
+        [Regions.Purple]: [
+            // Sweden South
+            { number: 10, type: PowerPlantType.Uranium, cost: 2, citiesPowered: 3 },
+            { number: 39, type: PowerPlantType.Wind, cost: 0, citiesPowered: 5 },
+        ],
+        [Regions.Yellow]: [
+            // Sweden North
+            { number: 21, type: PowerPlantType.Wind, cost: 0, citiesPowered: 2 },
+            { number: 25, type: PowerPlantType.Uranium, cost: 1, citiesPowered: 4 },
+        ],
+        [Regions.Brown]: [
+            // Finland
+            { number: 32, type: PowerPlantType.Garbage, cost: 2, citiesPowered: 6 },
+            { number: 44, type: PowerPlantType.Uranium, cost: 1, citiesPowered: 7 },
+        ],
+        [Regions.Pink]: [
+            // Baltic States
+            { number: 18, type: PowerPlantType.Coal, cost: 1, citiesPowered: 3 },
+            { number: 22, type: PowerPlantType.Wind, cost: 0, citiesPowered: 3 },
+        ],
+    },
+    mapSpecificRules:
+        'Nuclear plants may only be purchased by players with at least one city in Sweden, Finland, or the Baltic States. ' +
+        'Players with cities only in Norway or Denmark may not bid on or buy nuclear plants. ' +
+        'Resources start at: coal 3 Elektro, oil 3 Elektro, garbage 5 Elektro, uranium 7 Elektro.',
     connections: [
         { nodes: [Cities.Bood, Cities.Tromso], cost: 17 },
         { nodes: [Cities.Tromso, Cities.Oulu], cost: 25 },

--- a/engine/src/move.ts
+++ b/engine/src/move.ts
@@ -27,6 +27,9 @@ export declare namespace Moves {
         name: MoveName.BuyResource;
         data: {
             resource: ResourceType;
+            // Korea: which side's market the resource was bought from.
+            // Omitted on all other maps.
+            side?: 'north' | 'south';
         };
         fromSupply?: boolean;
     }

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -11,8 +11,8 @@
 		"url": "https://github.com/boardgamers/powergrid/issues"
 	},
 	"scripts": {
-		"serve": "vue-cli-service serve",
-		"build": "vue-cli-service build",
+		"serve": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve",
+		"build": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
 		"test:unit": "vue-cli-service test:unit",
 		"package": "vue-cli-service build --target lib --name powergrid-viewer src/wrapper.ts",
 		"prepublishOnly": "npm run package"

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -287,6 +287,9 @@
                                     <li><strong>One</strong> player per city</li>
                                     <li>
                                         Resource Resupply: <strong>{{ G.resourceResupply[0] }}</strong>
+                                        <template v-if="G.resourceResupplyNorth">
+                                            (S), <strong>{{ G.resourceResupplyNorth[0] }}</strong> (N)
+                                        </template>
                                     </li>
                                     <li>Bureaucracy: remove <strong>highest</strong> power plant from market</li>
                                 </ul>
@@ -301,6 +304,9 @@
                                     <li><strong>Two</strong> players per city</li>
                                     <li>
                                         Resource Resupply: <strong>{{ G.resourceResupply[1] }}</strong>
+                                        <template v-if="G.resourceResupplyNorth">
+                                            (S), <strong>{{ G.resourceResupplyNorth[1] }}</strong> (N)
+                                        </template>
                                     </li>
                                     <li>Bureaucracy: remove <strong>highest</strong> power plant from market</li>
                                 </ul>
@@ -312,6 +318,9 @@
                                     <li><strong>Three</strong> players per city</li>
                                     <li>
                                         Resource Resupply: <strong>{{ G.resourceResupply[2] }}</strong>
+                                        <template v-if="G.resourceResupplyNorth">
+                                            (S), <strong>{{ G.resourceResupplyNorth[2] }}</strong> (N)
+                                        </template>
                                     </li>
                                     <li>Bureaucracy: remove <strong>lowest</strong> power plant from market</li>
                                     <li>All power plants available for auction</li>
@@ -329,7 +338,7 @@
                         <br />
                         <div>
                             <strong>Map Specific Rules:</strong><br />
-                            <span style="white-space: pre">{{ G.map.mapSpecificRules }}</span>
+                            <span style="white-space: pre-wrap">{{ G.map.mapSpecificRules }}</span>
                         </div>
                     </template>
                     <br />

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -621,8 +621,12 @@ export default class Game extends Vue {
         }
     }
 
-    buyResource(resource: ResourceType) {
-        this.sendMove({ name: MoveName.BuyResource, data: { resource } });
+    buyResource(payload: { resource: ResourceType, side?: 'north' | 'south' }) {
+        const data: { resource: ResourceType, side?: 'north' | 'south' } = { resource: payload.resource };
+        if (payload.side) {
+            data.side = payload.side;
+        }
+        this.sendMove({ name: MoveName.BuyResource, data });
     }
 
     bid(bid: number) {
@@ -862,13 +866,13 @@ export default class Game extends Vue {
         return !!availableMoves[MoveName.ChoosePowerPlant];
     }
 
-    buyableResources() {
+    buyableResources(): { resource: ResourceType, side?: 'north' | 'south' }[] {
         if (!this.canMove()) return [];
 
         const currentPlayer = this.G!.players[this.player!];
         const availableMoves = currentPlayer.availableMoves!;
 
-        return !!availableMoves[MoveName.BuyResource] && availableMoves[MoveName.BuyResource]!.map((m) => m.resource) || [];
+        return availableMoves[MoveName.BuyResource] || [];
     }
 
     canBuyResource(resource?: ResourceType) {

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -1,5 +1,73 @@
 <template>
     <g>
+        <!-- Korea: North resource market (above the standard market block).
+             The South market re-uses the existing rendering below; Korea-specific
+             cube positions are populated in createPieces. -->
+        <template v-if="isKorea">
+            <text x="20" y="-110" font-weight="700" fill="black" style="font-size: 22px">North Market</text>
+            <rect width="760" height="80" x="20" y="-100" rx="3" fill="#c89c3a" />
+            <template v-for="index in 8">
+                <rect
+                    :key="'north_resources' + index"
+                    width="70"
+                    height="70"
+                    :x="25 + 85 * (index - 1)"
+                    y="-95"
+                    rx="2"
+                    fill="darkgoldenrod"
+                />
+                <circle
+                    :key="'north_resourcesCircle' + index"
+                    r="10"
+                    :cx="92 + 85 * (index - 1)"
+                    cy="-92"
+                    fill="yellow"
+                />
+                <text
+                    :key="'north_resourcesText' + index"
+                    text-anchor="middle"
+                    style="font-size: 16px; font-family: monospace"
+                    :x="92 + 85 * (index - 1)"
+                    y="-92"
+                    fill="darkgoldenrod"
+                >
+                    {{ index }}
+                </text>
+            </template>
+            <template v-for="coal in coalsNorth">
+                <Coal
+                    :key="coal.id"
+                    :pieceId="coal.id"
+                    :targetState="{ x: coal.x, y: coal.y }"
+                    :canClick="!coal.transparent && canBuyResource('coal', coal.side)"
+                    :transparent="coal.transparent"
+                    :scale="0.08"
+                    @click="buyResource('coal', coal.side)"
+                />
+            </template>
+            <template v-for="oil in oilsNorth">
+                <Oil
+                    :key="oil.id"
+                    :pieceId="oil.id"
+                    :targetState="{ x: oil.x, y: oil.y }"
+                    :canClick="!oil.transparent && canBuyResource('oil', oil.side)"
+                    :transparent="oil.transparent"
+                    @click="buyResource('oil', oil.side)"
+                />
+            </template>
+            <template v-for="garbage in garbagesNorth">
+                <Garbage
+                    :key="garbage.id"
+                    :pieceId="garbage.id"
+                    :targetState="{ x: garbage.x, y: garbage.y }"
+                    :canClick="!garbage.transparent && canBuyResource('garbage', garbage.side)"
+                    :transparent="garbage.transparent"
+                    @click="buyResource('garbage', garbage.side)"
+                />
+            </template>
+            <text x="20" y="35" font-weight="700" fill="black" style="font-size: 22px">South Market</text>
+        </template>
+
         <text v-if="resourceResupply[0] < 10" x="30" y="20" font-weight="600" fill="black" style="font-size: 24px"
             >Resource Resupply:</text
         >
@@ -164,10 +232,10 @@
                 :key="coal.id"
                 :pieceId="coal.id"
                 :targetState="{ x: coal.x, y: coal.y }"
-                :canClick="!coal.transparent && canBuyResource('coal')"
+                :canClick="!coal.transparent && canBuyResource('coal', coal.side)"
                 :transparent="coal.transparent"
                 :scale="isIndiaResourceMarket ? 0.06 : 0.08"
-                @click="buyResource('coal')"
+                @click="buyResource('coal', coal.side)"
             />
         </template>
 
@@ -176,9 +244,9 @@
                 :key="oil.id"
                 :pieceId="oil.id"
                 :targetState="{ x: oil.x, y: oil.y }"
-                :canClick="!oil.transparent && canBuyResource('oil')"
+                :canClick="!oil.transparent && canBuyResource('oil', oil.side)"
                 :transparent="oil.transparent"
-                @click="buyResource('oil')"
+                @click="buyResource('oil', oil.side)"
             />
         </template>
 
@@ -187,10 +255,10 @@
                 :key="garbage.id"
                 :pieceId="garbage.id"
                 :targetState="{ x: garbage.x, y: garbage.y }"
-                :canClick="!garbage.transparent && canBuyResource('garbage')"
+                :canClick="!garbage.transparent && canBuyResource('garbage', garbage.side)"
                 :transparent="garbage.transparent"
                 :scale="isIndiaResourceMarket ? 0.8 : 1"
-                @click="buyResource('garbage')"
+                @click="buyResource('garbage', garbage.side)"
             />
         </template>
 
@@ -199,9 +267,9 @@
                 :key="uranium.id"
                 :pieceId="uranium.id"
                 :targetState="{ x: uranium.x, y: uranium.y }"
-                :canClick="!uranium.transparent && canBuyResource('uranium')"
+                :canClick="!uranium.transparent && canBuyResource('uranium', uranium.side)"
                 :transparent="uranium.transparent"
-                @click="buyResource('uranium')"
+                @click="buyResource('uranium', uranium.side)"
             />
         </template>
 
@@ -222,7 +290,29 @@
 
         <template v-if="!preferences.disableHelp">
             <rect
-                v-if="buyableResources.length > 0"
+                v-if="!isKorea && buyableResources.length > 0"
+                x="15"
+                y="35"
+                width="770"
+                height="90"
+                rx="2"
+                fill="none"
+                stroke="blue"
+                stroke-width="2px"
+            />
+            <rect
+                v-if="isKorea && hasBuyableNorth"
+                x="15"
+                y="-105"
+                width="770"
+                height="90"
+                rx="2"
+                fill="none"
+                stroke="blue"
+                stroke-width="2px"
+            />
+            <rect
+                v-if="isKorea && hasBuyableSouth"
                 x="15"
                 y="35"
                 width="770"
@@ -254,7 +344,7 @@ export default class Resources extends Vue {
     @Prop() isMiddleEast?: boolean;
     @Prop() isIndiaResourceMarket?: boolean;
     @Prop() availableSurplusOil?: number;
-    @Prop() buyableResources?: string[];
+    @Prop() buyableResources?: { resource: string, side?: 'north' | 'south' }[];
 
     @Inject() preferences!: Preferences;
 
@@ -263,8 +353,118 @@ export default class Resources extends Vue {
     garbages: Piece[] = [];
     uraniums: Piece[] = [];
 
+    isKorea: boolean = false;
+    coalsNorth: Piece[] = [];
+    oilsNorth: Piece[] = [];
+    garbagesNorth: Piece[] = [];
+
+    // Korea: lay out cubes within 8 price spaces ($1..$8) using the prices array
+    // to determine slot count per space. Cubes are indexed cheap→expensive in the
+    // prices array, so the cheap end empties as the market depletes.
+    // Skips entries with price > 8 (uranium corner $10/$12/$14/$16) — caller renders
+    // those separately.
+    private buildKoreaMainRowPieces(
+        prices: number[],
+        market: number,
+        idPrefix: string,
+        side: 'north' | 'south',
+        y: number,
+    ): Piece[] {
+        const groups: { price: number; slots: number; firstIdx: number }[] = [];
+        prices.forEach((p, idx) => {
+            if (p > 8) return;
+            const last = groups[groups.length - 1];
+            if (last && last.price === p) last.slots++;
+            else groups.push({ price: p, slots: 1, firstIdx: idx });
+        });
+
+        const pieces: Piece[] = [];
+        // Width within a price space across which cubes are distributed. Bigger
+        // value → cubes within the same price space appear farther apart.
+        const cubeAreaW = 64;
+        groups.forEach((g) => {
+            const psCenter = 60 + 85 * (g.price - 1);
+            for (let s = 0; s < g.slots; s++) {
+                const i = g.firstIdx + s;
+                const x = g.slots === 1
+                    ? psCenter
+                    : psCenter - cubeAreaW / 2 + (cubeAreaW * (s + 0.5)) / g.slots;
+                pieces.push({
+                    id: `${idPrefix}_${i}`,
+                    x,
+                    y,
+                    transparent: i < (prices.length - market),
+                    side,
+                });
+            }
+        });
+        return pieces;
+    }
+
     createPieces(gameState: GameState) {
-        if (gameState) {
+        if (!gameState) return;
+
+        const isKorea = gameState.coalMarketNorth !== undefined;
+        this.isKorea = isKorea;
+
+        if (isKorea) {
+            // SOUTH market — main row coal/oil/garbage at the existing y positions.
+            this.coals = this.buildKoreaMainRowPieces(
+                gameState.coalPrices!, gameState.coalMarket, 'coal', 'south', 48,
+            );
+            this.oils = this.buildKoreaMainRowPieces(
+                gameState.oilPrices!, gameState.oilMarket, 'oil', 'south', 70,
+            );
+            this.garbages = this.buildKoreaMainRowPieces(
+                gameState.garbagePrices!, gameState.garbageMarket, 'garbage', 'south', 94,
+            );
+
+            // SOUTH uranium: $1..$8 sit between the oil (y=70) and garbage (y=94) rows
+            // so they don't visually overlap with oil. $10/$12/$14/$16 go in the corner
+            // 2x2 grid (top row at y=52, bottom row at y=91).
+            this.uraniums = [];
+            const uPrices = gameState.uraniumPrices!;
+            uPrices.forEach((p, i) => {
+                let x: number, y: number;
+                if (p <= 8) {
+                    x = 60 + 85 * (p - 1);
+                    y = 85;
+                } else {
+                    // $10 → (710, 52), $12 → (750, 52), $14 → (710, 91), $16 → (750, 91)
+                    const cornerX = (p === 10 || p === 14) ? 710 : 750;
+                    const cornerY = (p === 10 || p === 12) ? 52 : 91;
+                    x = cornerX;
+                    y = cornerY;
+                }
+                this.uraniums.push({
+                    id: `uranium_${i}`,
+                    x, y,
+                    transparent: i < (uPrices.length - gameState.uraniumMarket),
+                    side: 'south',
+                });
+            });
+
+            // NORTH market — placed above the South so its rect sits at y=-100..-20.
+            // Cube rows match the South layout's offsets within the rect (top/mid/bottom).
+            this.coalsNorth = this.buildKoreaMainRowPieces(
+                gameState.coalPricesNorth!, gameState.coalMarketNorth!, 'coal_north', 'north', -92,
+            );
+            this.oilsNorth = this.buildKoreaMainRowPieces(
+                gameState.oilPricesNorth!, gameState.oilMarketNorth!, 'oil_north', 'north', -70,
+            );
+            this.garbagesNorth = this.buildKoreaMainRowPieces(
+                gameState.garbagePricesNorth!, gameState.garbageMarketNorth!, 'garbage_north', 'north', -46,
+            );
+
+            return;
+        }
+
+        // Non-Korea: original logic below (unchanged).
+        this.coalsNorth = [];
+        this.oilsNorth = [];
+        this.garbagesNorth = [];
+
+        {
             this.coals = [];
             if (gameState.map?.name == 'India') {
                 Array(24)
@@ -435,12 +635,20 @@ export default class Resources extends Vue {
         }
     }
 
-    canBuyResource(resource: string) {
-        return !!this.buyableResources!.find(r => r == resource);
+    canBuyResource(resource: string, side?: 'north' | 'south') {
+        return !!this.buyableResources!.find(r => r.resource == resource && r.side == side);
     }
 
-    buyResource(resource: string) {
-        this.$emit('buyResource', resource);
+    get hasBuyableNorth() {
+        return !!this.buyableResources?.some(r => r.side === 'north');
+    }
+
+    get hasBuyableSouth() {
+        return !!this.buyableResources?.some(r => r.side === 'south');
+    }
+
+    buyResource(resource: string, side?: 'north' | 'south') {
+        this.$emit('buyResource', { resource, side });
     }
 }
 </script>

--- a/viewer/src/self-contained.ts
+++ b/viewer/src/self-contained.ts
@@ -10,7 +10,7 @@ function launchSelfContained(selector = '#app') {
 
     const emitter = launch(selector);
 
-    let gameState = setup(3, { map: 'Brazil', variant: 'original', showMoney: true, randomizeMap: true }, '3');
+    let gameState = setup(6, { map: 'Korea', variant: 'recharged', showMoney: true, randomizeMap: false }, '3');
 
     // gameState.map.viewBox = [1480, 1060];
     // gameState.map.playerOrderPosition = [1160, 140];

--- a/viewer/src/types/ui-data.ts
+++ b/viewer/src/types/ui-data.ts
@@ -21,6 +21,7 @@ export interface Piece {
     color?: string;
     powerPlant?: PowerPlant;
     transparent?: boolean;
+    side?: 'north' | 'south';
 }
 
 export enum PieceType {


### PR DESCRIPTION
## Summary

- **Northern Europe** map (commit 65dfc9e): full city/connection data, regional power plant swaps, resupply table from the Rio Grande PDF.
- **Korea** map with the dual resource market mechanic:
  - Engine support (commit 1260da2): two parallel markets, side-locking via `chosenSide`, North-restocks-first bureaucracy from a shared supply pool, North has no uranium track.
  - Viewer dual-market UI + two engine bug fixes (commit e3d2296): North market rendered above South with side-aware click handling, and:
    - Undo of the last `BuyResource` now clears `chosenSide` so a player can switch sides if they revert their only buy.
    - Bureaucracy resupply caps by remaining market capacity (`prices.length - market`), fixing Korea's smaller markets overflowing past their slot count and breaking the price lookup.

## Test plan

- [ ] Northern Europe: regional plant swaps trigger as configured
- [ ] Korea: dual-market UI renders with North above South
- [ ] Korea: side lock engages on first buy and clears on undo of last buy
- [ ] Korea: bureaucracy resupply respects market capacity (no overflow)
- [ ] All 11 existing engine tests still pass
