### PR TITLE
Fix Northern Europe plant 26 and UK & Ireland 2P step2 trigger

### DIFF
--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -15,7 +15,7 @@ export const playerColors = ['limegreen', 'mediumorchid', 'red', 'dodgerblue', '
 
 const citiesToStep2 = [10, 7, 7, 7, 6];
 const citiesToStep2BadenWurttemberg = [9, 6, 6, 6, 5];
-const citiesToStep2UKIreland = [7, 7, 7, 7, 6];
+const citiesToStep2UKIreland = [10, 7, 7, 7, 6];
 const citiesToEndGame = [21, 17, 17, 15, 14];
 const cityIncome = [10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150];
 const regionsInPlay = [3, 3, 4, 5, 5];

--- a/engine/src/maps/northerneurope.ts
+++ b/engine/src/maps/northerneurope.ts
@@ -144,7 +144,7 @@ export const map: GameMap = {
         [Regions.Orange]: [
             // Denmark
             { number: 19, type: PowerPlantType.Oil, cost: 2, citiesPowered: 4 },
-            { number: 26, type: PowerPlantType.Coal, cost: 3, citiesPowered: 5 },
+            { number: 26, type: PowerPlantType.Oil, cost: 3, citiesPowered: 5 },
         ],
         [Regions.Red]: [
             // Norway


### PR DESCRIPTION
## Summary
Two small bug fixes Mike reported from playtest:

1. **Northern Europe plant 26** was set to Coal in the Denmark regional override; should be Oil. The Denmark deck is oil-themed (plant 19 is already Oil 2→4) and Coal was the only deviation from the consistent regional theming across the map (Norway=wind, Sweden=nuclear+wind, Finland=garbage+nuclear, Baltic=coal+wind, Denmark=oil).
2. **UK & Ireland 2P step-2 trigger** was set to 7 cities; should be 10 (matching base game). The 2P slot got copied from the 3P slot at authoring time — the original commit message claimed it was intentional but the array shape (only 2P deviates, and equals its neighbor) and Mike's playtest both contradict that.

Both reported by Mike playtesting at boardgamers.space.

## Test plan
- [x] Engine tests pass locally (15/15 on the parent branch; 12/12 on this fresh-from-master branch)
- [ ] CI: lint + test
- [ ] 2P UK & Ireland game — verify step-2 trigger shows 10 on the city-count track
- [ ] Northern Europe — verify Denmark regional plant 26 displays as Oil 3→5 when in deck/market

🤖 Generated with [Claude Code](https://claude.com/claude-code)
