### PR TITLE
Soak test and misc fixes

### DIFF
--- a/.github/workflows/engine-test.yml
+++ b/.github/workflows/engine-test.yml
@@ -9,6 +9,9 @@ on:
             - '.github/workflows/engine-test.yml'
             - 'engine/**'
 
+permissions:
+    contents: read
+
 defaults:
     run:
         working-directory: engine

--- a/.github/workflows/engine-test.yml
+++ b/.github/workflows/engine-test.yml
@@ -17,8 +17,8 @@ jobs:
     lint_and_test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: '14'
             - run: corepack enable

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,6 +1,9 @@
 name: All
 on: [pull_request, push]
 
+permissions:
+    contents: read
+
 jobs:
     prettier:
         runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -5,8 +5,8 @@ jobs:
     prettier:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: '22'
             - run: corepack enable

--- a/.github/workflows/viewer-test.yml
+++ b/.github/workflows/viewer-test.yml
@@ -19,8 +19,8 @@ jobs:
     test_and_build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: '14'
             - run: corepack enable

--- a/.github/workflows/viewer-test.yml
+++ b/.github/workflows/viewer-test.yml
@@ -11,6 +11,9 @@ on:
             - '.github/workflows/viewer-test.yml'
             - 'viewer/**'
 
+permissions:
+    contents: read
+
 defaults:
     run:
         working-directory: viewer

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
 import 'mocha';
-import { ended, move, reconstructState, setup } from './engine';
+import { availableMoves } from './available-moves';
+import { ended, getPowerPlant, move, reconstructState, setup } from './engine';
 import GermanyRecharged from './fixtures/GermanyRecharged.json';
 import supply from './fixtures/supply.json';
 import undo from './fixtures/undo.json';
 import USAOriginal from './fixtures/USAOriginal.json';
-import { GameOptions, MapName, Variant } from './gamestate';
-import { Move } from './move';
+import { GameOptions, MapName, PowerPlant, Variant } from './gamestate';
+import { Move, MoveName } from './move';
 
 describe('Engine', () => {
     it('should setup a game correctly', () => {
@@ -183,6 +184,70 @@ describe('Engine', () => {
         expect(ended(G)).to.be.false;
         expect(G.map.name).to.equal('Northern Europe');
         expect(G.players.some((p) => p.availableMoves && Object.keys(p.availableMoves).length > 0)).to.be.true;
+    });
+
+    it('should preserve regionalPowerPlants override when chosen for auction', () => {
+        // Regression: ChoosePowerPlant previously used getPowerPlant() canonical
+        // lookup, losing regionalPowerPlants overrides — Mike reported plants in
+        // Northern Europe reverting from regional (e.g. coal/3-cities) to canonical
+        // (wind/2-cities) on bid selection.
+        const G = setup(
+            5,
+            { map: 'Northern Europe', variant: 'recharged', randomizeMap: false, fastBid: false },
+            'ne-test-seed'
+        );
+
+        // Find a regional plant whose values differ from canonical and is currently
+        // in the market or deck, then place it into actualMarket[0] so it's choosable.
+        const overrides = (G.map as any).regionalPowerPlants as Record<string, PowerPlant[]>;
+        const regionsInPlay = new Set(G.map.cities.map((c) => c.region));
+
+        let regional: PowerPlant | undefined;
+        for (const region of regionsInPlay) {
+            for (const override of overrides[region] ?? []) {
+                const canonical = getPowerPlant(override.number);
+                if (
+                    canonical.type !== override.type ||
+                    canonical.citiesPowered !== override.citiesPowered ||
+                    canonical.cost !== override.cost
+                ) {
+                    const found = [...G.actualMarket, ...G.futureMarket, ...G.powerPlantsDeck].find(
+                        (p) => p.number === override.number
+                    );
+                    if (found) {
+                        regional = found;
+                        break;
+                    }
+                }
+            }
+            if (regional) break;
+        }
+
+        expect(regional, 'expected at least one regional plant in play with this seed').to.exist;
+
+        // Swap the regional plant into actualMarket[0] and recompute the starting
+        // player's available moves so they can choose it.
+        G.actualMarket[0] = regional!;
+        const startingPlayer = G.currentPlayers[0];
+        G.players[startingPlayer].money = 100; // ensure they can afford the plant
+        G.players[startingPlayer].availableMoves = availableMoves(G, G.players[startingPlayer]);
+
+        const G2 = move(G, { name: MoveName.ChoosePowerPlant, data: regional!.number } as Move, startingPlayer);
+
+        // Chosen plant must be the regional version, not canonical.
+        const canonical = getPowerPlant(regional!.number);
+        expect(G2.chosenPowerPlant).to.exist;
+        expect(G2.chosenPowerPlant!.number).to.equal(regional!.number);
+        expect(G2.chosenPowerPlant!.type).to.equal(regional!.type);
+        expect(G2.chosenPowerPlant!.citiesPowered).to.equal(regional!.citiesPowered);
+        expect(G2.chosenPowerPlant!.cost).to.equal(regional!.cost);
+        // Sanity: the override must actually differ from canonical, otherwise the
+        // test wouldn't catch the bug.
+        expect(
+            G2.chosenPowerPlant!.type !== canonical.type ||
+                G2.chosenPowerPlant!.citiesPowered !== canonical.citiesPowered ||
+                G2.chosenPowerPlant!.cost !== canonical.cost
+        ).to.be.true;
     });
 
     it('should place UK & Ireland Step 3 card third from last with two plants below it', () => {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -495,7 +495,9 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
         case MoveName.ChoosePowerPlant: {
             asserts<Moves.MoveChoosePowerPlant>(move);
 
-            G.chosenPowerPlant = getPowerPlant(move.data, G.map.name);
+            // Pull from actualMarket so regionalPowerPlants overrides survive
+            // selection — canonical getPowerPlant() lookup would lose them.
+            G.chosenPowerPlant = G.actualMarket.find((p) => p.number === move.data)!;
             G.auctioningPlayer = player.id;
 
             if (move.data == 39) {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -17,6 +17,7 @@ const citiesToStep2 = [10, 7, 7, 7, 6];
 const citiesToStep2BadenWurttemberg = [9, 6, 6, 6, 5];
 const citiesToStep2UKIreland = [10, 7, 7, 7, 6];
 const citiesToEndGame = [21, 17, 17, 15, 14];
+const citiesToEndGameSouthAfrica = [18, 17, 17, 15, 14];
 const cityIncome = [10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150];
 const regionsInPlay = [3, 3, 4, 5, 5];
 
@@ -402,7 +403,12 @@ export function setup(
                 : (forceMap || finalMap).name == 'UK & Ireland'
                 ? citiesToStep2UKIreland[numPlayers - 2]
                 : citiesToStep2[numPlayers - 2],
-        citiesToEndGame: citiesToEndGame[numPlayers - 2],
+        citiesToEndGame:
+            (forceMap || finalMap).name == 'South Africa'
+                ? citiesToEndGameSouthAfrica[numPlayers - 2]
+                : (forceMap || finalMap).name == 'UK & Ireland' && numPlayers == 2
+                ? Math.min(citiesToEndGame[numPlayers - 2], (forceMap || finalMap).cities.length)
+                : citiesToEndGame[numPlayers - 2],
         resourceResupply: [
             `[${coalResupply[p][0]}, ${oilResupply[p][0]}, ${garbageResupply[p][0]}, ${uraniumResupply[p][0]}]`,
             `[${coalResupply[p][1]}, ${oilResupply[p][1]}, ${garbageResupply[p][1]}, ${uraniumResupply[p][1]}]`,
@@ -757,7 +763,15 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     if (G.players.filter((p) => !p.passed && !p.isDropped).length == 0) {
                         const maxCities = Math.max(...G.players.map((p) => p.cities.length));
                         if (G.step == 1) {
-                            if (maxCities >= G.citiesToStep2 && G.map.name != 'Middle East') {
+                            // Step 1 is single-occupancy, so the sum of player city
+                            // counts equals the number of cities with a house. When
+                            // that hits map.cities.length, every Step 1 slot is full
+                            // and Step 2 needs to fire even if no player reached
+                            // citiesToStep2 (can happen on small maps / small region
+                            // counts where the threshold is unreachable).
+                            const totalCitiesBuilt = G.players.reduce((sum, p) => sum + p.cities.length, 0);
+                            const allStep1HousesFilled = totalCitiesBuilt >= G.map.cities.length;
+                            if ((maxCities >= G.citiesToStep2 || allStep1HousesFilled) && G.map.name != 'Middle East') {
                                 const powerPlant = G.actualMarket.shift()!;
                                 G.log.push({
                                     type: 'event',
@@ -1962,6 +1976,16 @@ function addPowerPlant(G: GameState) {
                     enterStepTwoMiddleEast(G);
                     skipAdd = true;
                 } else {
+                    if (G.map.name == 'UK & Ireland' && G.step == 1) {
+                        // UK&I: Step 3 sits 3rd from last in the deck, so it can
+                        // surface before any player hits citiesToStep2. Fire Step
+                        // 2 here so its rules register before Step 3 takes over.
+                        G.log.push({
+                            type: 'event',
+                            event: 'Starting Step 2 (Step 3 card drawn before Step 2 threshold).',
+                        });
+                        G.step = 2;
+                    }
                     const powerPlantDiscarded = G.actualMarket.shift();
                     G.log.push({
                         type: 'event',

--- a/engine/src/maps/northamerica.ts
+++ b/engine/src/maps/northamerica.ts
@@ -351,10 +351,4 @@ export const map: GameMap = {
     startingResources: [20, 14, 18, 2],
     // Total cubes in the game (used cubes return here; refill draws from here).
     startingSupply: [24, 24, 24, 12],
-    mapSpecificRules:
-        'The metropolises of New York and Mexico City each consist of 2 cities ' +
-        '(New York N / New York S and Mexico City N / Mexico City S) connected by ' +
-        'a 0-cost edge. The official rules cap a player at 1 house per side of a ' +
-        'metropolis; this implementation does not enforce that cap pending publisher ' +
-        'clarification, so a player may build in both sides if they wish.',
 };

--- a/engine/src/maps/southafrica.ts
+++ b/engine/src/maps/southafrica.ts
@@ -62,7 +62,7 @@ export const map: GameMap = {
         { name: Cities.Polokwane, region: Regions.Orange, x: 802, y: 189 },
         { name: Cities.PretoriaN, region: Regions.Orange, x: 759, y: 261 },
         { name: Cities.PretoriaS, region: Regions.Orange, x: 759, y: 291 },
-        { name: Cities.Rustenburg, region: Regions.Orange, x: 666, y: 310 },
+        { name: Cities.Rustenburg, region: Regions.Orange, x: 632, y: 232 },
         { name: Cities.Mozambique, region: Regions.Green, x: 1011, y: 170, singleOccupancy: true },
         { name: Cities.Mbombela, region: Regions.Green, x: 891, y: 275 },
         { name: Cities.Eswatini, region: Regions.Green, x: 926, y: 351, singleOccupancy: true },

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -71,6 +71,7 @@
                 :buyableResources="buyableResources()"
                 :coalStorage="G.coalStorage"
                 :resourceResupply="getResourceResupply()"
+                :resourceResupplyNorth="getResourceResupplyNorth()"
                 @buyResource="buyResource($event)"
             />
 
@@ -1139,6 +1140,15 @@ export default class Game extends Vue {
         }
 
         return [0, 0, 0, 0];
+    }
+
+    getResourceResupplyNorth() {
+        if (this.G && this.G.resourceResupplyNorth) {
+            let str = this.G.resourceResupplyNorth[this.G.step - 1];
+            str = str.substr(1, str.length - 2);
+            return str.split(',');
+        }
+        return null;
     }
 }
 </script>

--- a/viewer/src/components/boards/PowerPlantMarket.vue
+++ b/viewer/src/components/boards/PowerPlantMarket.vue
@@ -152,10 +152,13 @@ export default class PowerPlantMarket extends Vue {
         this.futureMarketCards = [];
         gameState.futureMarket.forEach((card, i) => {
             if (card.number != gameState.chosenPowerPlant?.number) {
+                // Europe step 1 has 5 plants in the future market; the 5th would
+                // sit under the bid calculator at x=actualMarketWidth, so wrap
+                // to a second row.
                 this.futureMarketCards.push({
                     id: 'future_' + i,
-                    x: 165 + i * 65,
-                    y: 90,
+                    x: 165 + (i % 4) * 65,
+                    y: 90 + Math.floor(i / 4) * 50,
                     powerPlant: card
                 });
             }

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -4,6 +4,42 @@
              The South market re-uses the existing rendering below; Korea-specific
              cube positions are populated in createPieces. -->
         <template v-if="isKorea">
+            <template v-if="resourceResupplyNorth">
+                <text
+                    v-if="resourceResupplyNorth[0] < 10"
+                    x="30"
+                    y="-125"
+                    font-weight="600"
+                    fill="black"
+                    style="font-size: 24px"
+                    >Resource Resupply:</text
+                >
+                <text v-else x="20" y="-125" font-weight="600" fill="black" style="font-size: 24px"
+                    >Resource Resupply:</text
+                >
+                <text
+                    v-if="resourceResupplyNorth[0] < 10"
+                    x="276"
+                    y="-125"
+                    font-weight="600"
+                    fill="black"
+                    style="font-size: 24px"
+                >
+                    {{ resourceResupplyNorth[0] }}
+                </text>
+                <text v-else x="262" y="-125" font-weight="600" fill="black" style="font-size: 24px">
+                    {{ resourceResupplyNorth[0] }}
+                </text>
+                <Coal :pieceId="-1" :targetState="{ x: 288, y: -133 }" :canClick="false" :transparent="false" />
+                <text x="321" y="-125" font-weight="600" fill="black" style="font-size: 24px">
+                    {{ resourceResupplyNorth[1] }}
+                </text>
+                <Oil :pieceId="-1" :targetState="{ x: 331, y: -134 }" :canClick="false" :transparent="false" />
+                <text x="368" y="-125" font-weight="600" fill="black" style="font-size: 24px">
+                    {{ resourceResupplyNorth[2] }}
+                </text>
+                <Garbage :pieceId="-1" :targetState="{ x: 382, y: -134 }" :canClick="false" :transparent="false" />
+            </template>
             <text x="20" y="-110" font-weight="700" fill="black" style="font-size: 22px">North Market</text>
             <rect width="760" height="80" x="20" y="-100" rx="3" fill="#c89c3a" />
             <template v-for="index in 8">
@@ -377,6 +413,7 @@ import { range } from 'lodash';
 })
 export default class Resources extends Vue {
     @Prop() resourceResupply?: number[];
+    @Prop() resourceResupplyNorth?: number[];
     @Prop() isUsaRecharged?: boolean;
     @Prop() isMiddleEast?: boolean;
     @Prop() isIndiaResourceMarket?: boolean;


### PR DESCRIPTION
## Summary
Bundle of five commits:

- **North Market resupply indicator for Korea** — viewer was missing the
  step-by-step resupply display on the North market; mirrors the South
  side.
- **Northern Europe regionalPowerPlants override fix** — the override on `actualMarket[0]`
  was being lost when that plant was chosen for auction.
- **CI: workflow actions v6 bump** — clears the Node 20 deprecation warning.
- **CI: scope GITHUB_TOKEN to `contents: read`** in test/prettier
  workflows.
- **Soak-test feedback fixes** (from Mike + other players):
  - South Africa 2P endgame 21 → 18 (single-occupancy $30 cities make
    21 unreachable in 2P)
  - UK & Ireland 2P endgame capped at `min(21, citiesInPlay)` for small
    region selections
  - Universal Step 2 OR-trigger: fires when all Step 1 houses are filled,
    even if no player reached `citiesToStep2` (with a UK-specific
    fallback when the Step 3 card surfaces while still in Step 1)
  - North America: remove metropolis disclaimer paragraph from the
    map-rules dialog
  - South Africa: nudge Rustenburg coords so it no longer reads as a
    0-cost edge twin of Klerksdorp
  - Europe market: wrap the 5th future-market plant to a second row so
    it isn't hidden behind the bid calculator during auctions

## Test plan
- [x] `pnpm test` in engine — 15/15 passing
- [x] Visual check in self-contained dev viewer: South Africa 6P (all
  regions) for Rustenburg placement
- [x] Visual check in self-contained dev viewer: Europe 6P, reached
  auction phase, confirmed 5th plant on second row
