### PR TITLE
Fix Northern Europe uranium restriction and Europe deck reduction

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -106,6 +106,26 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                             }
                         }
 
+                        // Nuclear plants for Northern Europe are only allowed for players with
+                        // cities in Sweden (purple/yellow), Finland (brown), or the Baltic
+                        // States (pink). Players with cities only in Norway (red) or Denmark
+                        // (orange) — and players in round 1 with no cities yet — may not bid.
+                        if (G.map.name == 'Northern Europe') {
+                            const validCities = player.cities
+                                .map((c) => G.map.cities.find((c_) => c_.name == c.name)!)
+                                .filter(
+                                    (c) =>
+                                        c.region == 'purple' ||
+                                        c.region == 'yellow' ||
+                                        c.region == 'brown' ||
+                                        c.region == 'pink'
+                                );
+
+                            if (validCities.length == 0) {
+                                canBid = canBid.filter((p) => p.type != PowerPlantType.Uranium);
+                            }
+                        }
+
                         if (canBid.length > 0) {
                             moves[MoveName.ChoosePowerPlant] = canBid.map((p) => p.number);
                         }
@@ -162,6 +182,24 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                                 playerCities.every((c) => c.region == 'green') &&
                                 G.chosenPowerPlant.type == PowerPlantType.Uranium
                             ) {
+                                moves[MoveName.Bid] = undefined;
+                            }
+                        }
+
+                        // Northern Europe nuclear restriction — mirror of the ChoosePowerPlant
+                        // filter above, applied to active-auction bids.
+                        if (G.map.name == 'Northern Europe') {
+                            const validCities = player.cities
+                                .map((c) => G.map.cities.find((c_) => c_.name == c.name)!)
+                                .filter(
+                                    (c) =>
+                                        c.region == 'purple' ||
+                                        c.region == 'yellow' ||
+                                        c.region == 'brown' ||
+                                        c.region == 'pink'
+                                );
+
+                            if (validCities.length == 0 && G.chosenPowerPlant.type == PowerPlantType.Uranium) {
                                 moves[MoveName.Bid] = undefined;
                             }
                         }

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -8,6 +8,7 @@ import undo from './fixtures/undo.json';
 import USAOriginal from './fixtures/USAOriginal.json';
 import { GameOptions, MapName, PowerPlant, PowerPlantType, Variant } from './gamestate';
 import { Move, MoveName } from './move';
+import { powerPlants } from './powerPlants';
 
 describe('Engine', () => {
     it('should setup a game correctly', () => {
@@ -278,27 +279,53 @@ describe('Engine', () => {
         }
     });
 
-    it('should reduce Europe deck for low player counts', () => {
-        // Mike's feedback: in 2P the rules call for 2 plug + 6 normal cards removed
-        // (8 total). Engine had no reduction for Europe, leaving a too-large deck
-        // at low player counts. Standard PG: 2/3P remove 8, 4P remove 4, 5+P none.
+    it('should reduce Europe deck with weak/main split for low player counts', () => {
+        // Mike's feedback: Europe 2P rules call for "2 plug + 6 normal" cards removed.
+        // Engine ships only one combined plant set, so we approximate Set 2 ("plug")
+        // membership with the low-numbered (weak, <=15) band — same convention the
+        // Recharged default setup already uses to separate the initial-market
+        // reserve. Splits: 2/3P remove 2 weak + 6 main, 4P remove 1 weak + 3 main,
+        // 5+P remove nothing.
         // Total plants = 42 normal + step3. Initial market draw is 9 (4 actual + 5
         // future). Step 3 buried at bottom of deck. So deck length after setup:
         //   2/3P: 42 - 9 - 8 = 25, plus step3 = 26
         //   4P:   42 - 9 - 4 = 29, plus step3 = 30
         //   5+P:  42 - 9     = 33, plus step3 = 34
-        const expected: Record<number, number> = { 2: 26, 3: 26, 4: 30, 5: 34, 6: 34 };
+        const expectedSize: Record<number, number> = { 2: 26, 3: 26, 4: 30, 5: 34, 6: 34 };
+        const expectedWeakRemoved: Record<number, number> = { 2: 2, 3: 2, 4: 1, 5: 0, 6: 0 };
+        const expectedMainRemoved: Record<number, number> = { 2: 6, 3: 6, 4: 3, 5: 0, 6: 0 };
+
         for (const numPlayers of [2, 3, 4, 5, 6]) {
             const G = setup(
                 numPlayers,
                 { map: 'Europe', variant: 'recharged', randomizeMap: false },
                 `eu-trim-${numPlayers}p`
             );
-            expect(G.powerPlantsDeck.length, `Europe ${numPlayers}P deck size`).to.equal(expected[numPlayers]);
+
+            expect(G.powerPlantsDeck.length, `Europe ${numPlayers}P deck size`).to.equal(expectedSize[numPlayers]);
             expect(G.actualMarket.length).to.equal(4);
             expect(G.futureMarket.length).to.equal(5);
             // Step 3 is the last card in the deck.
             expect(G.powerPlantsDeck[G.powerPlantsDeck.length - 1].type).to.equal(PowerPlantType.Step3);
+
+            // Verify the weak/main split: compare the numbers still visible (market
+            // + future + deck) against the canonical set of plant numbers to see
+            // which were removed.
+            const visibleNumbers = new Set<number>([
+                ...G.actualMarket.map((p) => p.number),
+                ...G.futureMarket.map((p) => p.number),
+                ...G.powerPlantsDeck.map((p) => p.number),
+            ]);
+            const removed: number[] = [];
+            for (const p of powerPlants) {
+                if (p.type !== PowerPlantType.Step3 && !visibleNumbers.has(p.number)) {
+                    removed.push(p.number);
+                }
+            }
+            const weakRemoved = removed.filter((n) => n <= 15).length;
+            const mainRemoved = removed.filter((n) => n > 15).length;
+            expect(weakRemoved, `Europe ${numPlayers}P weak cards removed`).to.equal(expectedWeakRemoved[numPlayers]);
+            expect(mainRemoved, `Europe ${numPlayers}P main cards removed`).to.equal(expectedMainRemoved[numPlayers]);
         }
     });
 

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -6,7 +6,7 @@ import GermanyRecharged from './fixtures/GermanyRecharged.json';
 import supply from './fixtures/supply.json';
 import undo from './fixtures/undo.json';
 import USAOriginal from './fixtures/USAOriginal.json';
-import { GameOptions, MapName, PowerPlant, Variant } from './gamestate';
+import { GameOptions, MapName, PowerPlant, PowerPlantType, Variant } from './gamestate';
 import { Move, MoveName } from './move';
 
 describe('Engine', () => {
@@ -248,6 +248,58 @@ describe('Engine', () => {
                 G2.chosenPowerPlant!.citiesPowered !== canonical.citiesPowered ||
                 G2.chosenPowerPlant!.cost !== canonical.cost
         ).to.be.true;
+    });
+
+    it('should forbid uranium plants for Northern Europe players with no valid-region cities', () => {
+        // Mike's feedback: round 1 has no cities yet, so no player should be able to
+        // bid on uranium. More generally, players need at least one city in Sweden
+        // (purple/yellow), Finland (brown), or the Baltic States (pink). Norway (red)
+        // and Denmark (orange) alone do not qualify.
+        const G = setup(
+            5,
+            { map: 'Northern Europe', variant: 'recharged', randomizeMap: false, fastBid: false },
+            'ne-uranium-seed'
+        );
+
+        // Inject a uranium plant into the visible market so the test is meaningful
+        // regardless of seed (canonical plant 17 is a uranium plant priced 17).
+        const uraniumPlant = getPowerPlant(17);
+        expect(uraniumPlant.type).to.equal(PowerPlantType.Uranium);
+        G.actualMarket[0] = uraniumPlant;
+
+        for (const player of G.players) {
+            player.money = 100; // afford filter must not be what hides it
+            player.availableMoves = availableMoves(G, player);
+            const choosable = (player.availableMoves?.[MoveName.ChoosePowerPlant] ?? []) as number[];
+            expect(
+                choosable.includes(uraniumPlant.number),
+                `player ${player.id} (no cities yet) must not be able to choose a uranium plant`
+            ).to.be.false;
+        }
+    });
+
+    it('should reduce Europe deck for low player counts', () => {
+        // Mike's feedback: in 2P the rules call for 2 plug + 6 normal cards removed
+        // (8 total). Engine had no reduction for Europe, leaving a too-large deck
+        // at low player counts. Standard PG: 2/3P remove 8, 4P remove 4, 5+P none.
+        // Total plants = 42 normal + step3. Initial market draw is 9 (4 actual + 5
+        // future). Step 3 buried at bottom of deck. So deck length after setup:
+        //   2/3P: 42 - 9 - 8 = 25, plus step3 = 26
+        //   4P:   42 - 9 - 4 = 29, plus step3 = 30
+        //   5+P:  42 - 9     = 33, plus step3 = 34
+        const expected: Record<number, number> = { 2: 26, 3: 26, 4: 30, 5: 34, 6: 34 };
+        for (const numPlayers of [2, 3, 4, 5, 6]) {
+            const G = setup(
+                numPlayers,
+                { map: 'Europe', variant: 'recharged', randomizeMap: false },
+                `eu-trim-${numPlayers}p`
+            );
+            expect(G.powerPlantsDeck.length, `Europe ${numPlayers}P deck size`).to.equal(expected[numPlayers]);
+            expect(G.actualMarket.length).to.equal(4);
+            expect(G.futureMarket.length).to.equal(5);
+            // Step 3 is the last card in the deck.
+            expect(G.powerPlantsDeck[G.powerPlantsDeck.length - 1].type).to.equal(PowerPlantType.Step3);
+        }
     });
 
     it('should place UK & Ireland Step 3 card third from last with two plants below it', () => {

--- a/engine/src/maps/europe.ts
+++ b/engine/src/maps/europe.ts
@@ -360,10 +360,12 @@ export const map: GameMap = {
     // the current market and the 5 next in the future market, with the Step 3 card
     // buried at the bottom of the deck.
     //
-    // The rules call for the New Power Plants Set 2 deck ("plug-back" cards) and a
-    // rule against placing a plug-back card on top of the deck — both are no-ops
-    // here since this engine ships only one power-plant set. Revisit if/when Set 2
-    // is added.
+    // For low player counts, remove random plants from the remaining deck to match
+    // standard Power Grid rules (matches the per-map reductions other maps already
+    // apply via defaultSetupDeck). The Europe rulebook splits these removals across
+    // its two plant sets ("plug-back" Set 2 vs normal Set 1) — e.g. 2P removes 2
+    // plug + 6 normal — but since this engine ships only one combined set, we
+    // remove the same total at random and revisit if Set 2 is ever added.
     //
     // The Step 2 trigger for Europe is handled in engine.ts (special branch): it
     // removes the lowest plant from the current market once, then re-sorts the
@@ -379,6 +381,12 @@ export const map: GameMap = {
         const initialPlants = powerPlantsDeck.splice(0, 9).sort((a, b) => a.number - b.number);
         const actualMarket = initialPlants.slice(0, 4);
         const futureMarket = initialPlants.slice(4); // 5 plants
+
+        if (numPlayers == 2 || numPlayers == 3) {
+            powerPlantsDeck = powerPlantsDeck.slice(8);
+        } else if (numPlayers == 4) {
+            powerPlantsDeck = powerPlantsDeck.slice(4);
+        }
 
         powerPlantsDeck.push(step3);
 

--- a/engine/src/maps/europe.ts
+++ b/engine/src/maps/europe.ts
@@ -360,12 +360,15 @@ export const map: GameMap = {
     // the current market and the 5 next in the future market, with the Step 3 card
     // buried at the bottom of the deck.
     //
-    // For low player counts, remove random plants from the remaining deck to match
-    // standard Power Grid rules (matches the per-map reductions other maps already
-    // apply via defaultSetupDeck). The Europe rulebook splits these removals across
-    // its two plant sets ("plug-back" Set 2 vs normal Set 1) — e.g. 2P removes 2
-    // plug + 6 normal — but since this engine ships only one combined set, we
-    // remove the same total at random and revisit if Set 2 is ever added.
+    // For low player counts, remove plants from the remaining deck split across the
+    // weak (number <= 15) and main (number > 15) bands — mirrors the Recharged
+    // default setup, which already removes "2 weak + 6 main" for 2/3P and
+    // "1 weak + 3 main" for 4P. The Europe rulebook describes this as "2 plug + 6
+    // normal" using the Set 2 / Set 1 split on the back of the cards; the engine
+    // ships only one combined set, so we approximate Set 2 membership with the
+    // low-numbered ("weak") band that Recharged already treats as a separate pool.
+    // If the initial 9-card market draw consumed most weak cards, fall back to
+    // topping up the removal from the main band so the total reduction stays right.
     //
     // The Step 2 trigger for Europe is handled in engine.ts (special branch): it
     // removes the lowest plant from the current market once, then re-sorts the
@@ -382,10 +385,35 @@ export const map: GameMap = {
         const actualMarket = initialPlants.slice(0, 4);
         const futureMarket = initialPlants.slice(4); // 5 plants
 
+        let weakToRemove = 0;
+        let mainToRemove = 0;
         if (numPlayers == 2 || numPlayers == 3) {
-            powerPlantsDeck = powerPlantsDeck.slice(8);
+            weakToRemove = 2;
+            mainToRemove = 6;
         } else if (numPlayers == 4) {
-            powerPlantsDeck = powerPlantsDeck.slice(4);
+            weakToRemove = 1;
+            mainToRemove = 3;
+        }
+
+        if (weakToRemove + mainToRemove > 0) {
+            const weakPool = shuffle(
+                powerPlantsDeck.filter((p) => p.number <= 15),
+                rng() + ''
+            );
+            const mainPool = shuffle(
+                powerPlantsDeck.filter((p) => p.number > 15),
+                rng() + ''
+            );
+
+            const actualWeakRemoved = Math.min(weakToRemove, weakPool.length);
+            const weakShortfall = weakToRemove - actualWeakRemoved;
+            const actualMainRemoved = Math.min(mainToRemove + weakShortfall, mainPool.length);
+
+            const removedNumbers = new Set<number>([
+                ...weakPool.slice(0, actualWeakRemoved).map((p) => p.number),
+                ...mainPool.slice(0, actualMainRemoved).map((p) => p.number),
+            ]);
+            powerPlantsDeck = powerPlantsDeck.filter((p) => !removedNumbers.has(p.number));
         }
 
         powerPlantsDeck.push(step3);


### PR DESCRIPTION
## Summary

Two fixes from Mike's playtest feedback:

- **Northern Europe nuclear restriction**: nuclear plants now require at least one city in Sweden (purple/yellow), Finland (brown), or the Baltic States (pink). Players with cities only in Norway (red) or Denmark (orange) — and players in round 1 with no cities yet — can no longer bid on or buy uranium plants. Mirrors the existing Central Europe and UK & Ireland restrictions in `available-moves.ts`.
- **Europe deck reduction**: `Europe.setupDeck` now reduces the deck for low player counts, splitting across the weak (≤15) and main (>15) bands — 2/3P remove 2 weak + 6 main (8 total), 4P remove 1 weak + 3 main (4 total). Mirrors the Recharged default-setup pattern in `engine.ts` and approximates Mike's "2 plug + 6 normal" split (Set 2 vs Set 1). Every other map was already reducing the deck via `defaultSetupDeck`; Europe's custom `setupDeck` was the only one skipping reduction.


## Test plan

- [x] New unit test: NE players with no valid-region cities cannot choose a uranium plant from the market
- [x] New unit test: Europe deck size matches expected count after setup for 2P/3P/4P/5P/6P, with Step 3 buried at the bottom
- [x] All existing engine tests still pass (17 total)
- [x] Visual playtest: NE 6P self-contained game, confirmed Orange/Denmark-only player cannot bid on uranium plants
- [x] New unit test verifies the exact weak/main split per player count, not just the total

🤖 Generated with [Claude Code](https://claude.com/claude-code)
