### PR TITLE
Korea: enlarge map for better visibility

### DIFF
--- a/engine/src/maps/korea.ts
+++ b/engine/src/maps/korea.ts
@@ -184,8 +184,8 @@ export const map: GameMap = {
         { nodes: [Cities.Hamheung, Cities.Hyesan], cost: 23 },
     ],
     layout: 'Portrait',
-    adjustRatio: [0.22, 0.22],
-    mapPosition: [80, 30],
+    adjustRatio: [0.25, 0.25],
+    mapPosition: [40, 30],
     // Taller than the default Portrait viewBox to make room for Korea's stacked
     // dual resource markets (North above South).
     viewBox: [1480, 1180],


### PR DESCRIPTION
## Summary
Bert's feedback to make Korea bigger:
- Bumps Korea's `adjustRatio` from 0.22 to 0.25 (~14% larger linearly, ~30% more area) so cities and labels read more comfortably.
- Shifts `mapPosition[0]` from 80 to 40 so the wider footprint stays clear of the North/South market column (right edge of the rightmost city flag ends ~30px before the market block at x=695).
- Responds to playtest feedback that Korea felt cramped at the previous scale.

## Test plan
- [x] Loaded via `self-contained.ts` (Korea, 5P, recharged) — cities, connections, and the dual N/S resource markets render without overlap.