### PR TITLE
Japan update

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -647,7 +647,7 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
     return moves;
 }
 
-function countNetworks(connections: { nodes: string[] }[], cityNames: string[]): number {
+export function countNetworks(connections: { nodes: string[] }[], cityNames: string[]): number {
     const citySet = new Set(cityNames);
     const visited = new Set<string>();
     let count = 0;

--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -18,7 +18,7 @@ export interface AvailableMoves {
         // Distinct from the regular market buy (which can also be offered alongside).
         fromStorage?: boolean;
     }[];
-    [MoveName.Build]?: { name: string; price: number }[];
+    [MoveName.Build]?: { name: string; price: number; freeJump?: boolean }[];
     [MoveName.UsePowerPlant]?: {
         powerPlant: number;
         resourcesSpent: ResourceType[];
@@ -395,7 +395,7 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                 const isJapan = G.map.name === 'Japan';
                 const japanStartingCities = isJapan ? new Set(G.map.startingCities ?? []) : new Set<string>();
 
-                let toBuild: { name: string; price: number }[];
+                let toBuild: { name: string; price: number; freeJump?: boolean }[];
                 if (player.cities.length == 0) {
                     // Japan: first house must go in one of the 6 designated starting cities.
                     const candidates = isJapan
@@ -413,18 +413,24 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
 
                     // Japan: a player may start a second disconnected network at any available
                     // starting city, paying only the slot cost (no connection fee).
+                    // We add a separate freeJump:true entry for each qualifying starting city
+                    // at connection cost 0 alongside the normal-price entry, so the player
+                    // can explicitly choose whether to spend the free jump or pay full price.
                     if (
                         isJapan &&
+                        !player.usedFreeJump &&
                         countNetworks(
                             G.map.connections,
                             player.cities.map((c) => c.name)
                         ) < 2
                     ) {
-                        toBuild.forEach((city) => {
-                            if (japanStartingCities.has(city.name)) {
-                                city.price = 0;
+                        const freeJumpEntries: { name: string; price: number; freeJump?: boolean }[] = [];
+                        japanStartingCities.forEach((cityName) => {
+                            if (!player.cities.find((c) => c.name === cityName)) {
+                                freeJumpEntries.push({ name: cityName, price: 0, freeJump: true });
                             }
                         });
+                        toBuild = [...toBuild, ...freeJumpEntries];
                     }
                 }
 

--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -441,10 +441,15 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                             city.price = 9999;
                             return;
                         }
-                        city.price += G.step == 3 ? 20 : 15;
 
-                        if (othersCount == G.step) {
+                        const trSlotCosts = cityData.slotCosts;
+                        const trMaxSlots = cityData.stepSlots ? cityData.stepSlots[G.step - 1] : G.step;
+                        const trTotalSlots = trSlotCosts ? trSlotCosts.length : 3;
+
+                        if (othersCount >= trMaxSlots || othersCount >= trTotalSlots) {
                             city.price = 9999;
+                        } else {
+                            city.price += trSlotCosts ? trSlotCosts[othersCount] : G.step == 3 ? 20 : 15;
                         }
 
                         if (player.cities.find((c) => c.name == city.name)) {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1432,20 +1432,18 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
         case MoveName.Build: {
             asserts<Moves.MoveBuild>(move);
 
-            // Japan: detect free jump BEFORE pushing — the free jump override only applies
-            // when the player currently has < 2 networks. If they already had >= 2 networks,
-            // this is a normal (paid) build and should not consume the free jump.
+            // Japan: detect free jump.
+            // Round 1: any second starting-city build uses the jump.
+            // Round 2+: the player explicitly opted in via freeJump:true on the move.
             let isJapanFreeJump = false;
-            if (G.map.name === 'Japan' && G.map.startingCities && !player.usedFreeJump && player.cities.length >= 1) {
-                const startingCities = new Set(G.map.startingCities);
-                if (startingCities.has(move.data.name)) {
-                    const networksBefore = countNetworks(
-                        G.map.connections,
-                        player.cities.map((c) => c.name)
-                    );
-                    if (networksBefore < 2) {
+            if (G.map.name === 'Japan' && !player.usedFreeJump && player.cities.length >= 1) {
+                if (G.round === 1 && G.map.startingCities) {
+                    const startingCities = new Set(G.map.startingCities);
+                    if (startingCities.has(move.data.name)) {
                         isJapanFreeJump = true;
                     }
+                } else if (move.data.freeJump) {
+                    isJapanFreeJump = true;
                 }
             }
 
@@ -1474,15 +1472,8 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }</span>.`,
             });
 
-            // Confirm: new city is truly disconnected (forms a second network)
             if (isJapanFreeJump) {
-                const networksAfter = countNetworks(
-                    G.map.connections,
-                    player.cities.map((c) => c.name)
-                );
-                if (networksAfter >= 2) {
-                    player.usedFreeJump = true;
-                }
+                player.usedFreeJump = true;
             }
 
             if (G.map.name == 'India') {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1432,6 +1432,23 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
         case MoveName.Build: {
             asserts<Moves.MoveBuild>(move);
 
+            // Japan: detect free jump BEFORE pushing — the free jump override only applies
+            // when the player currently has < 2 networks. If they already had >= 2 networks,
+            // this is a normal (paid) build and should not consume the free jump.
+            let isJapanFreeJump = false;
+            if (G.map.name === 'Japan' && G.map.startingCities && !player.usedFreeJump && player.cities.length >= 1) {
+                const startingCities = new Set(G.map.startingCities);
+                if (startingCities.has(move.data.name)) {
+                    const networksBefore = countNetworks(
+                        G.map.connections,
+                        player.cities.map((c) => c.name)
+                    );
+                    if (networksBefore < 2) {
+                        isJapanFreeJump = true;
+                    }
+                }
+            }
+
             const position = G.players.filter((p) => p.cities.find((c) => c.name == move.data.name)).length;
             player.cities.push({ name: move.data.name, position });
             player.money -= move.data.price;
@@ -1457,17 +1474,14 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }</span>.`,
             });
 
-            // Japan: detect when a player uses their free jump (starts a second network)
-            if (G.map.name === 'Japan' && G.map.startingCities && !player.usedFreeJump && player.cities.length >= 2) {
-                const startingCities = new Set(G.map.startingCities);
-                if (startingCities.has(move.data.name)) {
-                    const networksNow = countNetworks(
-                        G.map.connections,
-                        player.cities.map((c) => c.name)
-                    );
-                    if (networksNow >= 2) {
-                        player.usedFreeJump = true;
-                    }
+            // Confirm: new city is truly disconnected (forms a second network)
+            if (isJapanFreeJump) {
+                const networksAfter = countNetworks(
+                    G.map.connections,
+                    player.cities.map((c) => c.name)
+                );
+                if (networksAfter >= 2) {
+                    player.usedFreeJump = true;
                 }
             }
 

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { cloneDeep, isEqual, range } from 'lodash';
 import seedrandom from 'seedrandom';
-import { availableMoves } from './available-moves';
+import { availableMoves, countNetworks } from './available-moves';
 import { GameOptions, GameState, Phase, Player, PowerPlant, PowerPlantType, ResourceType } from './gamestate';
 import { LogMove } from './log';
 import { GameMap, maps, mapsRecharged } from './maps';
@@ -155,6 +155,7 @@ export function setup(
         totalSpentConnections: 0,
         totalSpentPlants: 0,
         totalSpentResources: 0,
+        usedFreeJump: false,
     }));
 
     const p = players.length - 2;
@@ -1456,6 +1457,20 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }</span>.`,
             });
 
+            // Japan: detect when a player uses their free jump (starts a second network)
+            if (G.map.name === 'Japan' && G.map.startingCities && !player.usedFreeJump && player.cities.length >= 2) {
+                const startingCities = new Set(G.map.startingCities);
+                if (startingCities.has(move.data.name)) {
+                    const networksNow = countNetworks(
+                        G.map.connections,
+                        player.cities.map((c) => c.name)
+                    );
+                    if (networksNow >= 2) {
+                        player.usedFreeJump = true;
+                    }
+                }
+            }
+
             if (G.map.name == 'India') {
                 G.citiesBuiltInCurrentRound!++;
             }
@@ -1667,6 +1682,17 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                     if (G.map.name == 'India') {
                         G.citiesBuiltInCurrentRound!--;
+                    }
+
+                    // Japan: reset free jump flag if undo collapses back to a single network
+                    if (G.map.name === 'Japan' && player.usedFreeJump) {
+                        const networksAfterUndo = countNetworks(
+                            G.map.connections,
+                            player.cities.map((c) => c.name)
+                        );
+                        if (networksAfterUndo < 2) {
+                            player.usedFreeJump = false;
+                        }
                     }
 
                     break;

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -102,6 +102,7 @@ export interface Player {
     totalSpentPlants: number;
     totalSpentResources: number;
     ranking?: number;
+    usedFreeJump?: boolean;
 }
 
 export enum Phase {

--- a/engine/src/move.ts
+++ b/engine/src/move.ts
@@ -43,6 +43,7 @@ export declare namespace Moves {
         data: {
             name: string;
             price: number;
+            freeJump?: boolean;
         };
     }
 

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -66,7 +66,7 @@
                     <g
                         :key="'fj_' + i"
                         :transform="`translate(${480 + i * 30}, 80) scale(0.045)`"
-                        :opacity="fjPlayer.usedFreeJump ? 0.2 : 1"
+                        :opacity="playerHasUsedFreeJump(i) ? 0.2 : 1"
                     >
                         <path
                             d="M187.698 263.636V456.017L3 341.204V169.522L80.8579 108.141L187.698 263.636Z"
@@ -956,6 +956,38 @@ export default class Game extends Vue {
         const availableMoves = currentPlayer.availableMoves!;
 
         return availableMoves[MoveName.Build] && availableMoves[MoveName.Build]!.map((c) => c.name) || [];
+    }
+
+    playerHasUsedFreeJump(playerIndex: number): boolean {
+        if (!this.G) return false;
+        const player = this.G.players[playerIndex];
+        if (!player || player.cities.length < 2) return false;
+        if (player.usedFreeJump) return true;
+        // Retroactively compute: check if player has 2+ disconnected networks
+        const cityNames = player.cities.map((c) => c.name);
+        const citySet = new Set(cityNames);
+        const visited = new Set<string>();
+        let networkCount = 0;
+        for (const city of cityNames) {
+            if (visited.has(city)) continue;
+            networkCount++;
+            if (networkCount >= 2) return true;
+            const stack = [city];
+            while (stack.length > 0) {
+                const current = stack.pop()!;
+                if (visited.has(current)) continue;
+                visited.add(current);
+                for (const conn of this.G.map.connections) {
+                    if (conn.nodes.includes(current)) {
+                        const neighbor = conn.nodes.find((n) => n !== current)!;
+                        if (citySet.has(neighbor) && !visited.has(neighbor)) {
+                            stack.push(neighbor);
+                        }
+                    }
+                }
+            }
+        }
+        return networkCount >= 2;
     }
 
     canBuild(city: City) {

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -959,35 +959,7 @@ export default class Game extends Vue {
     }
 
     playerHasUsedFreeJump(playerIndex: number): boolean {
-        if (!this.G) return false;
-        const player = this.G.players[playerIndex];
-        if (!player || player.cities.length < 2) return false;
-        if (player.usedFreeJump) return true;
-        // Retroactively compute: check if player has 2+ disconnected networks
-        const cityNames = player.cities.map((c) => c.name);
-        const citySet = new Set(cityNames);
-        const visited = new Set<string>();
-        let networkCount = 0;
-        for (const city of cityNames) {
-            if (visited.has(city)) continue;
-            networkCount++;
-            if (networkCount >= 2) return true;
-            const stack = [city];
-            while (stack.length > 0) {
-                const current = stack.pop()!;
-                if (visited.has(current)) continue;
-                visited.add(current);
-                for (const conn of this.G.map.connections) {
-                    if (conn.nodes.includes(current)) {
-                        const neighbor = conn.nodes.find((n) => n !== current)!;
-                        if (citySet.has(neighbor) && !visited.has(neighbor)) {
-                            stack.push(neighbor);
-                        }
-                    }
-                }
-            }
-        }
-        return networkCount >= 2;
+        return !!this.G?.players[playerIndex]?.usedFreeJump;
     }
 
     canBuild(city: City) {

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -59,6 +59,40 @@
                 @build="build($event)"
             />
 
+            <!-- Japan: Free Jump indicator -->
+            <g v-if="G.map.name === 'Japan'">
+                <text x="330" y="93" font-size="20" font-weight="bold" fill="black">Free Jump:</text>
+                <template v-for="(fjPlayer, i) in G.players">
+                    <g
+                        :key="'fj_' + i"
+                        :transform="`translate(${480 + i * 30}, 80) scale(0.045)`"
+                        :opacity="fjPlayer.usedFreeJump ? 0.2 : 1"
+                    >
+                        <path
+                            d="M187.698 263.636V456.017L3 341.204V169.522L80.8579 108.141L187.698 263.636Z"
+                            :fill="playerColors[i]"
+                            stroke="#010101"
+                            stroke-width="12"
+                            stroke-miterlimit="10"
+                        />
+                        <path
+                            d="M395.724 136.361V300.164L187.698 456.017V263.636L395.724 136.361Z"
+                            :fill="playerColors[i]"
+                            stroke="#010101"
+                            stroke-width="12"
+                            stroke-miterlimit="10"
+                        />
+                        <path
+                            d="M395.724 136.361L187.698 263.636L80.8579 108.141L304.771 4L395.724 136.361Z"
+                            :fill="playerColors[i]"
+                            stroke="#010101"
+                            stroke-width="12"
+                            stroke-miterlimit="10"
+                        />
+                    </g>
+                </template>
+            </g>
+
             <Resources
                 ref="resources"
                 :transform="`translate(${G.map.supplyPosition[0]}, ${G.map.supplyPosition[1]})`"

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -202,6 +202,45 @@
             </div>
         </div>
 
+        <div v-if="G && freeJumpCity" :class="['modal', { visible: freeJumpVisible }]">
+            <div class="modal-content">
+                <span
+                    class="close"
+                    @click="
+                        freeJumpVisible = false;
+                        freeJumpCity = null;
+                    "
+                    >&times;</span
+                >
+                <div class="modal-title">Free Jump — {{ freeJumpCity.name }}</div>
+                <div class="confirm-message" v-if="freeJumpNormalPrice !== null">
+                    Use your <b>Free Jump</b> to build here for ${{ freeJumpSlotPrice }} (slot cost only), or pay the
+                    full connection price of ${{ freeJumpNormalPrice }} and save the jump for later.
+                </div>
+                <div class="confirm-message" v-else>
+                    Use your <b>Free Jump</b> to build here for ${{ freeJumpSlotPrice }} (slot cost only)? This city is
+                    not reachable from your network otherwise.
+                </div>
+                <div class="confirm-buttons">
+                    <button class="confirm-button" @click="confirmFreeJump(true)">
+                        Use Free Jump (${{ freeJumpSlotPrice }})
+                    </button>
+                    <button v-if="freeJumpNormalPrice !== null" class="confirm-button" @click="confirmFreeJump(false)">
+                        Pay Full Price (${{ freeJumpNormalPrice }})
+                    </button>
+                    <button
+                        class="confirm-button"
+                        @click="
+                            freeJumpVisible = false;
+                            freeJumpCity = null;
+                        "
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+
         <div v-if="G && discardedPowerPlant" :class="['modal', { visible: discardVisible }]">
             <div class="modal-content">
                 <div class="modal-title">Discard Resources</div>
@@ -522,6 +561,11 @@ export default class Game extends Vue {
     discardVisible: boolean = false;
     resourcesToDiscard: { name: string, max: number, value: string }[] = [];
 
+    freeJumpCity: City | null = null;
+    freeJumpNormalPrice: number | null = null;
+    freeJumpSlotPrice: number = 0;
+    freeJumpVisible: boolean = false;
+
     disablePass: boolean = false;
 
     @Ref() powerPlantMarket!: PowerPlantMarket;
@@ -685,8 +729,41 @@ export default class Game extends Vue {
     build(city: City) {
         const currentPlayer = this.G!.players[this.player!];
         const availableMoves = currentPlayer.availableMoves!;
-        const move = availableMoves[MoveName.Build]!.find((c) => c.name == city.name)!;
-        this.sendMove({ name: MoveName.Build, data: { name: city.name, price: move.price } });
+        const buildMoves = availableMoves[MoveName.Build]!;
+        const freeJumpMove = buildMoves.find((c) => c.name === city.name && c.freeJump);
+        const normalMove = buildMoves.find((c) => c.name === city.name && !c.freeJump);
+
+        if (freeJumpMove && normalMove) {
+            // Player can choose: use the free jump or pay full price
+            this.freeJumpCity = city;
+            this.freeJumpSlotPrice = freeJumpMove.price;
+            this.freeJumpNormalPrice = normalMove.price;
+            this.freeJumpVisible = true;
+        } else if (freeJumpMove && !normalMove) {
+            // Only reachable via free jump — confirm before using it
+            this.freeJumpCity = city;
+            this.freeJumpSlotPrice = freeJumpMove.price;
+            this.freeJumpNormalPrice = null;
+            this.freeJumpVisible = true;
+        } else {
+            // Normal build, no free jump involved
+            this.sendMove({ name: MoveName.Build, data: { name: city.name, price: normalMove!.price } });
+        }
+    }
+
+    confirmFreeJump(useJump: boolean) {
+        const city = this.freeJumpCity!;
+        const currentPlayer = this.G!.players[this.player!];
+        const buildMoves = currentPlayer.availableMoves![MoveName.Build]!;
+        this.freeJumpVisible = false;
+        this.freeJumpCity = null;
+        if (useJump) {
+            const freeJumpMove = buildMoves.find((c) => c.name === city.name && c.freeJump)!;
+            this.sendMove({ name: MoveName.Build, data: { name: city.name, price: freeJumpMove.price, freeJump: true } });
+        } else {
+            const normalMove = buildMoves.find((c) => c.name === city.name && !c.freeJump)!;
+            this.sendMove({ name: MoveName.Build, data: { name: city.name, price: normalMove.price } });
+        }
     }
 
     confirmDiscard() {

--- a/viewer/src/components/boards/Map.vue
+++ b/viewer/src/components/boards/Map.vue
@@ -152,6 +152,23 @@
                     stroke-linecap="round"
                 />
             </template>
+            <!-- [10,10,20] city: "10" label at bottom-left (two 10-Elektro slots) -->
+            <text
+                v-if="
+                    city.slotCosts &&
+                    city.slotCosts.length === 3 &&
+                    city.slotCosts[0] === 10 &&
+                    city.slotCosts[1] === 10
+                "
+                :key="city.name + '_10label'"
+                :x="city.x - 20"
+                :y="city.y + 19"
+                font-size="17"
+                font-weight="bold"
+                fill="black"
+                text-anchor="middle"
+                >10</text
+            >
             <!-- [15,20] city: X at top-middle -->
             <template v-if="city.slotCosts && city.slotCosts.length === 2 && city.slotCosts[0] === 15">
                 <line


### PR DESCRIPTION
## Summary
- Adds a per-player Free Jump indicator in the header for the Japan map, 
  showing which players have used their one-time free jump (faded house = used)
- In round 1, building a second starting city automatically marks the free 
  jump as used
- In round 2+, clicking a qualifying starting city now shows a choice dialog: 
  use the free jump (pay slot cost only) or pay the full connection price and 
  save the jump for later
- Fixes transregional city slot limits to respect slotCosts and stepSlots
- Fixes house positioning for [15,20]-slot cities on the map

## Changes
- `gamestate.ts` — adds `usedFreeJump?: boolean` to Player
- `move.ts` — adds `freeJump?: boolean` to MoveBuild data
- `available-moves.ts` — offers explicit free-jump entries alongside normal 
  entries so the player can consciously choose
- `engine.ts` — detects free jump via explicit flag; resets on undo
- `Game.vue` — free jump indicator SVG + choice modal
- `Map.vue` — house offsets for [15,20] cities