### PR TITLE
Improve free jump detection: add log scan as third fallback

### DIFF
--- a/engine/src/maps/japan.ts
+++ b/engine/src/maps/japan.ts
@@ -133,10 +133,10 @@ export const map: GameMap = {
     startingCities: ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'],
     mapSpecificRules:
         'Each player can have two separate networks.\n' +
-        "All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a '10' on the map.\n" +
+        'All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a 10 on the map.\n' +
         'Starting cities have two first-connection spots (cost 10 Elektro each); two players can build there in Step 1.\n' +
         'In Step 3, a third connection spot opens in starting cities (cost 20 Elektro).\n' +
-        "Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an 'X' - 'X' at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), 'X' at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n" +
+        'Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an X - an X at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), an X at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n' +
         'If all spots in every starting city are taken, a player is forced to play with a single network.',
     connections: [
         { nodes: [Cities.Nagasaki, Cities.Fukuoka], cost: 10 },

--- a/engine/src/maps/japan.ts
+++ b/engine/src/maps/japan.ts
@@ -133,10 +133,10 @@ export const map: GameMap = {
     startingCities: ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'],
     mapSpecificRules:
         'Each player can have two separate networks.\n' +
-        "All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a '10' on the map.\n" +
+        'All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a \'10\' on the map.\n' +
         'Starting cities have two first-connection spots (cost 10 Elektro each); two players can build there in Step 1.\n' +
         'In Step 3, a third connection spot opens in starting cities (cost 20 Elektro).\n' +
-        "Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an 'X' - 'X' at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), 'X' at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n" +
+        'Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an \'X\' - \'X\' at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), \'X\' at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n' +
         'If all spots in every starting city are taken, a player is forced to play with a single network.',
     connections: [
         { nodes: [Cities.Nagasaki, Cities.Fukuoka], cost: 10 },

--- a/engine/src/maps/japan.ts
+++ b/engine/src/maps/japan.ts
@@ -133,10 +133,10 @@ export const map: GameMap = {
     startingCities: ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'],
     mapSpecificRules:
         'Each player can have two separate networks.\n' +
-        'First houses must be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama.\n' +
+        "All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a '10' on the map.\n" +
         'Starting cities have two first-connection spots (cost 10 Elektro each); two players can build there in Step 1.\n' +
         'In Step 3, a third connection spot opens in starting cities (cost 20 Elektro).\n' +
-        'Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2).\n' +
+        "Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an 'X' - 'X' at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), 'X' at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n" +
         'If all spots in every starting city are taken, a player is forced to play with a single network.',
     connections: [
         { nodes: [Cities.Nagasaki, Cities.Fukuoka], cost: 10 },

--- a/engine/src/maps/japan.ts
+++ b/engine/src/maps/japan.ts
@@ -133,10 +133,10 @@ export const map: GameMap = {
     startingCities: ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'],
     mapSpecificRules:
         'Each player can have two separate networks.\n' +
-        'All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a \'10\' on the map.\n' +
+        "All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a '10' on the map.\n" +
         'Starting cities have two first-connection spots (cost 10 Elektro each); two players can build there in Step 1.\n' +
         'In Step 3, a third connection spot opens in starting cities (cost 20 Elektro).\n' +
-        'Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an \'X\' - \'X\' at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), \'X\' at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n' +
+        "Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an 'X' - 'X' at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), 'X' at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n" +
         'If all spots in every starting city are taken, a player is forced to play with a single network.',
     connections: [
         { nodes: [Cities.Nagasaki, Cities.Fukuoka], cost: 10 },

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -1040,24 +1040,9 @@ export default class Game extends Vue {
     playerHasUsedFreeJump(playerIndex: number): boolean {
         const player = this.G?.players[playerIndex];
         if (!player) return false;
-        // 1. Engine flag — most reliable, set for all games running latest code.
         if (player.usedFreeJump) return true;
-        // 2. Network topology — works when the two networks are still disconnected.
         if (player.cities.length >= 2) {
             if (countNetworks(this.G!.map.connections, player.cities.map(c => c.name)) >= 2) return true;
-        }
-        // 3. Log scan — works for explicit round 2+ free jumps on older server builds
-        //    where usedFreeJump wasn't tracked: the freeJump:true flag is still stored
-        //    in the move data even if the engine ignored it.
-        if (this.G?.log) {
-            for (const entry of this.G.log) {
-                if (entry.type === 'move' && (entry as any).player === playerIndex) {
-                    const move = (entry as any).move;
-                    if (move?.name === MoveName.Build && move?.data?.freeJump === true) {
-                        return true;
-                    }
-                }
-            }
         }
         return false;
     }

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -1040,12 +1040,24 @@ export default class Game extends Vue {
     playerHasUsedFreeJump(playerIndex: number): boolean {
         const player = this.G?.players[playerIndex];
         if (!player) return false;
-        // Primary: trust the engine flag (set for all new games).
+        // 1. Engine flag — most reliable, set for all games running latest code.
         if (player.usedFreeJump) return true;
-        // Fallback: detect from network topology for game states where
-        // usedFreeJump wasn't tracked (games started before that field existed).
+        // 2. Network topology — works when the two networks are still disconnected.
         if (player.cities.length >= 2) {
-            return countNetworks(this.G!.map.connections, player.cities.map(c => c.name)) >= 2;
+            if (countNetworks(this.G!.map.connections, player.cities.map(c => c.name)) >= 2) return true;
+        }
+        // 3. Log scan — works for explicit round 2+ free jumps on older server builds
+        //    where usedFreeJump wasn't tracked: the freeJump:true flag is still stored
+        //    in the move data even if the engine ignored it.
+        if (this.G?.log) {
+            for (const entry of this.G.log) {
+                if (entry.type === 'move' && (entry as any).player === playerIndex) {
+                    const move = (entry as any).move;
+                    if (move?.name === MoveName.Build && move?.data?.freeJump === true) {
+                        return true;
+                    }
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
The topology check misses cases where the free-jumped city is reachable via the normal network (e.g. Sapporo is connected to the mainland via Hakodate-Admori). Scan the game log for any Build move with freeJump:true by the player — that flag is stored in the log even on older server builds that don't track usedFreeJump in engine state.