### PR TITLE
Add Bremen map / UK & Ireland step2 jump fix / North America city nudges

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -486,6 +486,9 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                     // is no sea edge so dijkstra reports the target city as unreachable
                     // (price=9999); we override here. The first build ever (player.cities
                     // empty) goes through the normal first-build path and pays no surcharge.
+                    // The jump can only START a city — an empty one (first house). Cities
+                    // already holding a house are not reachable via the jump, even in
+                    // Steps 2/3 when their later slots are open to same-island networks.
                     if (cityData.island && G.map.crossIslandSurcharge !== undefined && player.cities.length > 0) {
                         const playerIslands = new Set(
                             player.cities
@@ -493,15 +496,7 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                                 .filter((i): i is string => !!i)
                         );
                         if (!playerIslands.has(cityData.island)) {
-                            city.price = 10 + othersCount * 5 + G.map.crossIslandSurcharge;
-
-                            if (othersCount == G.step) {
-                                city.price = 9999;
-                            }
-
-                            if (player.cities.find((c) => c.name == city.name)) {
-                                city.price = 9999;
-                            }
+                            city.price = othersCount > 0 ? 9999 : 10 + G.map.crossIslandSurcharge;
                             return;
                         }
                     }

--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -732,7 +732,12 @@ function dijkstra(G: GameState, player: Player): { name: string; price: number }
         currentConnections.forEach((connection) => {
             const otherName = connection.nodes.filter((n) => n != currentNode.name)[0];
             const otherNode = nodes.find((n) => n.name == otherName)!;
-            const price = player.cities.find((c) => c.name == otherNode.name) ? 0 : currentNode.price + connection.cost;
+            // Bremen charges the cost of the district you enter (node-weighted),
+            // not the edge; `connectionCost` falls back to the per-edge cost for
+            // every other map. 0 is a valid free entry, so only undefined falls back.
+            const otherCity = G.map.cities.find((c) => c.name == otherName);
+            const stepCost = otherCity?.connectionCost ?? connection.cost;
+            const price = player.cities.find((c) => c.name == otherNode.name) ? 0 : currentNode.price + stepCost;
             if (!otherNode.visited && otherNode.price > price) {
                 otherNode.price = price;
             }

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -419,6 +419,28 @@ describe('Engine', () => {
         }
     });
 
+    it('should only offer the UK & Ireland cross-island jump into empty cities', () => {
+        const G = setup(5, { map: 'UK & Ireland', variant: 'recharged', randomizeMap: false }, 'uki-jump');
+        G.phase = Phase.Building;
+        G.step = 2; // second houses are open to same-island networks, but NOT to the jump
+        const player = G.players[0];
+        player.money = 200;
+
+        const gbCity = G.map.cities.find((c) => c.island === 'gb')!;
+        const ieCities = G.map.cities.filter((c) => c.island === 'ie');
+        player.cities = [{ name: gbCity.name, position: 0 }];
+        // Another player already holds a house in one Irish city.
+        G.players[1].cities = [{ name: ieCities[0].name, position: 0 }];
+
+        const builds = availableMoves(G, player)[MoveName.Build] as { name: string; price: number }[];
+        const priceOf = (name: string) => builds.find((b) => b.name === name)?.price;
+
+        const occupied = priceOf(ieCities[0].name);
+        expect(occupied === undefined || occupied === 9999, 'occupied Irish city not jumpable in Step 2').to.be.true;
+        // An empty Irish city is jumpable as a first house: 10 + 20 surcharge.
+        expect(priceOf(ieCities[1].name), 'empty Irish city jumpable at 30').to.equal(30);
+    });
+
     it('should remove uranium plant 17 from the Australia deck and keep the five mines', () => {
         // Australia replaces the six uranium plants with mines: plant 17 is removed
         // from the deck entirely, while 11/23/28/34/39 stay in (and behave as

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -623,4 +623,98 @@ describe('Engine', () => {
 
         expect(ended(G)).to.be.false;
     });
+
+    it('should set Bremen Step 2 and end-game thresholds (and set up) for every player count', () => {
+        const step2 = [5, 5, 5, 5, 4];
+        const endGame = [13, 13, 13, 12, 11];
+        for (let pc = 2; pc <= 6; pc++) {
+            const G = setup(
+                pc,
+                { map: 'Bremen', variant: 'recharged', randomizeMap: false },
+                `bremen-thresholds-${pc}`
+            );
+            expect(G.citiesToStep2, `Bremen ${pc}P Step 2`).to.equal(step2[pc - 2]);
+            expect(G.citiesToEndGame, `Bremen ${pc}P end game`).to.equal(endGame[pc - 2]);
+            expect(
+                G.players.some((p) => p.availableMoves && Object.keys(p.availableMoves).length > 0),
+                `Bremen ${pc}P ready`
+            ).to.be.true;
+        }
+    });
+
+    it('should remove the Bremen banned plants (incl. all nuclear) and use no uranium', () => {
+        const baseBanned = [11, 17, 23, 28, 34, 36, 38, 39, 46];
+        // 2–4P additionally box 31 and 50; check a low and a high player count.
+        for (const pc of [2, 5]) {
+            const G = setup(pc, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, `bremen-deck-${pc}`);
+            const allNumbers = new Set<number>([
+                ...G.actualMarket.map((p) => p.number),
+                ...G.futureMarket.map((p) => p.number),
+                ...G.powerPlantsDeck.map((p) => p.number),
+            ]);
+            for (const n of baseBanned) {
+                expect(allNumbers.has(n), `Bremen ${pc}P: plant ${n} removed`).to.be.false;
+            }
+            if (pc <= 4) {
+                expect(allNumbers.has(31), `Bremen ${pc}P: plant 31 removed`).to.be.false;
+                expect(allNumbers.has(50), `Bremen ${pc}P: plant 50 removed`).to.be.false;
+            }
+            // The opening market is drawn from the ≤15 weak pool.
+            expect(
+                [...G.actualMarket, ...G.futureMarket].every((p) => p.number <= 15),
+                `Bremen ${pc}P: market is weak-pool`
+            ).to.be.true;
+        }
+        // No uranium token is ever in play on Bremen.
+        const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-uranium');
+        expect(G.map.startingSupply![3], 'Bremen uranium supply').to.equal(0);
+    });
+
+    it('should price Bremen builds by summed district costs (node-weighted, asymmetric)', () => {
+        // 5P so all five regions (all 25 districts) are in play.
+        const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-build-cost');
+        G.phase = Phase.Building;
+        G.step = 1;
+        const player = G.players[0];
+        player.money = 100;
+
+        // From a network in Seehausen, the rulebook example: connecting Gröpelingen
+        // costs 25 — path Seehausen → Höfen (transit, 9) → Gröpelingen (8) = 17 in
+        // district costs, plus the first house (8). Höfen itself is a neighbour: 9 + 8.
+        player.cities = [{ name: 'Seehausen', position: 0 }];
+        let builds = availableMoves(G, player)[MoveName.Build] as { name: string; price: number }[];
+        expect(builds.find((b) => b.name === 'Höfen')?.price, 'Seehausen → Höfen').to.equal(17);
+        expect(builds.find((b) => b.name === 'Gröpelingen')?.price, 'Seehausen → Gröpelingen (rulebook)').to.equal(25);
+
+        // Asymmetry: from Höfen, connecting Seehausen pays Seehausen's own cost (14) +
+        // its first house (8, a small district) = 22, not the 17 of the reverse trip.
+        player.cities = [{ name: 'Höfen', position: 0 }];
+        builds = availableMoves(G, player)[MoveName.Build] as { name: string; price: number }[];
+        expect(builds.find((b) => b.name === 'Seehausen')?.price, 'Höfen → Seehausen (asymmetric)').to.equal(22);
+    });
+
+    it('should limit Bremen small districts to two networks', () => {
+        const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-small-cap');
+        G.phase = Phase.Building;
+        G.step = 3; // 3 slots open by step, so only the small district's own 2-slot limit binds
+        const player = G.players[0];
+        player.money = 100;
+        player.cities = [{ name: 'Walle', position: 0 }];
+        // Two other players already occupy Findorff (small, 2 slots) and Mitte (full, 3).
+        G.players[1].cities = [
+            { name: 'Findorff', position: 1 },
+            { name: 'Mitte', position: 1 },
+        ];
+        G.players[2].cities = [
+            { name: 'Findorff', position: 2 },
+            { name: 'Mitte', position: 2 },
+        ];
+
+        const builds = availableMoves(G, player)[MoveName.Build] as { name: string; price: number }[];
+        const priceOf = (name: string) => builds.find((b) => b.name === name)?.price;
+        // Findorff is full at two networks — no third slot for this player.
+        expect(priceOf('Findorff') === undefined || priceOf('Findorff') === 9999, 'Findorff small, full').to.be.true;
+        // Mitte still has its third slot (20): connection 1 + 20 = 21.
+        expect(priceOf('Mitte'), 'Mitte third slot').to.equal(21);
+    });
 });

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -30,6 +30,8 @@ const citiesToStep2BadenWurttemberg = [9, 6, 6, 6, 5];
 const citiesToStep2UKIreland = [10, 7, 7, 7, 6];
 const citiesToEndGame = [21, 17, 17, 15, 14];
 const citiesToEndGameSouthAfrica = [18, 17, 17, 15, 14];
+const citiesToStep2Bremen = [5, 5, 5, 5, 4];
+const citiesToEndGameBremen = [13, 13, 13, 12, 11];
 const cityIncome = [10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150];
 const regionsInPlay = [3, 3, 4, 5, 5];
 
@@ -455,12 +457,16 @@ export function setup(
                 ? citiesToStep2BadenWurttemberg[numPlayers - 2]
                 : (forceMap || finalMap).name == 'UK & Ireland'
                 ? citiesToStep2UKIreland[numPlayers - 2]
+                : (forceMap || finalMap).name == 'Bremen'
+                ? citiesToStep2Bremen[numPlayers - 2]
                 : citiesToStep2[numPlayers - 2],
         citiesToEndGame:
             (forceMap || finalMap).name == 'South Africa'
                 ? citiesToEndGameSouthAfrica[numPlayers - 2]
                 : (forceMap || finalMap).name == 'UK & Ireland' && numPlayers == 2
                 ? Math.min(citiesToEndGame[numPlayers - 2], (forceMap || finalMap).cities.length)
+                : (forceMap || finalMap).name == 'Bremen'
+                ? citiesToEndGameBremen[numPlayers - 2]
                 : citiesToEndGame[numPlayers - 2],
         resourceResupply: [
             `[${coalResupply[p][0]}, ${oilResupply[p][0]}, ${garbageResupply[p][0]}, ${uraniumResupply[p][0]}]`,

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -25,7 +25,8 @@ export type MapName =
     | 'South Africa'
     | 'UK & Ireland'
     | 'Japan'
-    | 'Australia';
+    | 'Australia'
+    | 'Bremen';
 export type Variant = 'original' | 'recharged';
 
 export interface GameOptions {

--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -5,6 +5,7 @@ import { map as australia } from './maps/australia';
 import { map as badenwurttemberg } from './maps/badenwurttemberg';
 import { map as benelux } from './maps/benelux';
 import { map as brazil } from './maps/brazil';
+import { map as bremen } from './maps/bremen';
 import { map as centraleurope } from './maps/centraleurope';
 import { map as china } from './maps/china';
 import { map as europe } from './maps/europe';
@@ -48,6 +49,13 @@ export interface City {
     // (no sea edges; starting a network on a new island costs a flat surcharge on
     // top of the first-house base cost).
     island?: string;
+    // Bremen: flat per-district connection cost. When set, the build-cost
+    // pathfinder (dijkstra) charges this district's own cost on entry instead of
+    // a per-edge `connection.cost` — so `connections` just encode adjacency and
+    // the price lives on the node. Paying the destination's cost on every hop
+    // makes links naturally asymmetric (A→B costs B, B→A costs A) and charges
+    // transit through unbuilt districts, matching the printed Bremen rules.
+    connectionCost?: number;
 }
 
 export interface Connection {
@@ -152,6 +160,7 @@ export const maps: GameMap[] = [
     southafrica,
     ukireland,
     australia,
+    bremen,
     japan,
 ];
 
@@ -177,6 +186,7 @@ export const mapsRecharged: GameMap[] = [
     southafrica,
     ukireland,
     australia,
+    bremen,
     // china,
     japanRecharged,
 ];

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -1,0 +1,264 @@
+// by John and Cici
+import { cloneDeep } from 'lodash';
+import seedrandom from 'seedrandom';
+import { getPowerPlant } from '../engine';
+import { PowerPlant } from '../gamestate';
+import { shuffle } from '../utils';
+import { GameMap } from './../maps';
+import { powerPlants } from './../powerPlants';
+
+export enum Regions {
+    Blue = 'blue',
+    Pink = 'pink',
+    Purple = 'purple',
+    Red = 'red',
+    Orange = 'orange',
+}
+
+export enum Cities {
+    Borgfeld = 'Borgfeld',
+    Oberneuland = 'Oberneuland',
+    Osterholz = 'Osterholz',
+    HornLehe = 'Horn-Lehe',
+    Vahr = 'Vahr',
+    Schwachhausen = 'Schwachhausen',
+    OstlicheVorstadt = 'Östliche Vorstadt',
+    Findorff = 'Findorff',
+    Walle = 'Walle',
+    Mitte = 'Mitte',
+    Hemelingen = 'Hemelingen',
+    Mahndorf = 'Mahndorf',
+    Neustadt = 'Neustadt',
+    Obervieland = 'Obervieland',
+    Huchting = 'Huchting',
+    Hofen = 'Höfen',
+    Pusdorf = 'Pusdorf',
+    Neustadtshafen = 'Neustadtshafen',
+    Strom = 'Strom',
+    Seehausen = 'Seehausen',
+    Blockland = 'Blockland',
+    Gropelingen = 'Gröpelingen',
+    Burglesum = 'Burglesum',
+    Vegesack = 'Vegesack',
+    Blumenthal = 'Blumenthal',
+}
+
+// Bremen prices each district as a flat node cost (`connectionCost`); building a
+// house costs 8 / 14 / 20 Elektro (the small districts have only two spaces,
+// 8 / 14, so only two players can ever connect them).
+export const map: GameMap = {
+    name: 'Bremen',
+    cities: [
+        // Blue
+        { name: Cities.Borgfeld, region: Regions.Blue, connectionCost: 15, slotCosts: [8, 14], x: 288, y: 120 },
+        { name: Cities.Oberneuland, region: Regions.Blue, connectionCost: 14, slotCosts: [8, 14, 20], x: 372, y: 128 },
+        { name: Cities.Osterholz, region: Regions.Blue, connectionCost: 11, slotCosts: [8, 14, 20], x: 456, y: 124 },
+        { name: Cities.HornLehe, region: Regions.Blue, connectionCost: 9, slotCosts: [8, 14, 20], x: 336, y: 192 },
+        { name: Cities.Vahr, region: Regions.Blue, connectionCost: 6, slotCosts: [8, 14, 20], x: 424, y: 216 },
+        // Pink
+        { name: Cities.Schwachhausen, region: Regions.Pink, connectionCost: 5, slotCosts: [8, 14, 20], x: 328, y: 240 },
+        {
+            name: Cities.OstlicheVorstadt,
+            region: Regions.Pink,
+            connectionCost: 2,
+            slotCosts: [8, 14, 20],
+            x: 404,
+            y: 240,
+        },
+        { name: Cities.Findorff, region: Regions.Pink, connectionCost: 3, slotCosts: [8, 14], x: 316, y: 282 },
+        { name: Cities.Walle, region: Regions.Pink, connectionCost: 6, slotCosts: [8, 14, 20], x: 330, y: 316 },
+        { name: Cities.Mitte, region: Regions.Pink, connectionCost: 1, slotCosts: [8, 14, 20], x: 368, y: 288 },
+        // Purple
+        { name: Cities.Hemelingen, region: Regions.Purple, connectionCost: 8, slotCosts: [8, 14, 20], x: 460, y: 216 },
+        { name: Cities.Mahndorf, region: Regions.Purple, connectionCost: 10, slotCosts: [8, 14, 20], x: 520, y: 172 },
+        { name: Cities.Neustadt, region: Regions.Purple, connectionCost: 5, slotCosts: [8, 14, 20], x: 488, y: 288 },
+        {
+            name: Cities.Obervieland,
+            region: Regions.Purple,
+            connectionCost: 10,
+            slotCosts: [8, 14, 20],
+            x: 464,
+            y: 380,
+        },
+        { name: Cities.Huchting, region: Regions.Purple, connectionCost: 12, slotCosts: [8, 14], x: 500, y: 424 },
+        // Red
+        { name: Cities.Hofen, region: Regions.Red, connectionCost: 9, slotCosts: [8, 14, 20], x: 292, y: 396 },
+        { name: Cities.Pusdorf, region: Regions.Red, connectionCost: 7, slotCosts: [8, 14, 20], x: 356, y: 348 },
+        { name: Cities.Neustadtshafen, region: Regions.Red, connectionCost: 8, slotCosts: [8, 14, 20], x: 388, y: 380 },
+        { name: Cities.Strom, region: Regions.Red, connectionCost: 14, slotCosts: [8, 14, 20], x: 432, y: 404 },
+        { name: Cities.Seehausen, region: Regions.Red, connectionCost: 14, slotCosts: [8, 14], x: 328, y: 452 },
+        // Orange
+        { name: Cities.Blockland, region: Regions.Orange, connectionCost: 11, slotCosts: [8, 14, 20], x: 248, y: 224 },
+        { name: Cities.Gropelingen, region: Regions.Orange, connectionCost: 8, slotCosts: [8, 14, 20], x: 268, y: 352 },
+        { name: Cities.Burglesum, region: Regions.Orange, connectionCost: 13, slotCosts: [8, 14, 20], x: 224, y: 408 },
+        { name: Cities.Vegesack, region: Regions.Orange, connectionCost: 10, slotCosts: [8, 14, 20], x: 188, y: 464 },
+        { name: Cities.Blumenthal, region: Regions.Orange, connectionCost: 15, slotCosts: [8, 14], x: 136, y: 624 },
+    ],
+    // Bremen has flat per-district costs (the `connectionCost` on each city), not
+    // per-edge costs — so every connection's `cost` is 0 and only encodes which
+    // districts border each other. Crossing the Weser/Lesum rivers costs nothing
+    // extra (you still pay the destination district's cost), so river borders are
+    // ordinary adjacencies here (e.g. Höfen ↔ Gröpelingen). First-pass adjacency
+    // read off the board photo — refine against the printed board.
+    connections: [
+        // Blue (internal)
+        { nodes: [Cities.Borgfeld, Cities.Oberneuland], cost: 0 },
+        { nodes: [Cities.Oberneuland, Cities.Osterholz], cost: 0 },
+        { nodes: [Cities.Borgfeld, Cities.HornLehe], cost: 0 },
+        { nodes: [Cities.Oberneuland, Cities.HornLehe], cost: 0 },
+        { nodes: [Cities.Oberneuland, Cities.Vahr], cost: 0 },
+        { nodes: [Cities.Osterholz, Cities.Vahr], cost: 0 },
+        { nodes: [Cities.HornLehe, Cities.Vahr], cost: 0 },
+        // Blue → neighbours
+        { nodes: [Cities.HornLehe, Cities.Schwachhausen], cost: 0 },
+        { nodes: [Cities.Vahr, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.Vahr, Cities.Hemelingen], cost: 0 },
+        { nodes: [Cities.Osterholz, Cities.Mahndorf], cost: 0 },
+        { nodes: [Cities.HornLehe, Cities.Blockland], cost: 0 },
+        // Pink (internal)
+        { nodes: [Cities.Schwachhausen, Cities.Findorff], cost: 0 },
+        { nodes: [Cities.Schwachhausen, Cities.Mitte], cost: 0 },
+        { nodes: [Cities.Schwachhausen, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.Findorff, Cities.Mitte], cost: 0 },
+        { nodes: [Cities.Findorff, Cities.Walle], cost: 0 },
+        { nodes: [Cities.Mitte, Cities.Walle], cost: 0 },
+        { nodes: [Cities.Mitte, Cities.OstlicheVorstadt], cost: 0 },
+        // Pink → neighbours
+        { nodes: [Cities.OstlicheVorstadt, Cities.Hemelingen], cost: 0 },
+        { nodes: [Cities.Walle, Cities.Gropelingen], cost: 0 },
+        { nodes: [Cities.Walle, Cities.Pusdorf], cost: 0 },
+        { nodes: [Cities.Mitte, Cities.Pusdorf], cost: 0 },
+        { nodes: [Cities.Findorff, Cities.Blockland], cost: 0 },
+        // Purple (internal)
+        { nodes: [Cities.Hemelingen, Cities.Mahndorf], cost: 0 },
+        { nodes: [Cities.Hemelingen, Cities.Neustadt], cost: 0 },
+        { nodes: [Cities.Mahndorf, Cities.Neustadt], cost: 0 },
+        { nodes: [Cities.Neustadt, Cities.Obervieland], cost: 0 },
+        { nodes: [Cities.Neustadt, Cities.Huchting], cost: 0 },
+        { nodes: [Cities.Obervieland, Cities.Huchting], cost: 0 },
+        // Purple → neighbours
+        { nodes: [Cities.Neustadt, Cities.Strom], cost: 0 },
+        { nodes: [Cities.Obervieland, Cities.Strom], cost: 0 },
+        { nodes: [Cities.Huchting, Cities.Seehausen], cost: 0 },
+        // Red (internal)
+        { nodes: [Cities.Hofen, Cities.Pusdorf], cost: 0 },
+        { nodes: [Cities.Hofen, Cities.Neustadtshafen], cost: 0 },
+        { nodes: [Cities.Hofen, Cities.Seehausen], cost: 0 },
+        { nodes: [Cities.Pusdorf, Cities.Neustadtshafen], cost: 0 },
+        { nodes: [Cities.Neustadtshafen, Cities.Seehausen], cost: 0 },
+        { nodes: [Cities.Neustadtshafen, Cities.Strom], cost: 0 },
+        { nodes: [Cities.Seehausen, Cities.Strom], cost: 0 },
+        // Red → neighbours (Höfen ↔ Gröpelingen crosses the Weser, free)
+        { nodes: [Cities.Hofen, Cities.Gropelingen], cost: 0 },
+        // Orange (internal)
+        { nodes: [Cities.Blockland, Cities.Gropelingen], cost: 0 },
+        { nodes: [Cities.Blockland, Cities.Burglesum], cost: 0 },
+        { nodes: [Cities.Gropelingen, Cities.Burglesum], cost: 0 },
+        { nodes: [Cities.Burglesum, Cities.Vegesack], cost: 0 },
+        { nodes: [Cities.Vegesack, Cities.Blumenthal], cost: 0 },
+    ],
+    layout: 'Portrait',
+    // First-pass coords in board-photo space scaled ×0.4; tune adjustRatio /
+    // mapPosition against the live render in the viewer session.
+    adjustRatio: [1, 1],
+    mapPosition: [0, 0],
+    mapRotation: 0,
+    // Resupply read from the printed Bremen refill cards. Indexed
+    // [resource][playerCount-2][step-1]. 2P and 3P rows are identical. No uranium.
+    resupply: [
+        // Coal
+        [
+            [4, 5, 3], // 2P
+            [4, 5, 3], // 3P
+            [5, 6, 4], // 4P
+            [5, 7, 5], // 5P
+            [7, 9, 6], // 6P
+        ],
+        // Oil
+        [
+            [2, 3, 4], // 2P
+            [2, 3, 4], // 3P
+            [3, 4, 5], // 4P
+            [4, 5, 6], // 5P
+            [5, 6, 7], // 6P
+        ],
+        // Garbage
+        [
+            [1, 2, 1], // 2P
+            [1, 2, 1], // 3P
+            [2, 3, 2], // 4P
+            [3, 3, 3], // 5P
+            [3, 5, 3], // 6P
+        ],
+        // Uranium — Bremen has none
+        [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ],
+    ],
+    // Coal fills 1–8, oil 3–8, garbage 3–8, no uranium. 2 each of coal/oil/garbage
+    // and all uranium are placed back in the box, so total supply is 22/22/22/0:
+    // coal starts 2 short of a full market (the top price slot), oil/garbage hold
+    // 4 in reserve each.
+    startingResources: [22, 18, 18, 0],
+    startingSupply: [22, 22, 22, 0],
+    // Bremen plays with fewer power plants. Remove 11, 17, 23, 28, 34, 36, 38, 39,
+    // 46 (this includes every nuclear plant); 2–4 players also remove 31 and 50.
+    // The opening market is then drawn from the remaining "weak" pool (≤15) per the
+    // recharged convention, and NO further player-count deck reduction is applied.
+    setupDeck(numPlayers: number, variant: string, rng: seedrandom.prng) {
+        const removed = new Set([11, 17, 23, 28, 34, 36, 38, 39, 46]);
+        if (numPlayers <= 4) {
+            removed.add(31);
+            removed.add(50);
+        }
+        let deck = cloneDeep(powerPlants).filter((pp) => !removed.has(pp.number));
+        // The Step 3 card is the last entry of the master list and is never removed.
+        const step3 = deck.pop()!;
+
+        let actualMarket: PowerPlant[];
+        let futureMarket: PowerPlant[];
+
+        if (variant == 'original') {
+            // Fixed opening market 3–6 / 7–10 (none of these are removed on Bremen).
+            actualMarket = [getPowerPlant(3), getPowerPlant(4), getPowerPlant(5), getPowerPlant(6)];
+            futureMarket = [getPowerPlant(7), getPowerPlant(8), getPowerPlant(9), getPowerPlant(10)];
+            const inMarket = new Set([3, 4, 5, 6, 7, 8, 9, 10]);
+            const plant13 = deck.find((pp) => pp.number == 13)!;
+            let rest = deck.filter((pp) => !inMarket.has(pp.number) && pp.number != 13);
+            rest = shuffle(rest, rng() + '');
+            rest.unshift(plant13);
+            rest.push(step3);
+            return { actualMarket, futureMarket, powerPlantsDeck: rest };
+        }
+
+        // Recharged: the opening 8 plants come from the ≤15 weak pool.
+        const weak = shuffle(
+            deck.filter((pp) => pp.number <= 15),
+            rng() + ''
+        );
+        let rest = deck.filter((pp) => pp.number > 15);
+        const initialMarket = weak.splice(0, 8).sort((a, b) => a.number - b.number);
+        actualMarket = initialMarket.slice(0, 4);
+        futureMarket = initialMarket.slice(4);
+        const first = weak.shift()!; // one weak plant guaranteed near the top of the deck
+        rest = shuffle(rest.concat(weak), rng() + ''); // leftover weak plants fold back in
+        rest.unshift(first);
+        rest.push(step3);
+        return { actualMarket, futureMarket, powerPlantsDeck: rest };
+    },
+    mapSpecificRules:
+        'Flat district costs: instead of connection costs between cities, each ' +
+        'district has a single cost. Connecting a new district to your network ' +
+        'costs the sum of the district costs along the cheapest path from your ' +
+        'network (you pay for each district entered, including ones you only pass ' +
+        'through), plus the cheapest building cost (8 / 14 / 20 Elektro) in the new ' +
+        'district. Small districts have only two spaces (8 / 14) and can hold just ' +
+        'two networks. The Weser and Lesum rivers can be crossed without extra ' +
+        'cost. No nuclear: nuclear power plants and uranium are not used. Step 2 ' +
+        'begins once a player has 5 connected districts (4 for 6 players); the game ' +
+        'ends when a player connects 13 districts (12 for 5 players, 11 for 6).',
+};

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -50,56 +50,58 @@ export const map: GameMap = {
     name: 'Bremen',
     cities: [
         // Blue
-        { name: Cities.Borgfeld, region: Regions.Blue, connectionCost: 15, slotCosts: [8, 14], x: 288, y: 120 },
-        { name: Cities.Oberneuland, region: Regions.Blue, connectionCost: 14, slotCosts: [8, 14, 20], x: 372, y: 128 },
-        { name: Cities.Osterholz, region: Regions.Blue, connectionCost: 11, slotCosts: [8, 14, 20], x: 456, y: 124 },
-        { name: Cities.HornLehe, region: Regions.Blue, connectionCost: 9, slotCosts: [8, 14, 20], x: 336, y: 192 },
-        { name: Cities.Vahr, region: Regions.Blue, connectionCost: 6, slotCosts: [8, 14, 20], x: 424, y: 216 },
+        { name: Cities.Borgfeld, region: Regions.Blue, connectionCost: 15, slotCosts: [8, 14], x: 645, y: 273 },
+        { name: Cities.Oberneuland, region: Regions.Blue, connectionCost: 14, slotCosts: [8, 14, 20], x: 652, y: 342 },
+        { name: Cities.Osterholz, region: Regions.Blue, connectionCost: 11, slotCosts: [8, 14, 20], x: 660, y: 434 },
+        { name: Cities.HornLehe, region: Regions.Blue, connectionCost: 9, slotCosts: [8, 14, 20], x: 572, y: 322 },
+        { name: Cities.Vahr, region: Regions.Blue, connectionCost: 6, slotCosts: [8, 14, 20], x: 583, y: 376 },
         // Pink
-        { name: Cities.Schwachhausen, region: Regions.Pink, connectionCost: 5, slotCosts: [8, 14, 20], x: 328, y: 240 },
+        { name: Cities.Schwachhausen, region: Regions.Pink, connectionCost: 5, slotCosts: [8, 14, 20], x: 517, y: 357 },
         {
             name: Cities.OstlicheVorstadt,
             region: Regions.Pink,
             connectionCost: 2,
             slotCosts: [8, 14, 20],
-            x: 404,
-            y: 240,
+            x: 536,
+            y: 409,
         },
-        { name: Cities.Findorff, region: Regions.Pink, connectionCost: 3, slotCosts: [8, 14], x: 316, y: 282 },
-        { name: Cities.Walle, region: Regions.Pink, connectionCost: 6, slotCosts: [8, 14, 20], x: 330, y: 316 },
-        { name: Cities.Mitte, region: Regions.Pink, connectionCost: 1, slotCosts: [8, 14, 20], x: 368, y: 288 },
+        { name: Cities.Findorff, region: Regions.Pink, connectionCost: 3, slotCosts: [8, 14], x: 488, y: 311 },
+        { name: Cities.Walle, region: Regions.Pink, connectionCost: 6, slotCosts: [8, 14, 20], x: 438, y: 342 },
+        { name: Cities.Mitte, region: Regions.Pink, connectionCost: 1, slotCosts: [8, 14, 20], x: 472, y: 388 },
         // Purple
-        { name: Cities.Hemelingen, region: Regions.Purple, connectionCost: 8, slotCosts: [8, 14, 20], x: 460, y: 216 },
-        { name: Cities.Mahndorf, region: Regions.Purple, connectionCost: 10, slotCosts: [8, 14, 20], x: 520, y: 172 },
-        { name: Cities.Neustadt, region: Regions.Purple, connectionCost: 5, slotCosts: [8, 14, 20], x: 488, y: 288 },
+        { name: Cities.Hemelingen, region: Regions.Purple, connectionCost: 8, slotCosts: [8, 14, 20], x: 600, y: 453 },
+        { name: Cities.Mahndorf, region: Regions.Purple, connectionCost: 10, slotCosts: [8, 14, 20], x: 666, y: 499 },
+        { name: Cities.Neustadt, region: Regions.Purple, connectionCost: 5, slotCosts: [8, 14, 20], x: 464, y: 452 },
         {
             name: Cities.Obervieland,
             region: Regions.Purple,
             connectionCost: 10,
             slotCosts: [8, 14, 20],
-            x: 464,
-            y: 380,
+            x: 529,
+            y: 479,
         },
-        { name: Cities.Huchting, region: Regions.Purple, connectionCost: 12, slotCosts: [8, 14], x: 500, y: 424 },
+        { name: Cities.Huchting, region: Regions.Purple, connectionCost: 12, slotCosts: [8, 14], x: 386, y: 442 },
         // Red
-        { name: Cities.Hofen, region: Regions.Red, connectionCost: 9, slotCosts: [8, 14, 20], x: 292, y: 396 },
-        { name: Cities.Pusdorf, region: Regions.Red, connectionCost: 7, slotCosts: [8, 14, 20], x: 356, y: 348 },
-        { name: Cities.Neustadtshafen, region: Regions.Red, connectionCost: 8, slotCosts: [8, 14, 20], x: 388, y: 380 },
-        { name: Cities.Strom, region: Regions.Red, connectionCost: 14, slotCosts: [8, 14, 20], x: 432, y: 404 },
-        { name: Cities.Seehausen, region: Regions.Red, connectionCost: 14, slotCosts: [8, 14], x: 328, y: 452 },
+        { name: Cities.Hofen, region: Regions.Red, connectionCost: 9, slotCosts: [8, 14, 20], x: 352, y: 272 },
+        { name: Cities.Pusdorf, region: Regions.Red, connectionCost: 7, slotCosts: [8, 14, 20], x: 399, y: 386 },
+        { name: Cities.Neustadtshafen, region: Regions.Red, connectionCost: 8, slotCosts: [8, 14, 20], x: 375, y: 340 },
+        { name: Cities.Strom, region: Regions.Red, connectionCost: 14, slotCosts: [8, 14, 20], x: 328, y: 393 },
+        { name: Cities.Seehausen, region: Regions.Red, connectionCost: 14, slotCosts: [8, 14], x: 290, y: 321 },
         // Orange
-        { name: Cities.Blockland, region: Regions.Orange, connectionCost: 11, slotCosts: [8, 14, 20], x: 248, y: 224 },
-        { name: Cities.Gropelingen, region: Regions.Orange, connectionCost: 8, slotCosts: [8, 14, 20], x: 268, y: 352 },
-        { name: Cities.Burglesum, region: Regions.Orange, connectionCost: 13, slotCosts: [8, 14, 20], x: 224, y: 408 },
-        { name: Cities.Vegesack, region: Regions.Orange, connectionCost: 10, slotCosts: [8, 14, 20], x: 188, y: 464 },
-        { name: Cities.Blumenthal, region: Regions.Orange, connectionCost: 15, slotCosts: [8, 14], x: 136, y: 624 },
+        { name: Cities.Blockland, region: Regions.Orange, connectionCost: 11, slotCosts: [8, 14, 20], x: 476, y: 251 },
+        { name: Cities.Gropelingen, region: Regions.Orange, connectionCost: 8, slotCosts: [8, 14, 20], x: 426, y: 280 },
+        { name: Cities.Burglesum, region: Regions.Orange, connectionCost: 13, slotCosts: [8, 14, 20], x: 337, y: 197 },
+        { name: Cities.Vegesack, region: Regions.Orange, connectionCost: 10, slotCosts: [8, 14, 20], x: 248, y: 170 },
+        { name: Cities.Blumenthal, region: Regions.Orange, connectionCost: 15, slotCosts: [8, 14], x: 154, y: 135 },
     ],
     // Bremen has flat per-district costs (the `connectionCost` on each city), not
     // per-edge costs — so every connection's `cost` is 0 and only encodes which
     // districts border each other. Crossing the Weser/Lesum rivers costs nothing
     // extra (you still pay the destination district's cost), so river borders are
-    // ordinary adjacencies here (e.g. Höfen ↔ Gröpelingen). First-pass adjacency
-    // read off the board photo — refine against the printed board.
+    // ordinary adjacencies here.
+    // WIP (S2 borders pass): reset to trusted internal skeletons for Blue/Red/Orange
+    // only. Pink + Purple internals and ALL inter-region links (incl. the Höfen↔
+    // Gröpelingen Weser crossing) were cleared, to be rebuilt against the board.
     connections: [
         // Blue (internal)
         { nodes: [Cities.Borgfeld, Cities.Oberneuland], cost: 0 },
@@ -109,59 +111,67 @@ export const map: GameMap = {
         { nodes: [Cities.Oberneuland, Cities.Vahr], cost: 0 },
         { nodes: [Cities.Osterholz, Cities.Vahr], cost: 0 },
         { nodes: [Cities.HornLehe, Cities.Vahr], cost: 0 },
-        // Blue → neighbours
+        // Blue → neighbours (S2 rebuild)
         { nodes: [Cities.HornLehe, Cities.Schwachhausen], cost: 0 },
-        { nodes: [Cities.Vahr, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.HornLehe, Cities.Findorff], cost: 0 },
         { nodes: [Cities.Vahr, Cities.Hemelingen], cost: 0 },
         { nodes: [Cities.Osterholz, Cities.Mahndorf], cost: 0 },
-        { nodes: [Cities.HornLehe, Cities.Blockland], cost: 0 },
-        // Pink (internal)
-        { nodes: [Cities.Schwachhausen, Cities.Findorff], cost: 0 },
-        { nodes: [Cities.Schwachhausen, Cities.Mitte], cost: 0 },
-        { nodes: [Cities.Schwachhausen, Cities.OstlicheVorstadt], cost: 0 },
-        { nodes: [Cities.Findorff, Cities.Mitte], cost: 0 },
-        { nodes: [Cities.Findorff, Cities.Walle], cost: 0 },
-        { nodes: [Cities.Mitte, Cities.Walle], cost: 0 },
-        { nodes: [Cities.Mitte, Cities.OstlicheVorstadt], cost: 0 },
-        // Pink → neighbours
-        { nodes: [Cities.OstlicheVorstadt, Cities.Hemelingen], cost: 0 },
-        { nodes: [Cities.Walle, Cities.Gropelingen], cost: 0 },
-        { nodes: [Cities.Walle, Cities.Pusdorf], cost: 0 },
-        { nodes: [Cities.Mitte, Cities.Pusdorf], cost: 0 },
-        { nodes: [Cities.Findorff, Cities.Blockland], cost: 0 },
-        // Purple (internal)
-        { nodes: [Cities.Hemelingen, Cities.Mahndorf], cost: 0 },
-        { nodes: [Cities.Hemelingen, Cities.Neustadt], cost: 0 },
-        { nodes: [Cities.Mahndorf, Cities.Neustadt], cost: 0 },
-        { nodes: [Cities.Neustadt, Cities.Obervieland], cost: 0 },
-        { nodes: [Cities.Neustadt, Cities.Huchting], cost: 0 },
-        { nodes: [Cities.Obervieland, Cities.Huchting], cost: 0 },
-        // Purple → neighbours
-        { nodes: [Cities.Neustadt, Cities.Strom], cost: 0 },
-        { nodes: [Cities.Obervieland, Cities.Strom], cost: 0 },
-        { nodes: [Cities.Huchting, Cities.Seehausen], cost: 0 },
         // Red (internal)
-        { nodes: [Cities.Hofen, Cities.Pusdorf], cost: 0 },
         { nodes: [Cities.Hofen, Cities.Neustadtshafen], cost: 0 },
         { nodes: [Cities.Hofen, Cities.Seehausen], cost: 0 },
         { nodes: [Cities.Pusdorf, Cities.Neustadtshafen], cost: 0 },
         { nodes: [Cities.Neustadtshafen, Cities.Seehausen], cost: 0 },
         { nodes: [Cities.Neustadtshafen, Cities.Strom], cost: 0 },
         { nodes: [Cities.Seehausen, Cities.Strom], cost: 0 },
-        // Red → neighbours (Höfen ↔ Gröpelingen crosses the Weser, free)
-        { nodes: [Cities.Hofen, Cities.Gropelingen], cost: 0 },
         // Orange (internal)
         { nodes: [Cities.Blockland, Cities.Gropelingen], cost: 0 },
         { nodes: [Cities.Blockland, Cities.Burglesum], cost: 0 },
         { nodes: [Cities.Gropelingen, Cities.Burglesum], cost: 0 },
         { nodes: [Cities.Burglesum, Cities.Vegesack], cost: 0 },
         { nodes: [Cities.Vegesack, Cities.Blumenthal], cost: 0 },
+        // Purple (internal, S2 rebuild)
+        { nodes: [Cities.Mahndorf, Cities.Hemelingen], cost: 0 },
+        { nodes: [Cities.Hemelingen, Cities.Obervieland], cost: 0 },
+        { nodes: [Cities.Obervieland, Cities.Neustadt], cost: 0 },
+        { nodes: [Cities.Neustadt, Cities.Huchting], cost: 0 },
+        // Purple → neighbours (S2 rebuild)
+        { nodes: [Cities.Hemelingen, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.Obervieland, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.Neustadt, Cities.Mitte], cost: 0 },
+        { nodes: [Cities.Neustadt, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.Huchting, Cities.Strom], cost: 0 },
+        { nodes: [Cities.Huchting, Cities.Pusdorf], cost: 0 },
+        // Pink (internal, S2 rebuild)
+        { nodes: [Cities.Findorff, Cities.Walle], cost: 0 },
+        { nodes: [Cities.Findorff, Cities.Mitte], cost: 0 },
+        { nodes: [Cities.Findorff, Cities.Schwachhausen], cost: 0 },
+        { nodes: [Cities.Schwachhausen, Cities.OstlicheVorstadt], cost: 0 },
+        { nodes: [Cities.Schwachhausen, Cities.Mitte], cost: 0 },
+        { nodes: [Cities.Walle, Cities.Mitte], cost: 0 },
+        { nodes: [Cities.Mitte, Cities.OstlicheVorstadt], cost: 0 },
+        // Red (internal, S2 rebuild)
+        { nodes: [Cities.Strom, Cities.Pusdorf], cost: 0 },
+        // Cross-region (S2 rebuild)
+        { nodes: [Cities.Vahr, Cities.Schwachhausen], cost: 0 }, // blue–pink
+        { nodes: [Cities.Blockland, Cities.HornLehe], cost: 0 }, // orange–blue
+        { nodes: [Cities.Hemelingen, Cities.Osterholz], cost: 0 }, // purple–blue
+        { nodes: [Cities.Hofen, Cities.Gropelingen], cost: 0 }, // red–orange (Weser crossing)
+        { nodes: [Cities.Hofen, Cities.Burglesum], cost: 0 }, // red–orange
+        { nodes: [Cities.Burglesum, Cities.Seehausen], cost: 0 }, // orange–red
+        { nodes: [Cities.Walle, Cities.Gropelingen], cost: 0 }, // pink–orange
+        { nodes: [Cities.Walle, Cities.Blockland], cost: 0 }, // pink–orange
+        { nodes: [Cities.Findorff, Cities.Blockland], cost: 0 }, // pink–orange
+        { nodes: [Cities.Walle, Cities.Hofen], cost: 0 }, // pink–red
+        { nodes: [Cities.Walle, Cities.Neustadtshafen], cost: 0 }, // pink–red
+        { nodes: [Cities.Walle, Cities.Pusdorf], cost: 0 }, // pink–red
+        { nodes: [Cities.Pusdorf, Cities.Neustadt], cost: 0 }, // red–purple
     ],
-    layout: 'Portrait',
-    // First-pass coords in board-photo space scaled ×0.4; tune adjustRatio /
-    // mapPosition against the live render in the viewer session.
-    adjustRatio: [1, 1],
-    mapPosition: [0, 0],
+    layout: 'Landscape',
+    // Coords authored in landscape (~768×576 space) by clicking the board photo in
+    // the viewer; scaled up here to fill the 1500×800 canvas with the panels to the
+    // right/top. (The board photo is EXIF-rotated 90° CW, so landscape is native.)
+    adjustRatio: [1.75, 1.75],
+    mapPosition: [-120, -140],
     mapRotation: 0,
     // Resupply read from the printed Bremen refill cards. Indexed
     // [resource][playerCount-2][step-1]. 2P and 3P rows are identical. No uranium.

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -225,7 +225,7 @@ export const map: GameMap = {
             removed.add(31);
             removed.add(50);
         }
-        let deck = cloneDeep(powerPlants).filter((pp) => !removed.has(pp.number));
+        const deck = cloneDeep(powerPlants).filter((pp) => !removed.has(pp.number));
         // The Step 3 card is the last entry of the master list and is never removed.
         const step3 = deck.pop()!;
 

--- a/engine/src/maps/northamerica.ts
+++ b/engine/src/maps/northamerica.ts
@@ -93,7 +93,7 @@ export const map: GameMap = {
 
         // Brown — California / Pacific SW / Mountain West
         { name: Cities.Portland, region: Regions.Brown, x: 122, y: 516 },
-        { name: Cities.SanFrancisco, region: Regions.Brown, x: 135, y: 660 },
+        { name: Cities.SanFrancisco, region: Regions.Brown, x: 123, y: 697 },
         { name: Cities.LosAngeles, region: Regions.Brown, x: 160, y: 911 },
         { name: Cities.SanDiego, region: Regions.Brown, x: 223, y: 1007 },
         { name: Cities.SaltLakeCity, region: Regions.Brown, x: 380, y: 555 },
@@ -106,21 +106,21 @@ export const map: GameMap = {
         { name: Cities.Chihuahua, region: Regions.Orange, x: 577, y: 1183 },
         { name: Cities.Monterrey, region: Regions.Orange, x: 791, y: 1292 },
         { name: Cities.Guadalajara, region: Regions.Orange, x: 715, y: 1391 },
-        { name: Cities.MexicoCityN, region: Regions.Orange, x: 918, y: 1410 },
-        { name: Cities.MexicoCityS, region: Regions.Orange, x: 918, y: 1474 },
+        { name: Cities.MexicoCityN, region: Regions.Orange, x: 913, y: 1335 },
+        { name: Cities.MexicoCityS, region: Regions.Orange, x: 913, y: 1425 },
 
         // Green — Texas / Deep South / Florida
         { name: Cities.SanAntonio, region: Regions.Green, x: 767, y: 1172 },
         { name: Cities.DallasFortWorth, region: Regions.Green, x: 850, y: 1020 },
-        { name: Cities.Houston, region: Regions.Green, x: 931, y: 1095 },
+        { name: Cities.Houston, region: Regions.Green, x: 940, y: 1145 },
         { name: Cities.NewOrleans, region: Regions.Green, x: 1126, y: 1095 },
         { name: Cities.Atlanta, region: Regions.Green, x: 1318, y: 1021 },
         { name: Cities.Jacksonville, region: Regions.Green, x: 1398, y: 1109 },
         { name: Cities.Miami, region: Regions.Green, x: 1398, y: 1235 },
 
         // Blue — Midwest / Plains / Mid-South
-        { name: Cities.Milwaukee, region: Regions.Blue, x: 1165, y: 502 },
-        { name: Cities.Chicago, region: Regions.Blue, x: 1148, y: 601 },
+        { name: Cities.Milwaukee, region: Regions.Blue, x: 1206, y: 414 },
+        { name: Cities.Chicago, region: Regions.Blue, x: 1121, y: 531 },
         { name: Cities.KansasCity, region: Regions.Blue, x: 825, y: 720 },
         { name: Cities.StLouis, region: Regions.Blue, x: 1047, y: 768 },
         { name: Cities.Indianapolis, region: Regions.Blue, x: 1206, y: 694 },
@@ -140,8 +140,8 @@ export const map: GameMap = {
         { name: Cities.Quebec, region: Regions.Red, x: 1911, y: 354 },
         { name: Cities.Ottawa, region: Regions.Red, x: 1653, y: 458 },
         { name: Cities.Montreal, region: Regions.Red, x: 1875, y: 461 },
-        { name: Cities.NewYorkN, region: Regions.Red, x: 1730, y: 598 },
-        { name: Cities.NewYorkS, region: Regions.Red, x: 1730, y: 648 },
+        { name: Cities.NewYorkN, region: Regions.Red, x: 1727, y: 561 },
+        { name: Cities.NewYorkS, region: Regions.Red, x: 1727, y: 637 },
         { name: Cities.Boston, region: Regions.Red, x: 1928, y: 579 },
         { name: Cities.Philadelphia, region: Regions.Red, x: 1724, y: 755 },
     ],
@@ -290,7 +290,7 @@ export const map: GameMap = {
     mapPosition: [70, 50],
     // Slight counterclockwise tilt to keep the pink region out of the power-plant
     // header row at the top of the layout.
-    mapRotation: -5,
+    mapRotation: -2,
 
     // Resupply table verified with John from the NA refill summary cards.
     // Indexed [resource][playerCount-2][step-1].

--- a/viewer/src/components/boards/Map.vue
+++ b/viewer/src/components/boards/Map.vue
@@ -22,10 +22,26 @@
         </template> -->
 
         <template v-for="city in cities">
-            <circle :key="city.name + '_region'" r="25" :cx="city.x" :cy="city.y" :fill="city.region" stroke="black">
+            <circle
+                v-if="city.connectionCost == null"
+                :key="city.name + '_region'"
+                r="25"
+                :cx="city.x"
+                :cy="city.y"
+                :fill="city.region"
+                stroke="black"
+            >
                 <title>{{ city.name }}</title>
             </circle>
-            <circle :key="city.name + '_circle'" r="20" :cx="city.x" :cy="city.y" fill="gray" stroke="black">
+            <circle
+                v-if="city.connectionCost == null"
+                :key="city.name + '_circle'"
+                r="20"
+                :cx="city.x"
+                :cy="city.y"
+                fill="gray"
+                stroke="black"
+            >
                 <title>{{ city.name }}</title>
             </circle>
             <!-- South Africa cross-border spaces: render a small red pennant
@@ -72,8 +88,65 @@
             />
         </template>
 
+        <!-- Bremen-style node-weighted districts: clean labeled tiles (entry-cost
+             number + 8/14/20 house slots), drawn AFTER the links so the gray lines
+             sit behind. Gated on connectionCost; other maps keep circular nodes. -->
+        <template v-for="city in cities">
+            <g v-if="city.connectionCost != null" :key="city.name + '_tile'">
+                <rect
+                    :class="[{ canClick: canBuild(city) }]"
+                    :x="city.x - 23"
+                    :y="city.y - 23"
+                    width="46"
+                    height="46"
+                    rx="7"
+                    fill="gray"
+                    :stroke="city.region"
+                    stroke-width="4"
+                    :transform="`rotate(45, ${city.x}, ${city.y})`"
+                    @click="canBuild(city) && build(city)"
+                >
+                    <title>{{ city.name }} — connect for {{ city.connectionCost }} (entry) + house</title>
+                </rect>
+                <!-- house slots laid out like the board: 8 top, 14 left, 20 right -->
+                <template v-for="(sc, i) in city.slotCosts">
+                    <rect
+                        :key="city.name + '_slot' + i"
+                        :x="city.x + nodeSlotPos(i).dx - 6.5"
+                        :y="city.y + nodeSlotPos(i).dy - 6.5"
+                        width="13"
+                        height="13"
+                        rx="1"
+                        fill="gray"
+                        stroke="black"
+                        stroke-width="1"
+                        :transform="`rotate(45, ${city.x + nodeSlotPos(i).dx}, ${city.y + nodeSlotPos(i).dy})`"
+                    />
+                    <text
+                        :key="city.name + '_slotlbl' + i"
+                        :x="city.x + nodeSlotPos(i).dx"
+                        :y="city.y + nodeSlotPos(i).dy"
+                        font-size="10"
+                        text-anchor="middle"
+                        dominant-baseline="central"
+                        fill="black"
+                        :transform="
+                            mapRotation
+                                ? `rotate(${-mapRotation}, ${city.x + nodeSlotPos(i).dx}, ${
+                                      city.y + nodeSlotPos(i).dy
+                                  })`
+                                : undefined
+                        "
+                    >
+                        {{ sc }}
+                    </text>
+                </template>
+            </g>
+        </template>
+
         <template v-for="city in cities">
             <circle
+                v-if="city.connectionCost == null"
                 :key="city.name + '_circle2'"
                 :class="[{ canClick: canBuild(city) }]"
                 r="20"
@@ -133,6 +206,33 @@
                 :ownerName="house.ownerName"
                 :color="house.color"
             />
+        </template>
+
+        <!-- Bremen entry-cost number, on top so it stays readable over houses -->
+        <template v-for="city in cities">
+            <g v-if="city.connectionCost != null" :key="city.name + '_cc'">
+                <circle
+                    :cx="city.x"
+                    :cy="city.y + 15"
+                    r="11"
+                    fill="goldenrod"
+                    stroke="darkgoldenrod"
+                    stroke-width="2"
+                />
+                <circle :cx="city.x" :cy="city.y + 15" r="7.5" fill="gray" stroke="darkgoldenrod" stroke-width="1" />
+                <text
+                    :x="city.x"
+                    :y="city.y + 15"
+                    font-size="11"
+                    font-weight="bold"
+                    text-anchor="middle"
+                    dominant-baseline="central"
+                    fill="black"
+                    :transform="mapRotation ? `rotate(${-mapRotation}, ${city.x}, ${city.y + 15})` : undefined"
+                >
+                    {{ city.connectionCost }}
+                </text>
+            </g>
         </template>
 
         <template v-for="city in cities">
@@ -251,8 +351,16 @@ export default class Map extends Vue {
             player.cities.forEach((cityPiece) => {
                 const city = gameState.map.cities.find((city) => city.name == cityPiece.name)!;
                 let offsetX, offsetY;
+                const isNodeWeighted = city.connectionCost != null;
                 const is1520 = city.slotCosts?.length === 2 && city.slotCosts[0] === 15;
-                if (is1520) {
+                if (isNodeWeighted) {
+                    // Bremen tiles: 8 top, 14 left, 20 right — matches the board layout.
+                    // The House piece is anchored top-left (~14×16 after its scale), so
+                    // offset by half its size to center it on the slot.
+                    const slot = this.nodeSlotPos(cityPiece.position);
+                    offsetX = slot.dx - 7;
+                    offsetY = slot.dy - 8;
+                } else if (is1520) {
                     // [15,20] city: slot 0 (cost 15) → bottom-left, slot 1 (cost 20) → bottom-right
                     if (cityPiece.position == 0) {
                         offsetX = -15;
@@ -301,6 +409,13 @@ export default class Map extends Vue {
     getY2(connection) {
         const city = this.cities!.find((city) => city.name == connection.nodes[1])!;
         return city.y;
+    }
+
+    nodeSlotPos(i: number) {
+        // House slots laid out like the printed board: 0 = 8 (top), 1 = 14 (left), 2 = 20 (right).
+        if (i === 0) return { dx: 0, dy: -15 };
+        if (i === 1) return { dx: -15, dy: 0 };
+        return { dx: 15, dy: 0 };
     }
 
     canBuild(city: City) {

--- a/viewer/src/self-contained.ts
+++ b/viewer/src/self-contained.ts
@@ -10,7 +10,7 @@ function launchSelfContained(selector = '#app') {
 
     const emitter = launch(selector);
 
-    let gameState = setup(6, { map: 'Australia', variant: 'recharged', showMoney: true, randomizeMap: false }, '7');
+    let gameState = setup(6, { map: 'Bremen', variant: 'recharged', showMoney: true, randomizeMap: false }, '0');
 
     // Dev coord-picker example (commented; uncomment + drop a board photo into
     // viewer/public/ to author city coordinates for a new map). See the picker


### PR DESCRIPTION
## Bremen (new map)

The Bremen half of the Rio Grande 2024 Bremen/Manhattan expansion (recharged + original), by John and Cici.

**Signature mechanic — node-weighted district costs:** Bremen has no per-edge connection costs. Each of the 25 districts has ONE circled cost, paid every time a network enters it along the cheapest path (including transit through unbuilt districts), plus the house cost. Implemented as a generic optional `connectionCost` on `City` — the dijkstra step weight becomes `otherCity.connectionCost ?? connection.cost`, a provable no-op for every existing map. Asymmetric costs emerge naturally (rulebook example encoded as a spec: Seehausen→Gröpelingen = 25, reverse trip = 22).

Other Bremen specifics:
- House costs 8/14/20 via `slotCosts`; five small districts cap at two networks (`slotCosts: [8, 14]`)
- No nuclear: plants 11/17/23/28/34/36/38/39/46 boxed (+31/50 for 2–4P), no uranium in the market, no player-count deck reduction (custom `setupDeck`)
- Step 2 at 5 cities (4 for 6P), game end at 13/13/13/12/11
- Custom resupply table from the printed refill cards (2P = 3P)
- Viewer: districts render as labeled diamond tiles (cost ring + 8/14/20 slot boxes) — gated on `connectionCost`, reusable for future node-weighted maps

**Testing:** 36/36 engine specs (4 new Bremen specs incl. the rulebook cost example); 6 full AI playthroughs (6P + 3P × 3 seeds) all reach game end in Step 3 with thresholds firing exactly; live human playtests of 6P and 3P to the Game Ended banner.

## UK & Ireland: cross-island jump fix (live bug report)

The 20-Elektro island jump was offering occupied cities at `10 + position*5 + 20`, letting players take second/third houses across the sea in Steps 2/3. Per the rulebook the jump is only to **first houses**: empty city = flat 30, occupied city = unreachable until you own a city on that island. Regression spec added; fix live-verified in a 6P game across all three steps.

## North America: layout fixes (live bug report)

- Quebec rotated into the power-plant market header on some boards: the -5° rotation pivots on the in-play regions' bounding box, so 39 of the 91 possible region subsets clipped. Rotation reduced to -2° and coords adjusted; an exhaustive 91-subset sweep now reports zero collisions with any panel or the viewBox.
- De-crowded the Midwest/East band (Chicago, Milwaukee, Houston, San Francisco) and opened breathing room inside the New York and Mexico City metropolis pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
