### PR TITLE
Bremen: $7/$8 market spaces hold two cubes each

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -690,6 +690,16 @@ describe('Engine', () => {
         // No uranium token is ever in play on Bremen.
         const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-uranium');
         expect(G.map.startingSupply![3], 'Bremen uranium supply').to.equal(0);
+        // The printed track holds only two cubes per resource at $7 and $8,
+        // so a full market is 22 cubes and coal starts exactly full.
+        for (const track of [G.coalPrices!, G.oilPrices!, G.garbagePrices!]) {
+            expect(track, 'Bremen $7/$8 hold two cubes').to.deep.equal([
+                1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8,
+            ]);
+        }
+        expect(G.coalMarket, 'Bremen coal market starts full').to.equal(22);
+        expect(G.oilMarket, 'Bremen oil fills $3–$8').to.equal(16);
+        expect(G.garbageMarket, 'Bremen garbage fills $3–$8').to.equal(16);
     });
 
     it('should price Bremen builds by summed district costs (node-weighted, asymmetric)', () => {

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -209,11 +209,15 @@ export const map: GameMap = {
             [0, 0, 0],
         ],
     ],
-    // Coal fills 1–8, oil 3–8, garbage 3–8, no uranium. 2 each of coal/oil/garbage
-    // and all uranium are placed back in the box, so total supply is 22/22/22/0:
-    // coal starts 2 short of a full market (the top price slot), oil/garbage hold
-    // 4 in reserve each.
-    startingResources: [22, 18, 18, 0],
+    // The printed market track holds only TWO cubes per resource at $7 and $8
+    // (three everywhere else): 22 slots per resource, matching the 22-cube
+    // supply exactly — which is why 2 of each go back in the box.
+    coalPrices: [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8],
+    oilPrices: [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8],
+    garbagePrices: [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8],
+    // Coal fills 1–8 (a full 22-cube market), oil 3–8 and garbage 3–8 (16 cubes
+    // each, 6 in reserve), no uranium.
+    startingResources: [22, 16, 16, 0],
     startingSupply: [22, 22, 22, 0],
     // Bremen plays with fewer power plants. Remove 11, 17, 23, 28, 34, 36, 38, 39,
     // 46 (this includes every nuclear plant); 2–4 players also remove 31 and 50.

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -123,8 +123,8 @@
             {{ resourceResupply[2] }}
         </text>
         <Garbage :pieceId="-1" :targetState="{ x: 382, y: 11 }" :canClick="false" :transparent="false" />
-        <!-- Australia has no main-market uranium row, so its resupply indicator omits uranium. -->
-        <template v-if="!isAustraliaMarket">
+        <!-- Australia and Bremen have no main-market uranium row, so their resupply indicators omit uranium. -->
+        <template v-if="!isAustraliaMarket && !isBremenMarket">
             <text x="414" y="20" font-weight="600" fill="black" style="font-size: 24px">
                 {{ resourceResupply[3] }}
             </text>
@@ -164,7 +164,10 @@
             >
                 {{ index }}
             </text>
-            <g :key="'lines' + index" v-if="!isIndiaResourceMarket && !isNinePriceMarket && !isAustraliaMarket">
+            <g
+                :key="'lines' + index"
+                v-if="!isIndiaResourceMarket && !isNinePriceMarket && !isAustraliaMarket && !isBremenMarket"
+            >
                 <line :x1="25 + 85 * (index - 1)" y1="68" :x2="95 + 85 * (index - 1)" y2="68" stroke="goldenrod" />
                 <line :x1="25 + 85 * (index - 1)" y1="92" :x2="95 + 85 * (index - 1)" y2="92" stroke="goldenrod" />
 
@@ -216,7 +219,7 @@
             </g>
         </template>
 
-        <template v-if="!isIndiaResourceMarket && !isNinePriceMarket && !isAustraliaMarket">
+        <template v-if="!isIndiaResourceMarket && !isNinePriceMarket && !isAustraliaMarket && !isBremenMarket">
             <rect width="30" height="30" x="705" y="45" rx="2" fill="darkgoldenrod" />
             <circle r="10" cx="732" cy="48" fill="yellow" />
             <text
@@ -453,6 +456,9 @@ export default class Resources extends Vue {
     // Australia: coal/oil/garbage-only market that can reach $10 after the Step 3
     // CO2 tax. co2TaxActive closes the $1/$2 columns once that shift has happened.
     isAustraliaMarket: boolean = false;
+    // Bremen: coal/oil/garbage-only market (no uranium row, like Korea's North
+    // table) where the $7/$8 spaces hold two cubes each.
+    isBremenMarket: boolean = false;
     co2TaxActive: boolean = false;
     coalsNorth: Piece[] = [];
     oilsNorth: Piece[] = [];
@@ -507,6 +513,7 @@ export default class Resources extends Vue {
 
         this.isAustraliaMarket = gameState.map?.name === 'Australia';
         this.co2TaxActive = this.isAustraliaMarket && gameState.step >= 3;
+        this.isBremenMarket = gameState.map?.name === 'Bremen';
 
         const isKorea = gameState.coalMarketNorth !== undefined;
         this.isKorea = isKorea;
@@ -599,6 +606,20 @@ export default class Resources extends Vue {
             this.garbages = this.buildMainRowPieces(
                 gameState.garbagePrices!, gameState.garbageMarket, 'garbage', 94, { maxPrice: 10 },
             );
+            this.uraniums = [];
+            this.coalsNorth = [];
+            this.oilsNorth = [];
+            this.garbagesNorth = [];
+            return;
+        }
+
+        // Bremen: three-resource market rendered like Korea's North table — no
+        // uranium row or $10–$16 corner. Slot counts per price space come from
+        // the price arrays ($7/$8 hold two cubes each).
+        if (this.isBremenMarket) {
+            this.coals = this.buildMainRowPieces(gameState.coalPrices!, gameState.coalMarket, 'coal', 48);
+            this.oils = this.buildMainRowPieces(gameState.oilPrices!, gameState.oilMarket, 'oil', 70);
+            this.garbages = this.buildMainRowPieces(gameState.garbagePrices!, gameState.garbageMarket, 'garbage', 94);
             this.uraniums = [];
             this.coalsNorth = [];
             this.oilsNorth = [];


### PR DESCRIPTION
Follow-up to #92, improvement spotted by Mike: on the printed Bremen board, the resource track holds only **two** cubes per resource at the $7 and $8 spaces (three everywhere else). So a full market is 22 cubes per resource — exactly the in-play supply, which is why the rules return 2 of each to the box.

**Engine**
- Per-cube price arrays for coal/oil/garbage: `[1,1,1, … 6,6,6, 7,7, 8,8]` (22 slots)
- Opening market corrected to 22 coal / 16 oil / 16 garbage (oil & garbage fill $3–$8 with 6 in reserve; coal starts exactly full)
- Bureaucracy resupply capacity follows the price-array length automatically

**Viewer**
- Bremen now renders like Korea's North table: three resource rows, no uranium row / hollow uranium cubes, no $10–$16 corner spaces

**Tests**
- Spec locks in the track shape and opening fill; all 36 engine tests pass
- 
<img width="1900" height="700" alt="bremen_market_fix_02_crop" src="https://github.com/user-attachments/assets/a850a864-afbc-4ea2-aef8-8e77d141aed3" />
— the $7/$8 columns show two cubes per resource, coal full $1–$8, oil/garbage from $3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

