### PR TITLE
Fix Japan free jump indicator and clarify map rules

### DIFF
--- a/engine/src/maps/japan.ts
+++ b/engine/src/maps/japan.ts
@@ -132,12 +132,12 @@ export const map: GameMap = {
     startingResources: [21, 15, 9, 3],
     startingCities: ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'],
     mapSpecificRules:
-        'Each player can have two separate networks.\n' +
-        'All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your 1 free jump and build in a second of these six starting cities. All 6 are marked with a 10 on the map.\n' +
+        'Each player has one network but gets one free jump to start a city anywhere on the map, bypassing normal connection costs.\n' +
+        'All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your free jump and build in a second of these six starting cities. All 6 are marked with a 10 on the map.\n' +
         'Starting cities have two first-connection spots (cost 10 Elektro each); two players can build there in Step 1.\n' +
         'In Step 3, a third connection spot opens in starting cities (cost 20 Elektro).\n' +
         'Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an X - an X at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), an X at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n' +
-        'If all spots in every starting city are taken, a player is forced to play with a single network.',
+        'If all starting city spots are taken, you cannot use your free jump.',
     connections: [
         { nodes: [Cities.Nagasaki, Cities.Fukuoka], cost: 10 },
         { nodes: [Cities.Fukuoka, Cities.Shimonoseki], cost: 10 },

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -537,7 +537,6 @@ import Resources from './boards/Resources.vue';
 import { LogMove } from 'powergrid-engine/src/log';
 import { Phase, PowerPlant, PowerPlantType, ResourceType } from 'powergrid-engine/src/gamestate';
 import { City } from 'powergrid-engine/src/maps';
-import { countNetworks } from 'powergrid-engine/src/available-moves';
 
 @Component({
     created(this: Game) {
@@ -1119,8 +1118,15 @@ export default class Game extends Vue {
         const player = this.G?.players[playerIndex];
         if (!player) return false;
         if (player.usedFreeJump) return true;
-        if (player.cities.length >= 2) {
-            if (countNetworks(this.G!.map.connections, player.cities.map(c => c.name)) >= 2) return true;
+        if (this.G?.log) {
+            for (const entry of this.G.log) {
+                if (entry.type === 'move' && (entry as any).player === playerIndex) {
+                    const move = (entry as any).move;
+                    if (move?.name === MoveName.Build && move?.data?.freeJump === true) {
+                        return true;
+                    }
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Summary
- Fix the Japan free-jump indicator showing a jump as "used" when it wasn't.
  `playerHasUsedFreeJump` inferred usage from network topology
  (`countNetworks >= 2`), but `countNetworks` only traverses a player's own
  cities — so any two non-adjacent owned cities looked like two separate
  networks even when connected via the normal map (e.g. JapanJune11). Replaced
  that heuristic with a log scan that only counts an explicit `Build` move
  recorded with `freeJump: true`, alongside the authoritative
  `player.usedFreeJump` engine flag.
- Reframed the Japan rules text as "one network with one free jump" rather than
  "two separate networks", which better matches how the mechanic actually works.

## Test plan
- [x] `prettier --check` clean, `engine` eslint 0 errors, `engine` tests pass (36), `viewer` build succeeds
- [ ] In JapanJune11, the red player (no jump used) shows the indicator as available
- [ ] After a player makes a free jump, the indicator dims to "used"
- [ ] Japan rules text renders correctly in-game