### PR TITLE
Fix Japan free jump (track explicitly, not via topology) + clarify Bremen rules dialog

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -423,19 +423,15 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                 } else {
                     toBuild = dijkstra(G, player).map((c) => ({ name: c.name, price: c.price }));
 
-                    // Japan: a player may start a second disconnected network at any available
-                    // starting city, paying only the slot cost (no connection fee).
-                    // We add a separate freeJump:true entry for each qualifying starting city
-                    // at connection cost 0 alongside the normal-price entry, so the player
-                    // can explicitly choose whether to spend the free jump or pay full price.
-                    if (
-                        isJapan &&
-                        !player.usedFreeJump &&
-                        countNetworks(
-                            G.map.connections,
-                            player.cities.map((c) => c.name)
-                        ) < 2
-                    ) {
+                    // Japan: while the player still holds their one free jump, they may
+                    // start a house in any available starting city paying only the slot
+                    // cost (no connection fee). We add a freeJump:true entry at connection
+                    // cost 0 for each such city, alongside any normal-price entry, so the
+                    // player can explicitly choose to spend the jump or pay full price.
+                    // Availability is tracked solely by player.usedFreeJump — never inferred
+                    // from network topology: owned cities connect *through* unowned ones, so a
+                    // single intended network routinely looks like several components.
+                    if (isJapan && !player.usedFreeJump) {
                         const freeJumpEntries: { name: string; price: number; freeJump?: boolean }[] = [];
                         japanStartingCities.forEach((cityName) => {
                             if (!player.cities.find((c) => c.name === cityName)) {

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -749,4 +749,55 @@ describe('Engine', () => {
         // Mitte still has its third slot (20): connection 1 + 20 = 21.
         expect(priceOf('Mitte'), 'Mitte third slot').to.equal(21);
     });
+
+    it('should keep the Japan free jump available even when owned cities span multiple network components', () => {
+        // 5 players so all five Japan regions are in play (Sapporo sits in Brown).
+        const G = setup(5, { map: 'Japan', variant: 'recharged', randomizeMap: false }, 'japan-free-jump');
+        G.phase = Phase.Building;
+        G.step = 1;
+        G.round = 3; // any round past the first, where the free jump becomes a choice
+        const player = G.players[0];
+        player.money = 100;
+        player.usedFreeJump = false;
+        // Yokohama and Kofu connect only THROUGH unowned cities (Tokyo, Saitama), so
+        // countNetworks() sees two components — the exact shape that used to wrongly hide
+        // the free jump even though the player never spent it.
+        player.cities = [
+            { name: 'Yokohama', position: 0 },
+            { name: 'Kofu', position: 0 },
+        ];
+
+        const builds = availableMoves(G, player)[MoveName.Build] as {
+            name: string;
+            price: number;
+            freeJump?: boolean;
+        }[];
+        const sapporoJump = builds.find((b) => b.name === 'Sapporo' && b.freeJump === true);
+        expect(sapporoJump, 'Sapporo offered as a free jump').to.not.be.undefined;
+        expect(sapporoJump!.price, 'free jump pays the slot cost only (10 in Step 1)').to.equal(10);
+    });
+
+    it('should stop offering the Japan free jump once it has been spent', () => {
+        const G = setup(5, { map: 'Japan', variant: 'recharged', randomizeMap: false }, 'japan-free-jump-used');
+        G.phase = Phase.Building;
+        G.step = 1;
+        G.round = 3;
+        const player = G.players[0];
+        player.money = 100;
+        player.usedFreeJump = true;
+        player.cities = [
+            { name: 'Yokohama', position: 0 },
+            { name: 'Kofu', position: 0 },
+        ];
+
+        const builds = availableMoves(G, player)[MoveName.Build] as {
+            name: string;
+            price: number;
+            freeJump?: boolean;
+        }[];
+        expect(
+            builds.some((b) => b.freeJump === true),
+            'no free-jump entries after the jump is used'
+        ).to.be.false;
+    });
 });

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { cloneDeep, isEqual, range } from 'lodash';
 import seedrandom from 'seedrandom';
-import { availableMoves, countNetworks } from './available-moves';
+import { availableMoves } from './available-moves';
 import {
     countHeldPowerPlants,
     GameOptions,
@@ -1783,6 +1783,24 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }
 
                 case MoveName.Build: {
+                    // Japan: was this specific build the move that consumed the free jump?
+                    // Round 1: the player's second starting-city build auto-uses the jump.
+                    // Round 2+: the build carried freeJump:true. Decided before the city is
+                    // popped (the round-1 check needs the pre-pop city count). The jump is
+                    // returned only when *this* move spent it — never re-derived from topology.
+                    let undoJapanFreeJump = false;
+                    if (G.map.name === 'Japan' && player.usedFreeJump) {
+                        if (
+                            G.round === 1 &&
+                            player.cities.length >= 2 &&
+                            (G.map.startingCities?.includes(lastMove.data.name) ?? false)
+                        ) {
+                            undoJapanFreeJump = true;
+                        } else if (lastMove.data.freeJump) {
+                            undoJapanFreeJump = true;
+                        }
+                    }
+
                     player.cities.pop();
                     player.money += lastMove.data.price;
 
@@ -1799,15 +1817,9 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         G.citiesBuiltInCurrentRound!--;
                     }
 
-                    // Japan: reset free jump flag if undo collapses back to a single network
-                    if (G.map.name === 'Japan' && player.usedFreeJump) {
-                        const networksAfterUndo = countNetworks(
-                            G.map.connections,
-                            player.cities.map((c) => c.name)
-                        );
-                        if (networksAfterUndo < 2) {
-                            player.usedFreeJump = false;
-                        }
+                    // Japan: return the free jump only if this build was the one that spent it.
+                    if (undoJapanFreeJump) {
+                        player.usedFreeJump = false;
                     }
 
                     break;

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -270,9 +270,10 @@ export const map: GameMap = {
         'costs the sum of the district costs along the cheapest path from your ' +
         'network (you pay for each district entered, including ones you only pass ' +
         'through), plus the cheapest building cost (8 / 14 / 20 Elektro) in the new ' +
-        'district. Small districts have only two spaces (8 / 14) and can hold just ' +
-        'two networks. The Weser and Lesum rivers can be crossed without extra ' +
-        'cost. No nuclear: nuclear power plants and uranium are not used. Step 2 ' +
+        'district. (on your 1st placement if A has 1 and B has 3 then A to B is ' +
+        '8+3+8=19, and B to A is 8+1+8=17, meaning it is asymmetrical) Small ' +
+        'districts have only two spaces (8 / 14) and can hold just two networks. ' +
+        'No nuclear: nuclear power plants and uranium are not used. Step 2 ' +
         'begins once a player has 5 connected districts (4 for 6 players); the game ' +
         'ends when a player connects 13 districts (12 for 5 players, 11 for 6).',
 };


### PR DESCRIPTION
## Japan free jump

Players reported the free jump becoming unusable mid-game — e.g. **Sapporo not highlighted/buildable even though the indicator still showed the jump as available** (reported by Bert and Mike).

**Root cause:** availability was gated on `countNetworks(ownedCities) < 2` as a proxy for "has the player started a second network." But Power Grid networks connect *through* unowned cities, so a single intended network routinely appears as multiple components — which wrongly suppressed the free-jump build options while `usedFreeJump` was still `false`. The earlier fixes (#89 log-scan fallback, #94 indicator) layered more detection heuristics on top of the same flawed proxy.

**Fix:** rely solely on the explicit `player.usedFreeJump` flag.

- `available-moves`: offer the jump whenever `!usedFreeJump`.
- `undo`: return the jump only when the undone build was the one that spent it (a round-1 second starting-city build, or a `freeJump:true` move). This also closes a latent bug where undoing *any* normal build could hand the jump back once the network had become fully connected.
- Remove the now-unused `countNetworks` import.
- Add regression tests: availability despite multi-component ownership, and suppression once the jump is used.

Verified with the full engine suite (38 passing) plus manual playtests at 3P and 6P — free jump across disconnected clusters, undo integrity (re-acquire on undo of the jump; stays spent on undo of a later normal build), and Step 3 third-slot ($20) jumps.

## Bremen rules dialog

- Add a short worked example of the **asymmetric** district connection cost.
- Remove the "Weser and Lesum rivers can be crossed without extra cost" line — the online map shows no rivers, so the note confused players (the zero-cost crossings remain in the map data and code comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
