### PR TITLE
Japan: cap round 1 at two houses + clarify rules dialog

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -415,11 +415,16 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                         : G.map.cities;
                     toBuild = candidates.map((c) => ({ name: c.name, price: 0 }));
                 } else if (isJapan && G.round === 1) {
-                    // Japan round 1: any additional house must also be a starting city.
-                    // Players cannot extend to adjacent non-starting cities until round 2.
-                    toBuild = G.map.cities
-                        .filter((c) => japanStartingCities.has(c.name))
-                        .map((c) => ({ name: c.name, price: 0 }));
+                    // Japan round 1: the only legal builds are starting cities, and a player
+                    // may place at most two houses — the initial placement plus the one free
+                    // jump. The jump is auto-consumed on the second starting-city build, so
+                    // once it is spent no further round-1 builds are offered (players cannot
+                    // extend to adjacent non-starting cities until round 2 either way).
+                    toBuild = player.usedFreeJump
+                        ? []
+                        : G.map.cities
+                              .filter((c) => japanStartingCities.has(c.name))
+                              .map((c) => ({ name: c.name, price: 0 }));
                 } else {
                     toBuild = dijkstra(G, player).map((c) => ({ name: c.name, price: c.price }));
 

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -800,4 +800,88 @@ describe('Engine', () => {
             'no free-jump entries after the jump is used'
         ).to.be.false;
     });
+
+    it('should restrict the Japan first house to a starting city even when the player skipped round 1', () => {
+        // Player builds nothing in round 1; in round 2 their first house must still be
+        // one of the six starting cities (the cities.length===0 rule is not round-gated).
+        const G = setup(5, { map: 'Japan', variant: 'recharged', randomizeMap: false }, 'japan-skip-r1');
+        G.phase = Phase.Building;
+        G.step = 1;
+        G.round = 2;
+        const player = G.players[0];
+        player.money = 100;
+        player.usedFreeJump = false;
+        player.cities = [];
+
+        const builds = availableMoves(G, player)[MoveName.Build] as {
+            name: string;
+            price: number;
+            freeJump?: boolean;
+        }[];
+        expect(builds.map((b) => b.name).sort(), 'only the six starting cities are offered').to.deep.equal(
+            ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'].sort()
+        );
+        expect(
+            builds.every((b) => b.freeJump !== true),
+            'the initial placement is never a free jump'
+        ).to.be.true;
+    });
+
+    it('should keep then spend the Japan free jump for a player who skipped round 1', () => {
+        const G = setup(5, { map: 'Japan', variant: 'recharged', randomizeMap: false }, 'japan-skip-r1-jump');
+        G.phase = Phase.Building;
+        G.step = 1;
+        G.round = 2;
+        const player = G.players[0];
+        player.money = 100;
+        player.usedFreeJump = false;
+        player.cities = [];
+
+        // Initial placement in round 2 — must NOT consume the jump.
+        G.currentPlayers = [0];
+        player.availableMoves = availableMoves(G, player);
+        const tokyo = (player.availableMoves[MoveName.Build] as { name: string; price: number }[]).find(
+            (b) => b.name === 'Tokyo'
+        )!;
+        move(G, { name: MoveName.Build, data: tokyo }, 0);
+        expect(player.usedFreeJump, 'initial placement keeps the jump').to.be.false;
+
+        // Second build offers the jump into another starting city.
+        player.availableMoves = availableMoves(G, player);
+        const osaka = (
+            player.availableMoves[MoveName.Build] as { name: string; price: number; freeJump?: boolean }[]
+        ).find((b) => b.name === 'Osaka' && b.freeJump === true)!;
+        expect(osaka, 'free jump offered for the second build').to.not.be.undefined;
+        move(G, { name: MoveName.Build, data: osaka }, 0);
+        expect(player.usedFreeJump, 'jump consumed on the free-jump build').to.be.true;
+    });
+
+    it('should cap Japan round 1 at two houses (initial placement plus the free jump)', () => {
+        const G = setup(5, { map: 'Japan', variant: 'recharged', randomizeMap: false }, 'japan-r1-cap');
+        G.phase = Phase.Building;
+        G.step = 1;
+        G.round = 1;
+        const player = G.players[0];
+        player.money = 100;
+        player.usedFreeJump = false;
+        player.cities = [];
+
+        // House 1 (initial placement) and house 2 (auto free jump).
+        G.currentPlayers = [0];
+        player.availableMoves = availableMoves(G, player);
+        const h1 = (player.availableMoves[MoveName.Build] as { name: string; price: number }[]).find(
+            (b) => b.name === 'Tokyo'
+        )!;
+        move(G, { name: MoveName.Build, data: h1 }, 0);
+        player.availableMoves = availableMoves(G, player);
+        const h2 = (player.availableMoves[MoveName.Build] as { name: string; price: number }[]).find(
+            (b) => b.name === 'Osaka'
+        )!;
+        move(G, { name: MoveName.Build, data: h2 }, 0);
+        expect(player.usedFreeJump, 'second round-1 build consumes the jump').to.be.true;
+
+        // No third build may be offered in round 1 — the jump is spent.
+        const builds3 = availableMoves(G, player)[MoveName.Build];
+        expect(builds3, 'no further builds offered in round 1 after the jump is spent').to.be.undefined;
+    });
 });

--- a/engine/src/maps/japan.ts
+++ b/engine/src/maps/japan.ts
@@ -132,11 +132,12 @@ export const map: GameMap = {
     startingResources: [21, 15, 9, 3],
     startingCities: ['Fukuoka', 'Kobe', 'Osaka', 'Sapporo', 'Tokyo', 'Yokohama'],
     mapSpecificRules:
-        'Each player has one network but gets one free jump to start a city anywhere on the map, bypassing normal connection costs.\n' +
-        'All first round house/city builds MUST be placed in one of six starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama. If you build 2 cities in round 1, you must use your free jump and build in a second of these six starting cities. All 6 are marked with a 10 on the map.\n' +
-        'Starting cities have two first-connection spots (cost 10 Elektro each); two players can build there in Step 1.\n' +
-        'In Step 3, a third connection spot opens in starting cities (cost 20 Elektro).\n' +
-        'Some smaller cities have only two building spots (costs 10 and 15, or 15 and 20 from Step 2). These cities are marked with an X - an X at the top means no Step 1 builds allowed ($15 and $20 will be available during Step 2/Step 3), an X at the bottom means no Step 3 builds allowed, only $10 and $15 (Step 1 and Step 2) builds are allowed.\n' +
+        'Users may build 0, 1, 2 houses in round 1. The first house you place MUST be in one of the six special starting cities: Fukuoka, Kobe, Osaka, Sapporo, Tokyo, or Yokohama whether it be round 1 or after.\n' +
+        'You get a free jump but that free jump can only go into one of these six starting cities (you still pay for the house, just no connection fee).\n' +
+        'All of these six special starting cities are [10, 10, 20] meaning two players can go there in step 1 and these cities are marked with 10 on the map.\n' +
+        'If you build 2 cities in round 1, you must use your free jump even though they might have 0 connection like Tokyo and Yokohama (system will auto use your free jump).\n' +
+        'In Step 3, the third connection spots (cost 20) are opened in the starting cities and are available for normal or free jump.\n' +
+        'Some smaller cities have only two building spots (10 and 15, or 15 and 20). These cities are marked with an X. An X at the top means no Step 1 builds, an X at the bottom means no Step 3 builds.\n' +
         'If all starting city spots are taken, you cannot use your free jump.',
     connections: [
         { nodes: [Cities.Nagasaki, Cities.Fukuoka], cost: 10 },


### PR DESCRIPTION
## Summary
Two Japan fixes, bundled.

### 1. Round-1 build cap (bug fix)
Round-1 building offered every starting city at slot-cost-only with no check on how many a player already owned or whether the free jump was spent, so a player could place a 3rd, 4th, ... starting-city house in round 1 for just the slot fee — effectively unlimited free jumps. The rules allow at most two round-1 houses: the initial placement plus the one free jump (auto-consumed on the second starting-city build). Gated the round-1 offer on `!player.usedFreeJump`. Pre-existing since the original Japan map PR (#78).

### 2. Rules dialog rewrite
Restructured `mapSpecificRules` to match how the rules actually play out: round-1 build count (0–2), the first house always landing in a starting city (round 1 or later), the free jump limited to the six starting cities and auto-used on a second round-1 build, the Step 3 third spot, and the X markers for limited-slot cities.

## Edge case (raised by Mike)
Verified that a player who builds **0 houses in round 1** still has their first house restricted to the six starting cities in round 2, and keeps + can spend the free jump there. This was already correct; it is now covered by tests.

## Tests
Three new regression tests (round-2 first-house restriction for a round-1 skipper, keep-then-spend of the jump in that case, and the round-1 two-house cap). Full engine suite green (36 passing). Playtested in the self-contained viewer at 2 and 6 players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)