### PR TITLE
Choose regionsAdd chooseRegions option: draft in-play regions instead of random selection

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -8,6 +8,7 @@ import {
     PowerPlantType,
     ResourceType,
 } from './gamestate';
+import { GameMap } from './maps';
 import { MoveName } from './move';
 import prices from './prices';
 import { minBy } from './utils';
@@ -33,6 +34,7 @@ export interface AvailableMoves {
         resourcesSpent: ResourceType[];
         citiesPowered: number;
     }[];
+    [MoveName.ChooseRegion]?: string[];
     [MoveName.Pass]?: boolean[];
     [MoveName.Undo]?: boolean[];
 }
@@ -676,9 +678,79 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
             }
             break;
         }
+
+        case Phase.RegionSelection: {
+            // Drafting in-play regions (chooseRegions option). G.map still holds the
+            // full, unfiltered map, so its cities/connections describe every region.
+            const picked = G.regionDraft?.picked ?? [];
+            const graph = computeRegionGraph(G.map);
+            moves[MoveName.ChooseRegion] = graph.regions.filter((region) =>
+                regionPickable(G.map.name, graph, picked, region)
+            );
+            break;
+        }
     }
 
     return moves;
+}
+
+export interface RegionGraph {
+    // Distinct region names, in first-appearance order.
+    regions: string[];
+    // For each region (parallel to `regions`), the regions directly connected to it.
+    regionConnections: string[][];
+    // Region name -> landmass id. Only UK & Ireland tags cities with an `island`;
+    // empty for every other map.
+    regionIsland: Record<string, string>;
+}
+
+// Builds the region adjacency graph used by region selection (both the random
+// setup picker and the chooseRegions draft). Single source of truth so the two
+// paths can never diverge on what "connected" means.
+export function computeRegionGraph(map: Pick<GameMap, 'cities' | 'connections'>): RegionGraph {
+    const regions = map.cities
+        .filter((c, i) => map.cities.findIndex((cc) => cc.region == c.region) == i)
+        .map((c) => c.region);
+    const connections = map.connections.map((con) =>
+        con.nodes.map((n) => map.cities.find((city) => city.name == n)!.region)
+    );
+    const regionConnections = regions.map((region) =>
+        regions.filter(
+            (area2) => region != area2 && connections.some((con) => con.includes(region) && con.includes(area2))
+        )
+    );
+    const regionIsland: Record<string, string> = {};
+    for (const c of map.cities) {
+        if (c.island && regionIsland[c.region] === undefined) {
+            regionIsland[c.region] = c.island;
+        }
+    }
+    return { regions, regionConnections, regionIsland };
+}
+
+// Whether `region` may be added to the already-`picked` set under the region
+// connectivity rules. The first pick is always allowed; subsequent picks must
+// connect to an already-picked region, with two map-specific exceptions:
+//   - UK & Ireland: a region may open a fresh landmass (no picked region shares
+//     its island), since the two islands have no sea edges between them.
+//   - Australia: regions need not be adjacent (the 20-Elektro general connection
+//     reaches any city), so any region is allowed.
+export function regionPickable(mapName: string, graph: RegionGraph, picked: string[], region: string): boolean {
+    const pickedSet = new Set(picked);
+    if (pickedSet.has(region)) return false;
+    if (pickedSet.size == 0) return true;
+
+    const idx = graph.regions.indexOf(region);
+    if (idx == -1) return false;
+    if (graph.regionConnections[idx].some((con) => pickedSet.has(con))) return true;
+
+    if (mapName === 'UK & Ireland') {
+        const startedIslands = new Set([...pickedSet].map((r) => graph.regionIsland[r]));
+        if (!startedIslands.has(graph.regionIsland[region])) return true;
+    }
+    if (mapName === 'Australia') return true;
+
+    return false;
 }
 
 export function countNetworks(connections: { nodes: string[] }[], cityNames: string[]): number {

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import 'mocha';
-import { availableMoves } from './available-moves';
+import { availableMoves, computeRegionGraph, regionPickable } from './available-moves';
 import { applyAustraliaStep3Shift, ended, getPowerPlant, move, reconstructState, setup } from './engine';
 import GermanyRecharged from './fixtures/GermanyRecharged.json';
 import supply from './fixtures/supply.json';
@@ -748,5 +748,121 @@ describe('Engine', () => {
         expect(priceOf('Findorff') === undefined || priceOf('Findorff') === 9999, 'Findorff small, full').to.be.true;
         // Mitte still has its third slot (20): connection 1 + 20 = 21.
         expect(priceOf('Mitte'), 'Mitte third slot').to.equal(21);
+    });
+
+    it('should draft regions when chooseRegions is set, then start the auction', () => {
+        const numPlayers = 5;
+        const G0 = setup(numPlayers, { map: 'Germany', chooseRegions: true, fastBid: false }, 'cr-seed');
+
+        // Setup enters the draft holding the FULL map; nothing filtered yet.
+        const allRegions = new Set(G0.map.cities.map((c) => c.region));
+        const regionsNeeded = G0.regionDraft!.regionsNeeded;
+        expect(G0.phase).to.equal(Phase.RegionSelection);
+        expect(regionsNeeded).to.equal(5); // 5 players use 5 regions
+        expect(allRegions.size).to.be.greaterThan(regionsNeeded); // otherwise no real choice
+        expect(G0.currentPlayers).to.deep.equal([0]);
+
+        // The first picker may choose any region.
+        const firstMoves = G0.players[0].availableMoves![MoveName.ChooseRegion]!;
+        expect(new Set(firstMoves)).to.deep.equal(allRegions);
+
+        // Drive the draft: each current player picks the first legal region.
+        let G = G0;
+        const picks: string[] = [];
+        const pickOrder: number[] = [];
+        while (G.phase === Phase.RegionSelection) {
+            const picker = G.currentPlayers[0];
+            pickOrder.push(picker);
+            const options = G.players[picker].availableMoves![MoveName.ChooseRegion]!;
+            expect(options.length, 'the current picker always has at least one legal region').to.be.greaterThan(0);
+            const region = options[0];
+            picks.push(region);
+            G = move(G, { name: MoveName.ChooseRegion, data: region } as Move, picker);
+        }
+
+        // Draft completed straight into the auction.
+        expect(G.phase).to.equal(Phase.Auction);
+        expect(G.regionDraft).to.be.undefined;
+        expect(picks.length).to.equal(regionsNeeded);
+
+        // Players picked in seating order (5 regions, 5 players -> one each).
+        expect(pickOrder).to.deep.equal([0, 1, 2, 3, 4]);
+
+        // Map filtered to exactly the picked regions, and every kept connection lies
+        // entirely within them.
+        const finalRegions = new Set(G.map.cities.map((c) => c.region));
+        expect(finalRegions).to.deep.equal(new Set(picks));
+        const cityRegion = new Map(G.map.cities.map((c) => [c.name, c.region]));
+        for (const con of G.map.connections) {
+            for (const node of con.nodes) {
+                expect(finalRegions.has(cityRegion.get(node)!), node).to.be.true;
+            }
+        }
+
+        // The game is playable: the starting player can act in the auction.
+        expect(G.currentPlayers).to.deep.equal([0]);
+        expect(G.players[0].availableMoves![MoveName.ChoosePowerPlant]).to.exist;
+    });
+
+    it('should draft in seating order, wrapping for 2 players (chooseRegions)', () => {
+        const G0 = setup(2, { map: 'Germany', chooseRegions: true, fastBid: false }, 'cr-2p');
+        expect(G0.regionDraft!.regionsNeeded).to.equal(3); // 2 players use 3 regions
+
+        let G = G0;
+        const pickOrder: number[] = [];
+        while (G.phase === Phase.RegionSelection) {
+            const picker = G.currentPlayers[0];
+            pickOrder.push(picker);
+            const region = G.players[picker].availableMoves![MoveName.ChooseRegion]![0];
+            G = move(G, { name: MoveName.ChooseRegion, data: region } as Move, picker);
+        }
+
+        // First player, second player, then first player again.
+        expect(pickOrder).to.deep.equal([0, 1, 0]);
+        expect(G.phase).to.equal(Phase.Auction);
+        expect(new Set(G.map.cities.map((c) => c.region)).size).to.equal(3);
+    });
+
+    it('should restrict region picks to connected regions (chooseRegions)', () => {
+        const G0 = setup(3, { map: 'Germany', chooseRegions: true, fastBid: false }, 'cr-seed2');
+        expect(G0.phase).to.equal(Phase.RegionSelection);
+
+        // Player 0 picks one region.
+        const firstRegion = G0.players[0].availableMoves![MoveName.ChooseRegion]![0];
+        const G1 = move(G0, { name: MoveName.ChooseRegion, data: firstRegion } as Move, 0);
+
+        // Player 1's options exclude the picked region and are all legally connected
+        // (Germany has no UK/Australia exception).
+        const options = G1.players[1].availableMoves![MoveName.ChooseRegion]!;
+        expect(options.length).to.be.greaterThan(0);
+        expect(options).to.not.include(firstRegion);
+        const graph = computeRegionGraph(G1.map);
+        for (const region of options) {
+            expect(regionPickable('Germany', graph, [firstRegion], region), region).to.be.true;
+        }
+    });
+
+    it('should replay a chooseRegions draft deterministically', () => {
+        const opts: GameOptions = { map: 'Germany', chooseRegions: true, fastBid: false };
+        const seed = 'cr-replay';
+
+        // Play the draft, recording each pick.
+        let G = setup(4, opts, seed);
+        const draftMoves: { player: number; data: string }[] = [];
+        while (G.phase === Phase.RegionSelection) {
+            const picker = G.currentPlayers[0];
+            const region = G.players[picker].availableMoves![MoveName.ChooseRegion]![0];
+            draftMoves.push({ player: picker, data: region });
+            G = move(G, { name: MoveName.ChooseRegion, data: region } as Move, picker);
+        }
+
+        // Re-run setup with the same seed and replay the recorded picks.
+        let G2 = setup(4, opts, seed);
+        for (const m of draftMoves) {
+            G2 = move(G2, { name: MoveName.ChooseRegion, data: m.data } as Move, m.player);
+        }
+
+        expect(G2.phase).to.equal(Phase.Auction);
+        expect(G2.map.cities.map((c) => c.name).sort()).to.deep.equal(G.map.cities.map((c) => c.name).sort());
     });
 });

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { cloneDeep, isEqual, range } from 'lodash';
 import seedrandom from 'seedrandom';
-import { availableMoves, countNetworks } from './available-moves';
+import { availableMoves, computeRegionGraph, countNetworks, regionPickable } from './available-moves';
 import {
     countHeldPowerPlants,
     GameOptions,
@@ -107,6 +107,7 @@ export function setup(
         useNewRechargedSetup = true,
         trackTotalSpent = true,
         randomizeMap = false,
+        chooseRegions = false,
     }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
@@ -259,6 +260,9 @@ export function setup(
     }
 
     let finalMap: GameMap;
+    // Set when the chooseRegions option defers region selection to a player draft;
+    // consumed after the GameState is built to enter the RegionSelection phase.
+    let pendingRegionDraft: { regionsNeeded: number; picked: string[] } | undefined;
     if (randomizeMap) {
         finalMap = createRandomizedMap(chosenMap, regionsInPlay[p], rng);
     } else {
@@ -268,100 +272,43 @@ export function setup(
             y: city.y * chosenMap.adjustRatio![1],
         }));
 
-        const regions = chosenMap.cities
-            .filter((c, i) => chosenMap.cities.findIndex((cc) => cc.region == c.region) == i)
-            .map((c) => c.region);
-        const connections = chosenMap.connections.map((con) =>
-            con.nodes.map((n) => chosenMap.cities.find((city) => city.name == n)!.region)
-        );
-        const regionConnections = regions.map((region) =>
-            regions.filter(
-                (area2) => region != area2 && connections.some((con) => con.includes(region) && con.includes(area2))
-            )
-        );
+        // Region adjacency graph (shared with the chooseRegions draft via
+        // available-moves) — single source of truth for what "connected" means.
+        const graph = computeRegionGraph(chosenMap);
+        const regions = graph.regions;
+        const regionsNeeded = Math.min(regionsInPlay[p], regions.length);
 
-        // Map each region to the landmass ('island') it sits on. Only UK & Ireland
-        // tags cities with an `island`; for every other map this stays empty and is
-        // unused.
-        const regionIsland: Record<string, string> = {};
-        for (const c of chosenMap.cities) {
-            if (c.island && regionIsland[c.region] === undefined) {
-                regionIsland[c.region] = c.island;
-            }
-        }
+        if (chooseRegions && regions.length > regionsNeeded) {
+            // Defer region selection to a player draft (the RegionSelection phase).
+            // Keep the full map in play for now; finalizeRegions() filters it to the
+            // chosen regions once the draft completes, and applies the
+            // regionalPowerPlants swap at that point.
+            finalMap = chosenMap;
+            pendingRegionDraft = { regionsNeeded, picked: [] };
+        } else {
+            const playRegions = new Set<string>();
+            while (playRegions.size != regionsNeeded) {
+                const region = regions[Math.floor(rng() * regions.length)];
 
-        const playRegions = new Set<string>();
-        while (playRegions.size != Math.min(regionsInPlay[p], regions.length)) {
-            const region = regions[Math.floor(rng() * regions.length)];
-            const connectsToChosen =
-                playRegions.size == 0 || regionConnections[regions.indexOf(region)].some((con) => playRegions.has(con));
+                // regionPickable enforces connectivity with the UK & Ireland
+                // (fresh-landmass) and Australia (any-region) exceptions. A region
+                // that is already picked or that would be stranded is rejected, and
+                // the loop draws again — see regionPickable for the soft-lock
+                // reasoning behind the connectivity requirement.
+                if (regionPickable(chosenMap.name, graph, [...playRegions], region)) {
+                    playRegions.add(region);
 
-            let accept = connectsToChosen;
-
-            // UK & Ireland: Great Britain and Ireland have no edges between them (no
-            // sea connection), so a region may ALSO be accepted if it opens a fresh
-            // landmass — i.e. no already-chosen region shares its island. But within
-            // a landmass we still require connectivity, so a region is never stranded
-            // from the rest of its own island (e.g. Scotland chosen without N. England
-            // bridging it to the south). A stranded region's cities are unreachable by
-            // any player who didn't start there: they can never be built, so neither
-            // Step 2 trigger fires (no one reaches the city threshold, and "all Step 1
-            // houses filled" is impossible) and the game soft-locks. The cross-island
-            // surcharge bridges the two landmasses at build time. This also resolves
-            // the old "5-of-6 regions for 5p loops forever" worry (GB has 4 regions,
-            // IE has 2) — opening the second island keeps the picker unblocked.
-            if (!accept && chosenMap.name === 'UK & Ireland') {
-                const startedIslands = new Set([...playRegions].map((r) => regionIsland[r]));
-                if (!startedIslands.has(regionIsland[region])) {
-                    accept = true;
-                }
-            }
-
-            // Australia: regions need not be adjacent (rulebook). Western Australia
-            // (Red) has no inter-region edges, but the 20-Elektro general connection
-            // reaches ANY city at build time, so there is no unreachable-cluster
-            // soft-lock and the connectivity check can be skipped entirely.
-            if (!accept && chosenMap.name === 'Australia') {
-                accept = true;
-            }
-
-            if (accept) {
-                playRegions.add(region);
-
-                // Avoid italy Red Green Blue
-                if (chosenMap.name === 'Italy') {
-                    if (playRegions.has('red') && playRegions.has('green') && playRegions.has('blue')) {
-                        playRegions.clear();
+                    // Avoid italy Red Green Blue
+                    if (chosenMap.name === 'Italy') {
+                        if (playRegions.has('red') && playRegions.has('green') && playRegions.has('blue')) {
+                            playRegions.clear();
+                        }
                     }
                 }
             }
-        }
 
-        const filteredMap = cloneDeep(chosenMap);
-        filteredMap.cities = filteredMap.cities.filter((city) => playRegions.has(city.region));
-        filteredMap.connections = filteredMap.connections.filter((con) =>
-            con.nodes
-                .map((n) => chosenMap.cities.find((city) => city.name == n)!.region)
-                .every((r) => playRegions.has(r))
-        );
-
-        finalMap = filteredMap;
-
-        if (chosenMap.regionalPowerPlants) {
-            for (const region of playRegions) {
-                const replacements = chosenMap.regionalPowerPlants[region];
-                if (replacements) {
-                    for (const newPlant of replacements) {
-                        const swapIn = (arr: PowerPlant[]) => {
-                            const idx = arr.findIndex((p) => p.number === newPlant.number);
-                            if (idx !== -1) arr[idx] = { ...newPlant };
-                        };
-                        swapIn(actualMarket);
-                        swapIn(futureMarket);
-                        swapIn(powerPlantsDeck);
-                    }
-                }
-            }
+            finalMap = filterMapToRegions(chosenMap, playRegions);
+            applyRegionalPowerPlants(chosenMap, playRegions, actualMarket, futureMarket, powerPlantsDeck);
         }
     }
 
@@ -446,7 +393,7 @@ export function setup(
         auctioningPlayer: undefined,
         step: 1,
         phase: Phase.Auction,
-        options: { fastBid, map, variant, showMoney, useNewRechargedSetup, trackTotalSpent },
+        options: { fastBid, map, variant, showMoney, useNewRechargedSetup, trackTotalSpent, chooseRegions },
         log: [],
         hiddenLog: [],
         seed,
@@ -504,9 +451,81 @@ export function setup(
         removePlantsForMiddleEastStep1(G);
     }
 
+    // chooseRegions: start in the region draft instead of the auction. The map
+    // currently holds every region; finalizeRegions() filters it once the players
+    // finish picking.
+    if (pendingRegionDraft) {
+        G.phase = Phase.RegionSelection;
+        G.regionDraft = pendingRegionDraft;
+    }
+
     G.players[startingPlayer].availableMoves = availableMoves(G, G.players[startingPlayer]);
 
     return G;
+}
+
+// Filters a (full) map down to just the chosen regions: keeps only cities in
+// those regions and connections whose endpoints are both kept. Returns a new map;
+// the input is not mutated.
+function filterMapToRegions(map: GameMap, playRegions: Set<string>): GameMap {
+    const filteredMap = cloneDeep(map);
+    filteredMap.cities = filteredMap.cities.filter((city) => playRegions.has(city.region));
+    filteredMap.connections = filteredMap.connections.filter((con) =>
+        con.nodes.map((n) => map.cities.find((city) => city.name == n)!.region).every((r) => playRegions.has(r))
+    );
+    return filteredMap;
+}
+
+// Applies the map's regionalPowerPlants overrides for the chosen regions, swapping
+// the replacement plants into whichever of the three decks currently hold the
+// matching plant numbers. Mutates the passed arrays in place.
+function applyRegionalPowerPlants(
+    map: GameMap,
+    playRegions: Set<string>,
+    actualMarket: PowerPlant[],
+    futureMarket: PowerPlant[],
+    powerPlantsDeck: PowerPlant[]
+) {
+    if (!map.regionalPowerPlants) {
+        return;
+    }
+    for (const region of playRegions) {
+        const replacements = map.regionalPowerPlants[region];
+        if (replacements) {
+            for (const newPlant of replacements) {
+                const swapIn = (arr: PowerPlant[]) => {
+                    const idx = arr.findIndex((p) => p.number === newPlant.number);
+                    if (idx !== -1) arr[idx] = { ...newPlant };
+                };
+                swapIn(actualMarket);
+                swapIn(futureMarket);
+                swapIn(powerPlantsDeck);
+            }
+        }
+    }
+}
+
+// Completes the chooseRegions draft: filters the map to the picked regions, applies
+// the deferred regionalPowerPlants swap, fixes region-dependent end-game targets,
+// and hands off to the auction with the starting player to move.
+function finalizeRegions(G: GameState) {
+    const playRegions = new Set(G.regionDraft!.picked);
+    const fullMap = G.map;
+
+    G.map = filterMapToRegions(fullMap, playRegions);
+    applyRegionalPowerPlants(fullMap, playRegions, G.actualMarket, G.futureMarket, G.powerPlantsDeck);
+    // knownPowerPlantDeck mirrors actualMarket+futureMarket and must reflect any swap.
+    G.knownPowerPlantDeck = G.actualMarket.concat(G.futureMarket);
+
+    // UK & Ireland 2p caps the end-game target at the number of cities actually in
+    // play, which is only known once the regions are chosen.
+    if (G.map.name == 'UK & Ireland' && G.players.length == 2) {
+        G.citiesToEndGame = Math.min(citiesToEndGame[G.players.length - 2], G.map.cities.length);
+    }
+
+    G.regionDraft = undefined;
+    G.phase = Phase.Auction;
+    G.currentPlayers = [G.playerOrder[0]];
 }
 
 export function stripSecret(G: GameState, player?: number): GameState {
@@ -652,6 +671,30 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 });
 
                 nextPlayerClockwise(G);
+            }
+
+            break;
+        }
+
+        case MoveName.ChooseRegion: {
+            asserts<Moves.MoveChooseRegion>(move);
+
+            G.regionDraft!.picked.push(move.data);
+
+            G.log.push({
+                type: 'move',
+                player: playerNumber,
+                move,
+                simple: `${player.name} chooses region ${move.data}.`,
+                pretty: `${playerNameHTML(player)} chooses region <b>${move.data}</b>.`,
+            });
+
+            if (G.regionDraft!.picked.length >= G.regionDraft!.regionsNeeded) {
+                finalizeRegions(G);
+            } else {
+                // Next picker, in seating order, wrapping around.
+                const order = G.playerOrder;
+                G.currentPlayers = [order[(order.indexOf(playerNumber) + 1) % order.length]];
             }
 
             break;
@@ -1876,6 +1919,14 @@ export function moveAI(G: GameState, playerNumber: number): GameState {
     let chosenMove: Move = { name: MoveName.Pass, data: true };
 
     switch (G.phase) {
+        case Phase.RegionSelection: {
+            if (availableMoves?.ChooseRegion && availableMoves.ChooseRegion.length > 0) {
+                chosenMove = { name: MoveName.ChooseRegion, data: chooseRandom(availableMoves.ChooseRegion) };
+            }
+
+            break;
+        }
+
         case Phase.Auction: {
             if (availableMoves?.ChoosePowerPlant) {
                 if (

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -37,6 +37,9 @@ export interface GameOptions {
     useNewRechargedSetup?: boolean;
     trackTotalSpent?: boolean;
     randomizeMap?: boolean;
+    // When set, the regions in play are drafted by the players at the start of
+    // the game (each picks in turn) instead of being chosen randomly at setup.
+    chooseRegions?: boolean;
 }
 
 export enum ResourceType {
@@ -107,6 +110,7 @@ export interface Player {
 }
 
 export enum Phase {
+    RegionSelection = 'Region Selection',
     Order = 'Order',
     Auction = 'Auction',
     Resources = 'Resources',
@@ -173,6 +177,10 @@ export interface GameState {
     auctioningPlayer: number | undefined;
     step: number;
     phase: Phase;
+    // Present only while phase == RegionSelection (chooseRegions option). Tracks
+    // how many regions must be drafted and which have been picked so far. Cleared
+    // once the draft completes and the map is filtered to the chosen regions.
+    regionDraft?: { regionsNeeded: number; picked: string[] };
     options: GameOptions;
     log: LogItem[];
     hiddenLog: LogItem[];

--- a/engine/src/move.ts
+++ b/engine/src/move.ts
@@ -56,6 +56,11 @@ export declare namespace Moves {
         };
     }
 
+    export interface MoveChooseRegion {
+        name: MoveName.ChooseRegion;
+        data: string;
+    }
+
     export interface MovePass {
         name: MoveName.Pass;
         data: true;
@@ -75,6 +80,7 @@ export type Move =
     | Moves.MoveBuyResource
     | Moves.MoveBuild
     | Moves.MoveUsePowerPlant
+    | Moves.MoveChooseRegion
     | Moves.MovePass
     | Moves.MoveUndo;
 
@@ -86,6 +92,7 @@ export enum MoveName {
     BuyResource = 'BuyResource',
     Build = 'Build',
     UsePowerPlant = 'UsePowerPlant',
+    ChooseRegion = 'ChooseRegion',
     Pass = 'Pass',
     Undo = 'Undo',
 }

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -55,9 +55,11 @@
                 :connections="G.map.connections"
                 :polygons="G.map.polygons"
                 :buildableCities="getBuildableCities()"
+                :pickableRegions="getPickableRegions()"
                 :devBackdrop="G.map.devBackdrop"
                 :mapRotation="G.map.mapRotation || 0"
                 @build="build($event)"
+                @pickRegion="pickRegion($event)"
             />
 
             <!-- Japan: Free Jump indicator -->
@@ -1115,6 +1117,19 @@ export default class Game extends Vue {
         return availableMoves[MoveName.Build] && availableMoves[MoveName.Build]!.map((c) => c.name) || [];
     }
 
+    getPickableRegions(): string[] {
+        if (!this.canMove()) return [];
+
+        const currentPlayer = this.G!.players[this.player!];
+        const availableMoves = currentPlayer.availableMoves!;
+
+        return availableMoves[MoveName.ChooseRegion] || [];
+    }
+
+    pickRegion(region: string) {
+        this.sendMove({ name: MoveName.ChooseRegion, data: region });
+    }
+
     playerHasUsedFreeJump(playerIndex: number): boolean {
         const player = this.G?.players[playerIndex];
         if (!player) return false;
@@ -1216,6 +1231,20 @@ export default class Game extends Vue {
     }
 
     getStatusMessage() {
+        // Region draft (chooseRegions): show the pick prompt to the current picker
+        // even on the very first turn, before any moves are in the log.
+        if (
+            this.G &&
+            this.G.phase == Phase.RegionSelection &&
+            this.player !== undefined &&
+            this.G.currentPlayers.includes(this.player)
+        ) {
+            const draft = this.G.regionDraft;
+            return draft
+                ? `Choose a region to play in (${draft.picked.length + 1} of ${draft.regionsNeeded}).`
+                : 'Choose a region to play in.';
+        }
+
         if (!this.G || this.G.log.length == 1) {
             return 'Game Start!';
         } else if (this.G.currentPlayers == []) {

--- a/viewer/src/components/boards/Map.vue
+++ b/viewer/src/components/boards/Map.vue
@@ -94,7 +94,7 @@
         <template v-for="city in cities">
             <g v-if="city.connectionCost != null" :key="city.name + '_tile'">
                 <rect
-                    :class="[{ canClick: canBuild(city) }]"
+                    :class="[{ canClick: canBuild(city) || canPickRegion(city) }]"
                     :x="city.x - 23"
                     :y="city.y - 23"
                     width="46"
@@ -104,7 +104,7 @@
                     :stroke="city.region"
                     stroke-width="4"
                     :transform="`rotate(45, ${city.x}, ${city.y})`"
-                    @click="canBuild(city) && build(city)"
+                    @click="onCityClick(city)"
                 >
                     <title>{{ city.name }} — connect for {{ city.connectionCost }} (entry) + house</title>
                 </rect>
@@ -148,12 +148,12 @@
             <circle
                 v-if="city.connectionCost == null"
                 :key="city.name + '_circle2'"
-                :class="[{ canClick: canBuild(city) }]"
+                :class="[{ canClick: canBuild(city) || canPickRegion(city) }]"
                 r="20"
                 :cx="city.x"
                 :cy="city.y"
                 fill="gray"
-                @click="canBuild(city) && build(city)"
+                @click="onCityClick(city)"
             >
                 <title>{{ city.name }}</title>
             </circle>
@@ -317,6 +317,25 @@
                 />
             </template>
         </template>
+
+        <!-- chooseRegions draft: outline every city in a pickable region so the
+             current player can see and click the regions they may draft. Shown
+             regardless of the help preference since the draft can't proceed
+             without it. -->
+        <template v-for="city in cities">
+            <circle
+                v-if="canPickRegion(city)"
+                :key="city.name + '_pickRegion'"
+                class="canClick"
+                r="18"
+                :cx="city.x"
+                :cy="city.y"
+                fill="none"
+                stroke="gold"
+                stroke-width="5px"
+                @click="onCityClick(city)"
+            />
+        </template>
     </g>
 </template>
 
@@ -338,6 +357,8 @@ export default class Map extends Vue {
     @Prop() connections?: Connection[];
     @Prop() playerColors?: string[];
     @Prop() buildableCities?: string[];
+    // chooseRegions draft: region names the current player may pick this turn.
+    @Prop() pickableRegions?: string[];
     @Prop() devBackdrop?: { src: string; width: number; height: number; opacity?: number };
     @Prop({ default: 0 }) mapRotation!: number;
 
@@ -424,6 +445,23 @@ export default class Map extends Vue {
 
     build(city: City) {
         this.$emit('build', city);
+    }
+
+    canPickRegion(city: City) {
+        return !!this.pickableRegions && this.pickableRegions.includes(city.region);
+    }
+
+    pickRegion(city: City) {
+        this.$emit('pickRegion', city.region);
+    }
+
+    // During the region draft a city click picks its region; otherwise it builds.
+    onCityClick(city: City) {
+        if (this.canBuild(city)) {
+            this.build(city);
+        } else if (this.canPickRegion(city)) {
+            this.pickRegion(city);
+        }
     }
 
     onPickCoord(e: MouseEvent) {


### PR DESCRIPTION
## Summary
Adds a `chooseRegions` game option. When set, the regions in play are drafted by
the players at the start of the game — each picks a region in turn — instead of
the engine choosing them randomly during setup.

## Engine
- New `chooseRegions` option, `Phase.RegionSelection`, `ChooseRegion` move, and
  `regionDraft` state.
- `setup()` keeps the full map and enters the draft when the option is on and the
  map has more regions than are used (and isn't randomized). `finalizeRegions()`
  filters the map + applies regionalPowerPlants once the draft completes, then
  starts the auction with the starting player to move.
- Players draft in seating order, repeating until enough regions are chosen
  (2p → 1st, 2nd, 1st). Picks are restricted to regions that keep the board
  connected, reusing the random selector's exact rules — extracted into
  `computeRegionGraph` / `regionPickable` as a single source of truth — keeping
  the UK & Ireland (fresh-landmass) and Australia (any-region) exceptions.
- Bots/dropped players auto-pick a legal region.
- The random-selection path is rng-equivalent (all existing seeded setup tests
  unchanged). Adds tests for the draft flow, 2p wrap order, connectivity
  restriction, and replay determinism.

## Viewer
- During the draft, pickable regions are outlined in gold; clicking a city drafts
  its region. Status bar shows "Choose a region to play in (N of M)".

## Note
The new-game "other options" checkbox that sends `chooseRegions: true` is
configured on the boardgamers.space platform, not in this repo — the engine and
viewer here support the option once the site enables it.

## Test plan
- [x] `engine` tests pass (40), lint 0 errors, typecheck clean
- [x] `viewer` builds clean; region draft verified in the dev viewer (Germany 5p)