### PR TITLE
Manhattan: buying the discounted plant grants a second purchase

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -144,7 +144,10 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                             moves[MoveName.ChoosePowerPlant] = canBid.map((p) => p.number);
                         }
 
-                        if (G.round > 1) {
+                        // Round 1 forces every player to buy a plant — except a
+                        // Manhattan discount-bonus buyer, who may decline their extra
+                        // purchase (and must be able to, e.g. when nothing is affordable).
+                        if (G.round > 1 || G.discountBonusPlayer == player.id) {
                             moves[MoveName.Pass] = [true];
                         }
                     } else {

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1016,6 +1016,63 @@ describe('Engine', () => {
         );
     });
 
+    it('should grant a Manhattan discount buyer another purchase this phase (declinable in round 1)', () => {
+        let G = setup(2, { map: 'Manhattan', variant: 'recharged', randomizeMap: false }, 'manhattan-discount-bonus');
+        expect(G.phase, 'starts in Auction').to.equal(Phase.Auction);
+        expect(G.round, 'round 1').to.equal(1);
+        expect(G.plantDiscountActive, 'discount active at setup').to.be.true;
+
+        const buyer = G.currentPlayers[0];
+        const other = G.players.find((p) => p.id !== buyer)!.id;
+        const discounted = G.actualMarket[0].number;
+
+        // Take the discounted plant: choose it, open at the discount floor of 1,
+        // the other player passes the bid -> buyer wins it for 1.
+        G = move(G, { name: MoveName.ChoosePowerPlant, data: discounted } as Move, buyer);
+        G = move(G, { name: MoveName.Bid, data: 1 } as Move, buyer);
+        G = move(G, { name: MoveName.Pass, data: true } as Move, other);
+
+        expect(
+            G.players[buyer].powerPlants.map((p) => p.number),
+            'buyer got the discounted plant'
+        ).to.include(discounted);
+        // Buyer is owed the bonus purchase and is NOT yet done with the auction.
+        expect(G.discountBonusPlayer, 'buyer owed the bonus').to.equal(buyer);
+        expect(G.players[buyer].skipAuction, 'buyer still eligible').to.be.false;
+        expect(G.currentPlayers[0], 'buyer acts again').to.equal(buyer);
+
+        // The fix: round 1 normally forces a buy, but the bonus buyer may decline AND
+        // may buy another plant.
+        const bonusMoves = availableMoves(G, G.players[buyer]);
+        expect(bonusMoves[MoveName.Pass], 'bonus is declinable even in round 1').to.not.be.undefined;
+        expect(bonusMoves[MoveName.ChoosePowerPlant], 'bonus buyer may buy another plant').to.not.be.undefined;
+
+        // Decline it: buyer is now done, flag clears, the auction moves to the other player.
+        G = move(G, { name: MoveName.Pass, data: true } as Move, buyer);
+        expect(G.discountBonusPlayer, 'flag cleared on decline').to.be.undefined;
+        expect(G.players[buyer].skipAuction, 'buyer done after declining').to.be.true;
+        expect(G.currentPlayers[0], 'other player must still buy (round 1)').to.equal(other);
+    });
+
+    it('should NOT grant a bonus purchase for a non-discounted Manhattan buy', () => {
+        let G = setup(2, { map: 'Manhattan', variant: 'recharged', randomizeMap: false }, 'manhattan-no-bonus');
+        const buyer = G.currentPlayers[0];
+        const other = G.players.find((p) => p.id !== buyer)!.id;
+        // Choose a plant that is NOT the cheapest -> no discount applies.
+        const plant = G.actualMarket[1].number;
+
+        G = move(G, { name: MoveName.ChoosePowerPlant, data: plant } as Move, buyer);
+        G = move(G, { name: MoveName.Bid, data: plant } as Move, buyer);
+        G = move(G, { name: MoveName.Pass, data: true } as Move, other);
+
+        expect(
+            G.players[buyer].powerPlants.map((p) => p.number),
+            'buyer got the chosen plant'
+        ).to.include(plant);
+        expect(G.discountBonusPlayer, 'no bonus for a non-discounted buy').to.be.undefined;
+        expect(G.players[buyer].skipAuction, 'buyer done after a normal buy').to.be.true;
+    });
+
     it('should limit Bremen small districts to two networks', () => {
         const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-small-cap');
         G.phase = Phase.Building;

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -630,7 +630,13 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     setPlayerOrder(G);
                 }
 
-                if (
+                if (G.discountBonusPlayer != undefined) {
+                    // Manhattan: the buyer of the discounted plant gets another
+                    // purchase. They are still the only eligible bidder, so refill
+                    // the market and re-prompt them (they may also Pass to decline).
+                    addPowerPlant(G);
+                    setCurrentPlayer(G, G.discountBonusPlayer);
+                } else if (
                     countHeldPowerPlants(G, winningPlayer) <= 3 ||
                     (G.players.length == 2 && countHeldPowerPlants(G, winningPlayer) == 4)
                 ) {
@@ -730,6 +736,12 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 case Phase.Auction: {
                     if (G.chosenPowerPlant == undefined) {
                         player.skipAuction = true;
+
+                        // Manhattan: passing here declines the discount bonus purchase.
+                        if (G.discountBonusPlayer == player.id) {
+                            G.discountBonusPlayer = undefined;
+                        }
+
                         G.auctionSkips++;
                         if (G.auctionSkips == 1 && G.map.name == 'Russia' && G.actualMarket?.length > 0) {
                             G.log.push({
@@ -2681,6 +2693,8 @@ function toResourcesPhase(G: GameState) {
         p.skipAuction = false;
     });
 
+    G.discountBonusPlayer = undefined;
+
     if (G.options.variant == 'recharged') {
         if (G.plantDiscountActive) {
             G.plantDiscountActive = false;
@@ -2724,7 +2738,28 @@ function endAuction(G: GameState, winningPlayer: Player, bid: number) {
         winningPlayer.totalSpentPlants += bid;
     }
 
-    winningPlayer.skipAuction = true;
+    // Manhattan: buying the discounted power plant (whose minimum bid was lowered to
+    // 1) lets the buyer purchase one more plant this phase. Keep them eligible
+    // (skipAuction stays false) and remember they are owed the extra purchase, so
+    // they may also decline it via Pass even in round 1 — when buying is otherwise
+    // mandatory. minimunBid == 1 uniquely marks the discount auction (a normal bid
+    // floor is the plant number, always >= 3).
+    if (
+        G.map.name == 'Manhattan' &&
+        G.options.variant == 'recharged' &&
+        G.minimunBid == 1 &&
+        !winningPlayer.isDropped
+    ) {
+        G.discountBonusPlayer = winningPlayer.id;
+    } else {
+        winningPlayer.skipAuction = true;
+
+        // If this win was the bonus purchase itself, the buyer is now done.
+        if (G.discountBonusPlayer == winningPlayer.id) {
+            G.discountBonusPlayer = undefined;
+        }
+    }
+
     updatePlayerCapacity(winningPlayer);
 
     G.log.push({

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -196,6 +196,7 @@ export interface GameState {
     paymentTable: number[];
     minimunBid: number;
     plantDiscountActive: boolean;
+    discountBonusPlayer?: number; // Manhattan: id of the player who bought the discounted plant and may purchase one more this phase.
     discardSmallestPlant: boolean; // For Benelux map, there are times when we remove the smallest plant.
     nextCardWeak: boolean;
     cardsLeft: number;

--- a/engine/src/maps/manhattan.ts
+++ b/engine/src/maps/manhattan.ts
@@ -403,6 +403,7 @@ export const map: GameMap = {
         'players, some spaces are blocked at setup (4 players block 14 spaces; 2–3 ' +
         'players block 28). In the physical game the players mutually choose which ' +
         'spaces to block; here the system selects them automatically for your ' +
-        'convenience. The game ends when a player has connected 18 spaces ' +
-        '(17 for 3–4 players, 15 for 5, 14 for 6).',
+        'convenience. If you buy the discounted power plant you may purchase ' +
+        'another power plant during the same phase. The game ends when a player ' +
+        'has connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).',
 };


### PR DESCRIPTION
## What

Implements the Manhattan rule (RIO 686 Bremen/Manhattan expansion), Phase 2 — Auction Power Plants:

> If you buy the discounted power plant, you can purchase another power plant during this phase.

Reported from live play by Mike. The recharged "discount" (the cheapest plant in the market has its minimum bid lowered to 1) was already implemented; Manhattan's extra rule — buying that plant grants a second purchase the same phase — was not, so the buyer was sent straight on as if done.

## How

The auction already tracks whether each player is finished buying via `skipAuction`. The fix keeps the discount buyer eligible for one more turn rather than bolting on a parallel mechanism:

- **`gamestate.ts`** — new transient `discountBonusPlayer` (the id owed the extra purchase).
- **`endAuction`** — if the won plant was the discounted one (`minimunBid == 1` on Manhattan/recharged), record the buyer and leave `skipAuction` false; clear it once they buy again. Whoever **wins** the plant gets the bonus — initiator or an outbidder.
- **auto-win path** — the one branch that assumed the buyer was finished now refills the market and re-prompts them, instead of ending the phase. The contested and fast-bid paths already continue the auction for any still-eligible player, so they needed no change.
- **`available-moves.ts`** — round 1 normally forces every player to buy; the bonus buyer may `Pass` to decline (this also prevents a soft-lock if they cannot afford another plant, or the market is empty).
- Declining / phase-end clear the flag.

The second purchase is a normal auction (no further discount, no further bonus), so the bonus cannot chain.

## Tests

- 2 new specs: the bonus fires and is declinable in round 1; a non-discounted buy grants no bonus. Full engine suite green (**52/52**).
- `tsc --noEmit` and `eslint` clean (0 errors).
- Soak sweep (throwaway AI sim, 2–6P × 5 seeds = **25 full games**): the discount-bonus fires **1–7× per game**, every game ends cleanly in Step 1, the market lifecycle is intact, **zero soft-locks / move-cap hits**.
- Live-verified on a 2P game, covering both the **uncontested** auto-win path and a **contested** bonus auction where the opponent outbid the buyer for the second plant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
