### PR TITLE
Manhattan: fix discount-bonus double market refill + Step-1-only viewer cleanups

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1073,6 +1073,37 @@ describe('Engine', () => {
         expect(G.players[buyer].skipAuction, 'buyer done after a normal buy').to.be.true;
     });
 
+    it('should not grow the Manhattan market when a discount-bonus buy forces a discard', () => {
+        let G = setup(2, { map: 'Manhattan', variant: 'recharged', randomizeMap: false }, 'manhattan-overcap-bonus');
+        // Put player 0 at the 2P plant cap (4) with high plants that are NOT in the
+        // opening market, and make it their uncontested turn with the discount live.
+        // Buying the discounted plant pushes them to 5 -> forced discard.
+        const p0 = G.players[0];
+        p0.money = 100;
+        p0.powerPlants = [getPowerPlant(42), getPowerPlant(44), getPowerPlant(46), getPowerPlant(50)];
+        G.players[1].skipAuction = true;
+        G.plantDiscountActive = true;
+        G.round = 2;
+        G.currentPlayers = [0];
+        G.chosenPowerPlant = undefined;
+
+        const before = G.actualMarket.length + G.futureMarket.length;
+        const discounted = G.actualMarket[0].number;
+        G = move(G, { name: MoveName.ChoosePowerPlant, data: discounted } as Move, 0);
+
+        // Over the cap now -> must discard; the bonus is still owed.
+        expect(G.discountBonusPlayer, 'still owed the bonus after the discount buy').to.equal(0);
+        const discardable = (availableMoves(G, G.players[0])[MoveName.DiscardPowerPlant] ?? []) as number[];
+        expect(discardable.length, 'over the cap -> must discard a plant').to.be.greaterThan(0);
+
+        G = move(G, { name: MoveName.DiscardPowerPlant, data: discardable[0] } as Move, 0);
+
+        // The market must NOT have grown: one plant bought + one refilled = net zero.
+        // (Regression: the bonus branch used to refill here AND in the discard handler.)
+        expect(G.actualMarket.length + G.futureMarket.length, 'market unchanged by buy+discard').to.equal(before);
+        expect(G.discountBonusPlayer, 'bonus still owed after discarding').to.equal(0);
+    });
+
     it('should limit Bremen small districts to two networks', () => {
         const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-small-cap');
         G.phase = Phase.Building;

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -632,9 +632,18 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
 
                 if (G.discountBonusPlayer != undefined) {
                     // Manhattan: the buyer of the discounted plant gets another
-                    // purchase. They are still the only eligible bidder, so refill
-                    // the market and re-prompt them (they may also Pass to decline).
-                    addPowerPlant(G);
+                    // purchase. They are still the only eligible bidder, so re-prompt
+                    // them (they may also Pass to decline). Refill the market for the
+                    // plant they just took — UNLESS that purchase put them over the
+                    // plant limit: then they must discard first and the discard handler
+                    // does the refill, so refilling here too would draw a second plant
+                    // for one purchase and grow the market past 8.
+                    const overPlantLimit =
+                        countHeldPowerPlants(G, winningPlayer) > 4 ||
+                        (G.players.length > 2 && countHeldPowerPlants(G, winningPlayer) > 3);
+                    if (!overPlantLimit) {
+                        addPowerPlant(G);
+                    }
                     setCurrentPlayer(G, G.discountBonusPlayer);
                 } else if (
                     countHeldPowerPlants(G, winningPlayer) <= 3 ||

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -29,7 +29,7 @@
                 :transform="`translate(${G.map.cityCountPosition[0]}, ${G.map.cityCountPosition[1]})`"
                 :playerColors="playerColors"
                 :citiesToEndGame="G.citiesToEndGame"
-                :citiesToStep2="G.citiesToStep2"
+                :citiesToStep2="G.map.name === 'Manhattan' ? undefined : G.citiesToStep2"
             />
 
             <PowerPlantMarket
@@ -442,7 +442,7 @@
                                     <li>Bureaucracy: remove <strong>highest</strong> power plant from market</li>
                                 </ul>
                             </li>
-                            <li>
+                            <li v-if="G.map.name !== 'Manhattan'">
                                 <strong>Step 2:</strong>
                                 <ul>
                                     <li>
@@ -464,7 +464,7 @@
                                     <li>Bureaucracy: remove <strong>highest</strong> power plant from market</li>
                                 </ul>
                             </li>
-                            <li>
+                            <li v-if="G.map.name !== 'Manhattan'">
                                 <strong>Step 3:</strong>
                                 <ul>
                                     <li>Starts after the "Step 3" card is drawn from the deck</li>


### PR DESCRIPTION
## What

Follow-up to #99, fixing two issues Mike found playtesting the deployed Manhattan map.

### 1. Discount-bonus double market refill (engine)

Buying the **discounted** plant while already at the plant limit grew the power plant market from 8 to 9. The Site-1 auto-win bonus branch (added in #99) refilled the market unconditionally before re-prompting the buyer — but when that purchase pushes the buyer over the plant limit they must discard, and the **discard handler also refills**. Two draws for one purchase.

Fix: the bonus branch now refills only when the buy did **not** exceed the plant limit — mirroring the deferred-refill logic every other auction path already uses (the discard handler performs the refill in the over-limit case). Sites 2 & 3 (contested / fast-bid) were already correct.

From Mike's log (round 3): `wins ... pays $1` (discount plant) → `27 drawn` (bonus-branch refill) → `discards 3` (over the cap) → `29 drawn` (discard-handler refill) → market = 9.

### 2. Manhattan is Step-1-only, but the viewer showed Step 2/3 (viewer)

Manhattan runs only in Step 1 to the end, yet the city-count tracker outlined the **Step-2 threshold** tile (a dead default value of 10), and the rules modal listed **Step 2** and **Step 3** sections.

Fix: don't pass `citiesToStep2` to the tracker for Manhattan (the end-game marker still shows), and hide the Step 2 / Step 3 rules-modal sections for Manhattan. The map-specific rules already state the game stays in Step 1.

## Tests

- New regression spec: an over-cap discount buy keeps the market at 8 (fails before the fix). Full engine suite **53/53**, `tsc --noEmit` and `eslint` clean.
- Throwaway AI soak (2–6P × 5 seeds = 25 games) now also asserts a market-size invariant: **maxMarket 8 in every game**, discount-bonus still firing 1–7×/game, all ending cleanly in Step 1, zero soft-locks.
- Viewer: tracker re-screenshotted — no outline on 10, end-game 18 still marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
