### PR TITLE
Choose colors

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -5,6 +5,7 @@ import {
     isUraniumMine,
     Phase,
     Player,
+    playerColors,
     PowerPlantType,
     ResourceType,
 } from './gamestate';
@@ -35,6 +36,7 @@ export interface AvailableMoves {
         citiesPowered: number;
     }[];
     [MoveName.ChooseRegion]?: string[];
+    [MoveName.ChooseColor]?: string[];
     [MoveName.Pass]?: boolean[];
     [MoveName.Undo]?: boolean[];
 }
@@ -709,6 +711,14 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
             moves[MoveName.ChooseRegion] = graph.regions.filter((region) =>
                 regionPickable(G.map.name, graph, picked, region)
             );
+            break;
+        }
+
+        case Phase.ColorSelection: {
+            // Drafting player colors (chooseColors option): offer every palette
+            // color not already taken by an earlier picker.
+            const taken = G.colorDraft?.picked ?? [];
+            moves[MoveName.ChooseColor] = playerColors.filter((color) => !taken.includes(color));
             break;
         }
     }

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1379,4 +1379,83 @@ describe('Engine', () => {
         const builds3 = availableMoves(G, player)[MoveName.Build];
         expect(builds3, 'no further builds offered in round 1 after the jump is spent').to.be.undefined;
     });
+
+    it('should draft player colors when chooseColors is set, then start the auction', () => {
+        const numPlayers = 4;
+        const G0 = setup(numPlayers, { map: 'Germany', chooseColors: true, fastBid: false }, 'cc-seed');
+
+        expect(G0.phase).to.equal(Phase.ColorSelection);
+        expect(G0.colorDraft!.picked).to.deep.equal([]);
+        expect(G0.currentPlayers).to.deep.equal([0]);
+
+        // The first picker sees the full palette.
+        const firstOptions = G0.players[0].availableMoves![MoveName.ChooseColor]!;
+        expect(firstOptions.length).to.equal(6);
+
+        let G = G0;
+        const pickOrder: number[] = [];
+        const picks: string[] = [];
+        while (G.phase === Phase.ColorSelection) {
+            const picker = G.currentPlayers[0];
+            pickOrder.push(picker);
+            const options = G.players[picker].availableMoves![MoveName.ChooseColor]!;
+            // Already-taken colors are never offered again.
+            for (const taken of picks) expect(options).to.not.include(taken);
+            const color = options[0];
+            picks.push(color);
+            G = move(G, { name: MoveName.ChooseColor, data: color } as Move, picker);
+        }
+
+        // Each player picked exactly once, in seating order.
+        expect(pickOrder).to.deep.equal([0, 1, 2, 3]);
+        // Colors recorded per player and all distinct.
+        expect(G.players.map((p) => p.color)).to.deep.equal(picks);
+        expect(new Set(picks).size).to.equal(numPlayers);
+
+        // No region draft -> straight into a playable auction.
+        expect(G.phase).to.equal(Phase.Auction);
+        expect(G.colorDraft).to.be.undefined;
+        expect(G.currentPlayers).to.deep.equal([0]);
+        expect(G.players[0].availableMoves![MoveName.ChoosePowerPlant]).to.exist;
+    });
+
+    it('should leave colors unset and skip the color draft by default', () => {
+        const G = setup(4, { map: 'Germany', fastBid: false }, 'cc-default');
+        expect(G.phase).to.equal(Phase.Auction);
+        expect(G.colorDraft).to.be.undefined;
+        expect(G.players.every((p) => p.color === undefined)).to.be.true;
+    });
+
+    it('should run the color draft before the region draft when both options are set', () => {
+        const G0 = setup(3, { map: 'Germany', chooseColors: true, chooseRegions: true, fastBid: false }, 'cc-cr');
+        expect(G0.phase).to.equal(Phase.ColorSelection);
+        expect(G0.regionDraft, 'region draft is pending but inactive during the color draft').to.exist;
+        // Capture before play — move() mutates in place, so the draft clears this later.
+        const regionsNeeded = G0.regionDraft!.regionsNeeded;
+        const allRegions = new Set(G0.map.cities.map((c) => c.region));
+
+        let G = G0;
+        // Colors first.
+        while (G.phase === Phase.ColorSelection) {
+            const picker = G.currentPlayers[0];
+            const color = G.players[picker].availableMoves![MoveName.ChooseColor]![0];
+            G = move(G, { name: MoveName.ChooseColor, data: color } as Move, picker);
+        }
+
+        // Color draft hands off to the region draft, full map still intact.
+        expect(G.phase).to.equal(Phase.RegionSelection);
+        expect(G.players.every((p) => !!p.color)).to.be.true;
+        expect(new Set(G.map.cities.map((c) => c.region))).to.deep.equal(allRegions);
+
+        // Regions next.
+        while (G.phase === Phase.RegionSelection) {
+            const picker = G.currentPlayers[0];
+            const region = G.players[picker].availableMoves![MoveName.ChooseRegion]![0];
+            G = move(G, { name: MoveName.ChooseRegion, data: region } as Move, picker);
+        }
+
+        expect(G.phase).to.equal(Phase.Auction);
+        expect(new Set(G.map.cities.map((c) => c.region)).size).to.equal(regionsNeeded);
+        expect(G.players.every((p) => !!p.color)).to.be.true;
+    });
 });

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -9,6 +9,7 @@ import {
     isUraniumMine,
     Phase,
     Player,
+    playerColors,
     PowerPlant,
     PowerPlantType,
     ResourceType,
@@ -23,7 +24,9 @@ import prices from './prices';
 import { createRandomizedMap } from './randomizeMap';
 import { asserts, shuffle } from './utils';
 
-export const playerColors = ['limegreen', 'mediumorchid', 'red', 'dodgerblue', 'yellow', 'brown'];
+// Re-exported from gamestate (single source of truth) so existing importers that
+// reference engine.playerColors (e.g. the wrapper's factions()) keep working.
+export { playerColors };
 
 const citiesToStep2 = [10, 7, 7, 7, 6];
 const citiesToStep2BadenWurttemberg = [9, 6, 6, 6, 5];
@@ -109,6 +112,7 @@ export function setup(
         trackTotalSpent = true,
         randomizeMap = false,
         chooseRegions = false,
+        chooseColors = false,
     }: GameOptions,
     seed?: string,
     forceDeck?: PowerPlant[],
@@ -394,7 +398,16 @@ export function setup(
         auctioningPlayer: undefined,
         step: 1,
         phase: Phase.Auction,
-        options: { fastBid, map, variant, showMoney, useNewRechargedSetup, trackTotalSpent, chooseRegions },
+        options: {
+            fastBid,
+            map,
+            variant,
+            showMoney,
+            useNewRechargedSetup,
+            trackTotalSpent,
+            chooseRegions,
+            chooseColors,
+        },
         log: [],
         hiddenLog: [],
         seed,
@@ -460,6 +473,14 @@ export function setup(
     if (pendingRegionDraft) {
         G.phase = Phase.RegionSelection;
         G.regionDraft = pendingRegionDraft;
+    }
+
+    // chooseColors: players draft their colors first of all. The region draft (if
+    // any) stays pending in G.regionDraft and only activates once colors are done
+    // (see finalizeColors). The phase set here wins over RegionSelection above.
+    if (chooseColors) {
+        G.phase = Phase.ColorSelection;
+        G.colorDraft = { picked: [] };
     }
 
     if (G.map.blockSpaces) {
@@ -539,6 +560,19 @@ function finalizeRegions(G: GameState) {
     G.regionDraft = undefined;
     G.phase = Phase.Auction;
     G.currentPlayers = [G.playerOrder[0]];
+}
+
+// Completes the chooseColors draft once every player has a color. Hands off to the
+// region draft if one is still pending (chooseColors + chooseRegions), otherwise
+// straight to the auction with the starting player to move.
+function finalizeColors(G: GameState) {
+    G.colorDraft = undefined;
+    G.currentPlayers = [G.playerOrder[0]];
+    if (G.regionDraft) {
+        G.phase = Phase.RegionSelection;
+    } else {
+        G.phase = Phase.Auction;
+    }
 }
 
 export function stripSecret(G: GameState, player?: number): GameState {
@@ -723,6 +757,30 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 // Next picker, in seating order, wrapping around.
                 const order = G.playerOrder;
                 G.currentPlayers = [order[(order.indexOf(playerNumber) + 1) % order.length]];
+            }
+
+            break;
+        }
+
+        case MoveName.ChooseColor: {
+            asserts<Moves.MoveChooseColor>(move);
+
+            player.color = move.data;
+            G.colorDraft!.picked.push(move.data);
+
+            G.log.push({
+                type: 'move',
+                player: playerNumber,
+                move,
+                simple: `${player.name} chooses ${move.data}.`,
+                pretty: `${playerNameHTML(player)} chooses <b>${move.data}</b>.`,
+            });
+
+            if (G.colorDraft!.picked.length >= G.players.length) {
+                finalizeColors(G);
+            } else {
+                // Next picker, in seating order (each player picks exactly once).
+                G.currentPlayers = [G.playerOrder[G.colorDraft!.picked.length]];
             }
 
             break;
@@ -1985,6 +2043,14 @@ export function moveAI(G: GameState, playerNumber: number): GameState {
             break;
         }
 
+        case Phase.ColorSelection: {
+            if (availableMoves?.ChooseColor && availableMoves.ChooseColor.length > 0) {
+                chosenMove = { name: MoveName.ChooseColor, data: chooseRandom(availableMoves.ChooseColor) };
+            }
+
+            break;
+        }
+
         case Phase.Auction: {
             if (availableMoves?.ChoosePowerPlant) {
                 if (
@@ -2596,9 +2662,9 @@ function getBaseState(G: GameState): GameState {
 }
 
 function playerNameHTML(player) {
-    return `<span style="background-color: ${playerColors[player.id]}; font-weight: bold; padding: 0 3px;">${
-        player.name
-    }</span>`;
+    return `<span style="background-color: ${
+        player.color ?? playerColors[player.id]
+    }; font-weight: bold; padding: 0 3px;">${player.name}</span>`;
 }
 
 export function playersSortedByScore(G: GameState): Player[] {

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -3,6 +3,11 @@ import { LogItem } from './log';
 import { GameMap } from './maps';
 import { Move } from './move';
 
+// The default player palette, indexed by player id. Single source of truth: the
+// engine and (via factions / the chooseColors draft) the viewer both fall back to
+// this when a player has no explicitly chosen color.
+export const playerColors = ['limegreen', 'mediumorchid', 'red', 'dodgerblue', 'yellow', 'brown'];
+
 export type MapName =
     | 'USA'
     | 'Germany'
@@ -41,6 +46,9 @@ export interface GameOptions {
     // When set, the regions in play are drafted by the players at the start of
     // the game (each picks in turn) instead of being chosen randomly at setup.
     chooseRegions?: boolean;
+    // When set, each player picks their own color (in turn) at the start of the
+    // game instead of colors being assigned by seat. Runs before the region draft.
+    chooseColors?: boolean;
 }
 
 export enum ResourceType {
@@ -108,9 +116,13 @@ export interface Player {
     totalSpentResources: number;
     ranking?: number;
     usedFreeJump?: boolean;
+    // chooseColors: the color this player drafted. When unset, rendering falls
+    // back to the default palette entry for this player's id (playerColors[id]).
+    color?: string;
 }
 
 export enum Phase {
+    ColorSelection = 'Color Selection',
     RegionSelection = 'Region Selection',
     Order = 'Order',
     Auction = 'Auction',
@@ -181,7 +193,13 @@ export interface GameState {
     // Present only while phase == RegionSelection (chooseRegions option). Tracks
     // how many regions must be drafted and which have been picked so far. Cleared
     // once the draft completes and the map is filtered to the chosen regions.
+    // With chooseColors also on, this is populated at setup but stays inactive
+    // until the color draft finishes and the phase flips to RegionSelection.
     regionDraft?: { regionsNeeded: number; picked: string[] };
+    // Present only while phase == ColorSelection (chooseColors option). `picked`
+    // is the colors taken so far, in pick order; its length is also the seating
+    // index of the next picker. Cleared once every player has a color.
+    colorDraft?: { picked: string[] };
     options: GameOptions;
     log: LogItem[];
     hiddenLog: LogItem[];

--- a/engine/src/move.ts
+++ b/engine/src/move.ts
@@ -61,6 +61,11 @@ export declare namespace Moves {
         data: string;
     }
 
+    export interface MoveChooseColor {
+        name: MoveName.ChooseColor;
+        data: string;
+    }
+
     export interface MovePass {
         name: MoveName.Pass;
         data: true;
@@ -81,6 +86,7 @@ export type Move =
     | Moves.MoveBuild
     | Moves.MoveUsePowerPlant
     | Moves.MoveChooseRegion
+    | Moves.MoveChooseColor
     | Moves.MovePass
     | Moves.MoveUndo;
 
@@ -93,6 +99,7 @@ export enum MoveName {
     Build = 'Build',
     UsePowerPlant = 'UsePowerPlant',
     ChooseRegion = 'ChooseRegion',
+    ChooseColor = 'ChooseColor',
     Pass = 'Pass',
     Undo = 'Undo',
 }

--- a/engine/wrapper.ts
+++ b/engine/wrapper.ts
@@ -50,7 +50,7 @@ export function rankings(G: GameState): number[] {
 }
 
 export function factions(G: GameState): string[] {
-    return G.players.map((pl) => engine.playerColors[pl.id]);
+    return G.players.map((pl) => pl.color ?? engine.playerColors[pl.id]);
 }
 
 export function replay(G: GameState, { to = Infinity }: { to: number }): GameState {

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -308,6 +308,26 @@
             </div>
         </div>
 
+        <!-- chooseColors: shown on the current player's turn during the color draft.
+             No close button — picking a color is required to proceed. -->
+        <div v-if="G && canChooseColor()" class="modal visible">
+            <div class="modal-content">
+                <div class="modal-title">Choose your color</div>
+                <div class="confirm-message">Pick the color you'll play as.</div>
+                <div class="confirm-buttons">
+                    <button
+                        v-for="color in getChooseableColors()"
+                        :key="color"
+                        class="confirm-button"
+                        :style="`background-color: ${color}; color: white; text-shadow: 0 0 3px black;`"
+                        @click="chooseColor(color)"
+                    >
+                        {{ color }}
+                    </button>
+                </div>
+            </div>
+        </div>
+
         <div v-if="G && discardedPowerPlant" :class="['modal', { visible: discardVisible }]">
             <div class="modal-content">
                 <div class="modal-title">Discard Resources</div>
@@ -625,7 +645,19 @@ export default class Game extends Vue {
     G?: GameState | null = null;
     _futureState?: GameState;
 
-    playerColors = ['limegreen', 'mediumorchid', 'red', 'dodgerblue', 'yellow', 'brown'];
+    defaultPlayerColors = ['limegreen', 'mediumorchid', 'red', 'dodgerblue', 'yellow', 'brown'];
+
+    // Colors indexed by player id. Falls back to the default palette, but any color
+    // a player drafted via the chooseColors option overrides their default entry.
+    get playerColors() {
+        const colors = [...this.defaultPlayerColors];
+        if (this.G) {
+            for (const p of this.G.players) {
+                if (p.color) colors[p.id] = p.color;
+            }
+        }
+        return colors;
+    }
 
     animationQueue: Array<Function> = [];
 
@@ -1130,6 +1162,24 @@ export default class Game extends Vue {
         this.sendMove({ name: MoveName.ChooseRegion, data: region });
     }
 
+    canChooseColor() {
+        if (!this.canMove()) return false;
+
+        const currentPlayer = this.G!.players[this.player!];
+        return !!currentPlayer.availableMoves![MoveName.ChooseColor];
+    }
+
+    getChooseableColors(): string[] {
+        if (!this.canMove()) return [];
+
+        const currentPlayer = this.G!.players[this.player!];
+        return currentPlayer.availableMoves![MoveName.ChooseColor] || [];
+    }
+
+    chooseColor(color: string) {
+        this.sendMove({ name: MoveName.ChooseColor, data: color });
+    }
+
     playerHasUsedFreeJump(playerIndex: number): boolean {
         const player = this.G?.players[playerIndex];
         if (!player) return false;
@@ -1238,6 +1288,17 @@ export default class Game extends Vue {
     }
 
     getStatusMessage() {
+        // Color draft (chooseColors): prompt the current picker, even on the very
+        // first turn before any moves are in the log.
+        if (
+            this.G &&
+            this.G.phase == Phase.ColorSelection &&
+            this.player !== undefined &&
+            this.G.currentPlayers.includes(this.player)
+        ) {
+            return 'Choose your color.';
+        }
+
         // Region draft (chooseRegions): show the pick prompt to the current picker
         // even on the very first turn, before any moves are in the log.
         if (


### PR DESCRIPTION
## Summary
Adds a `chooseColors` game option. When set, each player picks their own color
(in seating order, one each) at the start of the game instead of colors being
assigned by seat.

## Engine
- New `chooseColors` option, `Phase.ColorSelection`, `ChooseColor` move,
  `colorDraft` state, and `Player.color`.
- The default palette moves to `gamestate.ts` as the single source of truth and is
  re-exported from `engine.ts` (`engine.playerColors` still works). `factions()`
  and the log name coloring use `player.color ?? playerColors[id]`, so a game
  without the option behaves exactly as before.
- `setup()` starts in `ColorSelection` when the option is on; `finalizeColors()`
  then hands off to the region draft if `chooseRegions` is also pending, otherwise
  to the auction — i.e. colors are drafted before regions when both are enabled.
- Bots/dropped players auto-pick a color.

## Viewer
- A color-swatch modal appears on the current player's turn; clicking a swatch
  drafts that color. `playerColors` is now a getter that overrides the default
  palette with each player's drafted color, so the board/houses/player boards
  render in the chosen colors.

## Notes
- Off by default: `Player.color` stays unset → default palette, unchanged behavior.
- The new-game "Choose colors" checkbox that sends `chooseColors: true` is
  configured on the boardgamers.space platform, not in this repo (same as
  `chooseRegions`).

## Test plan
- [x] engine tests pass (56; adds draft-flow, default-off, and colors+regions
      ordering cases), lint 0 errors, typecheck clean
- [x] viewer builds clean