### PR TITLE
Fix round 1 player order not updating after a contested/bonus auction

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1458,4 +1458,69 @@ describe('Engine', () => {
         expect(new Set(G.map.cities.map((c) => c.region)).size).to.equal(regionsNeeded);
         expect(G.players.every((p) => !!p.color)).to.be.true;
     });
+
+    it('should reorder players by plants after a contested round 1 auction (Manhattan)', () => {
+        // Regression (reported on ManhattanJune28): round-1 player order is set by the
+        // plants bought, but the reorder used to live only in the uncontested
+        // ChoosePowerPlant branch. Manhattan's discount-bonus purchase lets round 1
+        // finish via the contested/bonus completion path, which skipped the reorder
+        // and left the seating order [0,1,2,3,4]. This deterministic auction ends
+        // round 1 through that path; the reorder now happens in toResourcesPhase, the
+        // single funnel into the resources phase, so it always runs.
+        const moves: { player: number; move: Move }[] = [
+            { player: 0, move: { name: MoveName.ChoosePowerPlant, data: 3 } },
+            { player: 0, move: { name: MoveName.Bid, data: 1 } },
+            { player: 1, move: { name: MoveName.Pass, data: true } },
+            { player: 2, move: { name: MoveName.Bid, data: 2 } },
+            { player: 3, move: { name: MoveName.Bid, data: 3 } },
+            { player: 4, move: { name: MoveName.Pass, data: true } },
+            { player: 0, move: { name: MoveName.Pass, data: true } },
+            { player: 2, move: { name: MoveName.Bid, data: 4 } },
+            { player: 3, move: { name: MoveName.Bid, data: 5 } },
+            { player: 2, move: { name: MoveName.Pass, data: true } },
+            { player: 0, move: { name: MoveName.ChoosePowerPlant, data: 8 } },
+            { player: 0, move: { name: MoveName.Bid, data: 8 } },
+            { player: 1, move: { name: MoveName.Pass, data: true } },
+            { player: 2, move: { name: MoveName.Pass, data: true } },
+            { player: 3, move: { name: MoveName.Bid, data: 9 } },
+            { player: 4, move: { name: MoveName.Bid, data: 10 } },
+            { player: 0, move: { name: MoveName.Pass, data: true } },
+            { player: 3, move: { name: MoveName.Bid, data: 11 } },
+            { player: 4, move: { name: MoveName.Bid, data: 12 } },
+            { player: 3, move: { name: MoveName.Pass, data: true } },
+            { player: 0, move: { name: MoveName.ChoosePowerPlant, data: 9 } },
+            { player: 0, move: { name: MoveName.Bid, data: 9 } },
+            { player: 1, move: { name: MoveName.Bid, data: 10 } },
+            { player: 2, move: { name: MoveName.Pass, data: true } },
+            { player: 3, move: { name: MoveName.Pass, data: true } },
+            { player: 0, move: { name: MoveName.Pass, data: true } },
+            { player: 0, move: { name: MoveName.ChoosePowerPlant, data: 7 } },
+            { player: 0, move: { name: MoveName.Bid, data: 7 } },
+            { player: 2, move: { name: MoveName.Pass, data: true } },
+            { player: 3, move: { name: MoveName.Bid, data: 8 } },
+            { player: 0, move: { name: MoveName.Bid, data: 9 } },
+            { player: 3, move: { name: MoveName.Pass, data: true } },
+            { player: 2, move: { name: MoveName.ChoosePowerPlant, data: 10 } },
+            { player: 2, move: { name: MoveName.Bid, data: 10 } },
+            { player: 3, move: { name: MoveName.Bid, data: 11 } },
+            { player: 2, move: { name: MoveName.Bid, data: 12 } },
+            { player: 3, move: { name: MoveName.Pass, data: true } },
+            { player: 3, move: { name: MoveName.Pass, data: true } },
+        ];
+
+        let G = setup(5, { map: 'Manhattan', variant: 'recharged' }, 'cap1');
+        for (const m of moves) {
+            if (G.phase !== Phase.Auction) break;
+            G = move(G, m.move as Move, m.player);
+        }
+
+        expect(G.phase).to.equal(Phase.Resources);
+
+        // Round 1: no cities yet, so player order must be by largest plant descending
+        // — never the untouched seating order.
+        const largestPlant = G.playerOrder.map((id) => Math.max(...G.players[id].powerPlants.map((p) => p.number), -1));
+        expect(largestPlant).to.deep.equal([...largestPlant].sort((a, b) => b - a));
+        expect(G.playerOrder).to.not.deep.equal([0, 1, 2, 3, 4]);
+        expect(G.playerOrder).to.deep.equal([2, 1, 4, 0, 3]);
+    });
 });

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -660,10 +660,6 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 const winningPlayer = notPassed[0];
                 endAuction(G, winningPlayer, G.minimunBid);
 
-                if (G.round == 1) {
-                    setPlayerOrder(G);
-                }
-
                 if (G.discountBonusPlayer != undefined) {
                     // Manhattan: the buyer of the discounted plant gets another
                     // purchase. They are still the only eligible bidder, so re-prompt
@@ -2756,6 +2752,14 @@ function isValid(player: Player, powerPlants: PowerPlant[]) {
 function toResourcesPhase(G: GameState) {
     if (G.map.name == 'Baden-Württemberg') {
         // Baden-Württemberg: player order is determined AFTER the auction phase, every round.
+        setPlayerOrder(G);
+    } else if (G.round == 1) {
+        // Round 1 starts in seating order; once the auction ends, reorder by the
+        // plants just bought (there are no cities yet). Done here — the single funnel
+        // into the resources phase — so EVERY auction-completion path reorders, not
+        // just the uncontested ChoosePowerPlant branch. Contested bids and Manhattan's
+        // discount-bonus purchase otherwise reach this point with the seating order
+        // intact (e.g. the first player keeps moving first regardless of plants bought).
         setPlayerOrder(G);
     }
 


### PR DESCRIPTION
Round 1 starts in seating order and is reordered by the plants bought once the auction ends (there are no cities yet). That reorder lived only in the uncontested ChoosePowerPlant branch, so any round-1 auction that finished through another completion path kept the seating order. Manhattan's discount-bonus purchase makes this reachable in normal play: a buyer of the discounted plant stays eligible, so round 1 can end via the contested-bid / bonus path, and players were left in seating order instead of plant order (reported on ManhattanJune28).

Move the round-1 reorder into toResourcesPhase — the single funnel into the resources phase — so every auction-completion path reorders. Baden-Württemberg keeps its own every-round ordering there; later rounds are unaffected (their order is set at round start).

Adds a deterministic Manhattan regression test (a contested round-1 auction that previously left [0,1,2,3,4]) and confirms all existing full-game replays still pass.