### PR TITLE
Fix stale bid-calculator floor + AI discard picking illegal candidates

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -7,6 +7,7 @@ import {
     ended,
     getPowerPlant,
     move,
+    moveAI,
     reconstructState,
     setup,
 } from './engine';
@@ -524,6 +525,32 @@ describe('Engine', () => {
         expect(availableMoves(G, player)[MoveName.DiscardPowerPlant]).to.not.include(11);
     });
 
+    it('should have moveAI discard a legal candidate when a mine is held first', () => {
+        const G = setup(4, { map: 'Australia', variant: 'recharged', randomizeMap: false }, 'australia-ai-discard');
+        G.phase = Phase.Auction;
+        G.currentPlayers = [0];
+        const player = G.players[0];
+
+        // Mine 11 bought first, then four real plants: the over-limit discard
+        // prompt fires, but neither the mine nor the just-bought plant is a legal
+        // candidate. dropPlayer() auto-plays exactly this prompt through moveAI
+        // when a player times out, so an illegal AI pick throws in the drop path.
+        player.powerPlants = [
+            getPowerPlant(11),
+            getPowerPlant(19),
+            getPowerPlant(20),
+            getPowerPlant(22),
+            getPowerPlant(25),
+        ];
+        player.availableMoves = availableMoves(G, player);
+        const candidates = player.availableMoves[MoveName.DiscardPowerPlant]!;
+        expect(candidates, 'mine and just-bought plant are never candidates').to.deep.equal([19, 20, 22]);
+
+        const after = moveAI(G, 0);
+        const remaining = after.players[0].powerPlants.map((p) => p.number);
+        expect(remaining, 'discarded the weakest legal candidate').to.deep.equal([11, 20, 22, 25]);
+    });
+
     it('should not let Australia uranium mines power cities in Bureaucracy', () => {
         const G = setup(5, { map: 'Australia', variant: 'recharged', randomizeMap: false }, 'australia-mine-power');
         G.phase = Phase.Bureaucracy;
@@ -891,28 +918,43 @@ describe('Engine', () => {
         expect(G.powerPlantsDeck[G.powerPlantsDeck.length - 1].number, 'plant 10 rotated under the deck').to.equal(10);
 
         // Second depletion: deck empties again → the whole market becomes buyable
-        // (everything collapses into the actual market) and we stay in Step 1.
+        // (everything collapses into the actual market) and we stay in Step 1. The
+        // collapse must SORT the combined market: this is the "whole display is now
+        // buyable" moment, and a regression that skipped the sort would leave a plant
+        // out of order — the live-game symptom that prompted this guard (a smaller
+        // plant rendering after a larger one once everything became buyable). Seed an
+        // out-of-order input (future 5 behind actual's 8) so the assertion is real.
         G = base();
-        G.actualMarket = mkt(3, 4, 5);
-        G.futureMarket = mkt(8);
+        G.actualMarket = mkt(3, 4, 8);
+        G.futureMarket = mkt(5);
         G.powerPlantsDeck = [];
         G.manhattanRecyclePile = [];
         G.manhattanDepletion = 1;
         applyManhattanMarketLifecycle(G);
         expect(G.manhattanDepletion, 'second depletion → stage 2').to.equal(2);
         expect(G.futureMarket.length, 'no future market once all plants are buyable').to.equal(0);
-        expect(nums(G.actualMarket), 'every plant is in the buyable market').to.deep.equal([3, 4, 5, 8]);
+        expect(
+            G.actualMarket.map((p) => p.number),
+            'whole market is buyable AND sorted ascending (no out-of-order plant)'
+        ).to.deep.equal([3, 4, 5, 8]);
         expect(G.step, 'Manhattan never advances past Step 1').to.equal(1);
 
-        // Stage 2: each round boxes the single cheapest plant for the endgame churn.
+        // Stage 2: any straggler left in the future market collapses in (sorted),
+        // then the single cheapest plant is boxed for the endgame churn. Seed an
+        // out-of-order straggler (future 6 behind actual's 9) to guard the sort here
+        // too, and assert the surviving market stays in ascending order.
         G = base();
-        G.actualMarket = mkt(3, 4, 5, 6, 7, 8);
-        G.futureMarket = [];
+        G.actualMarket = mkt(3, 4, 5, 9);
+        G.futureMarket = mkt(6);
         G.powerPlantsDeck = [];
         G.manhattanDepletion = 2;
         applyManhattanMarketLifecycle(G);
         expect(G.manhattanDepletion, 'stage 2 is terminal').to.equal(2);
-        expect(nums(G.actualMarket), 'smallest plant (3) removed from the game').to.deep.equal([4, 5, 6, 7, 8]);
+        expect(G.futureMarket.length, 'stragglers collapse into the buyable market').to.equal(0);
+        expect(
+            G.actualMarket.map((p) => p.number),
+            'smallest plant (3) boxed; the rest stay sorted ascending'
+        ).to.deep.equal([4, 5, 6, 9]);
     });
 
     it('should block Manhattan spaces by player count, transitable but unbuildable', () => {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -2077,7 +2077,11 @@ export function moveAI(G: GameState, playerNumber: number): GameState {
                     chosenMove = { name: MoveName.Pass, data: true };
                 }
             } else if (availableMoves?.DiscardPowerPlant) {
-                chosenMove = { name: MoveName.DiscardPowerPlant, data: player.powerPlants[0].number };
+                // Pick from the offered candidates: the oldest-held plant can be an
+                // Australia uranium mine or the just-bought plant, neither of which
+                // is legal to discard — and dropPlayer() replays this prompt via
+                // moveAI, so an illegal pick would throw inside the drop path.
+                chosenMove = { name: MoveName.DiscardPowerPlant, data: Math.min(...availableMoves.DiscardPowerPlant) };
             } else if (availableMoves?.DiscardResources) {
                 chosenMove = { name: MoveName.DiscardResources, data: chooseRandom(availableMoves.DiscardResources) };
             }

--- a/viewer/src/components/Calculator.vue
+++ b/viewer/src/components/Calculator.vue
@@ -18,12 +18,12 @@
     </g>
 </template>
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 
 @Component({
     created(this: Calculator) {
         this.value = this.minValue;
-    }
+    },
 })
 export default class Calculator extends Vue {
     @Prop()
@@ -33,6 +33,13 @@ export default class Calculator extends Vue {
     maxValue;
 
     value: number = 0;
+
+    // The legal floor can rise while the calculator is open (e.g. a rival bid in a
+    // classic auction). Lift a stale value to the floor; never lower a dialed-in bid.
+    @Watch('minValue')
+    onMinValueChanged() {
+        this.value = Math.max(this.value, this.minValue);
+    }
 
     add() {
         this.value = Math.min(this.maxValue, this.value + 1);

--- a/viewer/src/components/boards/PowerPlantMarket.vue
+++ b/viewer/src/components/boards/PowerPlantMarket.vue
@@ -54,8 +54,11 @@
                 :targetState="{ x: chosenPowerPlant.x, y: chosenPowerPlant.y }"
                 :powerPlant="chosenPowerPlant.powerPlant"
             />
+            <!-- Keyed per plant so every auction gets a fresh calculator: a reused
+                 instance would keep displaying the previous auction's bid floor. -->
             <Calculator
                 v-if="canBid"
+                :key="'calc' + chosenPowerPlant.powerPlant.number"
                 :transform="`translate(${actualMarketWidth}, 80)`"
                 :minValue="minBid"
                 :maxValue="maxBid"
@@ -104,7 +107,7 @@ import Calculator from './../Calculator.vue';
 @Component({
     components: {
         Card,
-        Calculator
+        Calculator,
     },
 })
 export default class PowerPlantMarket extends Vue {
@@ -134,7 +137,7 @@ export default class PowerPlantMarket extends Vue {
                         id: 'actual_' + i,
                         x: 165 + i * 65,
                         y: 24,
-                        powerPlant: card
+                        powerPlant: card,
                     });
                 }
             } else {
@@ -143,7 +146,7 @@ export default class PowerPlantMarket extends Vue {
                         id: 'actual_' + i,
                         x: 165 + (i % 3) * 65,
                         y: i < 3 ? 24 : 80,
-                        powerPlant: card
+                        powerPlant: card,
                     });
                 }
             }
@@ -159,7 +162,7 @@ export default class PowerPlantMarket extends Vue {
                     id: 'future_' + i,
                     x: 165 + (i % 4) * 65,
                     y: 90 + Math.floor(i / 4) * 50,
-                    powerPlant: card
+                    powerPlant: card,
                 });
             }
         });
@@ -169,7 +172,7 @@ export default class PowerPlantMarket extends Vue {
                 id: 'chosen',
                 x: this.actualMarketWidth + 30,
                 y: 30,
-                powerPlant: gameState.chosenPowerPlant
+                powerPlant: gameState.chosenPowerPlant,
             };
         } else {
             this.chosenPowerPlant = null;


### PR DESCRIPTION
Two small, live-relevant auction fixes plus test hardening. Found while investigating a player report from `NorthernEuropeJune20` (fastBid) and a `randomizeMap` compatibility sweep.

## 1. Bid calculator could show the previous auction's floor (viewer)

**Report:** a player was prompted with **$24** pre-filled while **plant 26** was up for auction. $24 was the *previous* auction's floor (plant 24, sole-bidder win at face value — correct fastBid pricing).

**Cause:** `Calculator.vue` sets `value` once in `created()` and never follows `minValue`. When a client resumes from coalesced updates (async games, tab wake-ups), the bid panel can stay truthy across two auctions, so Vue reuses the component instance: the card shows the new plant, the visor still shows the old floor.

**Fix:** key the `Calculator` by the auctioned plant so every auction mounts a fresh instance, and `@Watch('minValue')` lifts a stale value up to the floor (also covers the classic-auction case where a rival outbids while the panel is open; it never lowers a higher bid the player already dialed in).

Display-only — the server always rejected such stale bids ("Wrong argument"), so no game state was ever corrupted.

## 2. moveAI discarded an illegal candidate → throw inside dropPlayer() (engine)

`moveAI` discarded `powerPlants[0]` blindly instead of choosing from the offered candidates. On **Australia** the oldest-held card is often a **uranium mine** (plant 11 is a natural first buy), and mines are never legal discard candidates (discarding one cannot resolve the over-limit condition). Since `wrapper.ts` `dropPlayer()` auto-plays a pending prompt through `moveAI` when a player times out, a player dropped at a forced-discard prompt threw `Wrong argument for the command DiscardPowerPlant` inside the platform drop path.

**Evidence:** 45-game AI sweep on the regular Australia board: **14/45 threw before the fix, 45/45 clean after.**

**Fix:** discard the smallest offered candidate. The new regression spec reproduces the dropPlayer scenario and fails on the unfixed engine with the exact live error.

## 3. Manhattan market sort-order guards (tests only)

Strengthened the two market-lifecycle specs to feed deliberately out-of-order inputs and assert the second-depletion collapse and stage-2 churn keep the buyable market sorted ascending — a tripwire for the out-of-order market observed live on June 24 (root cause still under investigation).

## Verification

- 58/58 engine specs (includes the full-game replay suites), `tsc --noEmit` clean, eslint 0 errors
- Viewer production build green; prettier (plugin invocation) clean
- Replay-safe for in-progress games: the viewer changes are display-only, and `moveAI` is never invoked when replaying logged moves — it only affects future drop/AI decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
