### PR TITLE
Fix Manhattan all-buyable market overlap; describe the deck cycle in the rules dialog

### DIFF
--- a/engine/src/maps/manhattan.ts
+++ b/engine/src/maps/manhattan.ts
@@ -404,6 +404,15 @@ export const map: GameMap = {
         'players block 28). In the physical game the players mutually choose which ' +
         'spaces to block; here the system selects them automatically for your ' +
         'convenience. If you buy the discounted power plant you may purchase ' +
-        'another power plant during the same phase. The game ends when a player ' +
-        'has connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).',
+        'another power plant during the same phase. Power plant market: during ' +
+        'each Bureaucracy phase the two highest plants of the future market are ' +
+        'placed on a discard pile and the market is refilled to 8 from the deck. ' +
+        'When the deck runs out for the first time, the discard pile is shuffled ' +
+        'and becomes the new deck; from then on, each Bureaucracy phase the ' +
+        'highest future-market plant is instead placed under the deck. When the ' +
+        'deck runs out for the second time, every plant in the whole market ' +
+        'becomes available for auction, and each Bureaucracy phase the lowest ' +
+        'plant is removed from the game. If the market is completely empty, no ' +
+        'more power plants can be bought. The game ends when a player has ' +
+        'connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).',
 };

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -459,7 +459,11 @@
                                         <strong>{{ G.map.uraniumMineResupply[G.players.length - 2][0] }}</strong>
                                         token(s) from the cheapest slots
                                     </li>
-                                    <li>Bureaucracy: remove <strong>highest</strong> power plant from market</li>
+                                    <li v-if="G.map.name === 'Manhattan'">
+                                        Bureaucracy: move the <strong>two highest</strong> future-market plants to the
+                                        discard pile (see Map Specific Rules for the full deck cycle)
+                                    </li>
+                                    <li v-else>Bureaucracy: remove <strong>highest</strong> power plant from market</li>
                                 </ul>
                             </li>
                             <li v-if="G.map.name !== 'Manhattan'">

--- a/viewer/src/components/boards/PowerPlantMarket.vue
+++ b/viewer/src/components/boards/PowerPlantMarket.vue
@@ -84,7 +84,7 @@
                     v-else
                     x="160"
                     y="5"
-                    width="200"
+                    :width="actualMarketHighlightWidth"
                     height="120"
                     fill="none"
                     stroke="blue"
@@ -126,10 +126,16 @@ export default class PowerPlantMarket extends Vue {
     futureMarketCards: Piece[] = [];
     chosenPowerPlant: Piece | null = null;
     actualMarketWidth: number = 430;
+    actualMarketHighlightWidth: number = 200;
 
     createPieces(gameState: GameState) {
         this.actualMarketWidth = gameState.map.actualMarketWidth ?? 430;
         this.actualMarketCards = [];
+        // Step 3 holds at most 6 plants (3+3), but Manhattan's second-depletion
+        // "whole market buyable" state keeps up to 8 in the actual market — wrap
+        // at 4 per row there so cards 7 and 8 don't paint on top of the second row.
+        const actualPerRow = gameState.actualMarket.length > 6 ? 4 : 3;
+        this.actualMarketHighlightWidth = 65 * Math.min(gameState.actualMarket.length, actualPerRow) + 5;
         gameState.actualMarket.forEach((card, i) => {
             if (gameState.futureMarket.length > 0) {
                 if (card.number != gameState.chosenPowerPlant?.number) {
@@ -144,8 +150,8 @@ export default class PowerPlantMarket extends Vue {
                 if (card.number != gameState.chosenPowerPlant?.number) {
                     this.actualMarketCards.push({
                         id: 'actual_' + i,
-                        x: 165 + (i % 3) * 65,
-                        y: i < 3 ? 24 : 80,
+                        x: 165 + (i % actualPerRow) * 65,
+                        y: 24 + Math.floor(i / actualPerRow) * 56,
                         powerPlant: card,
                     });
                 }


### PR DESCRIPTION
## What

Two Manhattan fixes from today's live games (`Redundant-witch-8891`, reported by goldjohn6 + Mike):

### 1. All-buyable market rendered plants on top of each other (viewer)

After *"The deck is empty for the second time — the entire market is now buyable"*, the market showed only **6 of its 8 plants**, apparently out of order:

```
shown:  27 37 39          stored (sorted, correct):
        46 50 44          27 37 39 40 42 44 46 50
```

The `futureMarket`-empty layout in `PowerPlantMarket.vue` assumed Step 3's 6-plant maximum: `x` wrapped modulo 3 and `y` was clamped to the second row. With Manhattan's 8-plant second-depletion market, cards 7 and 8 (the two **biggest** plants) painted exactly on top of cards 4 and 5 — so 40/42 were invisible under 46/50, and the visible second row read "46 50 44".

**This also explains the June-26 report** of the market showing "…46 50 44" with 44 seemingly misplaced: the engine market was correctly sorted the whole time, with two plants hidden by the same overlap. Verified against the stored game doc (`/api/gameplay/Redundant-witch-8891`): `actualMarket = 37,40,42,44,46,50` — sorted.

**Fix:** wrap at 4 per row when the actual market holds more than 6 plants, and size the blue choose-highlight to the row width. With ≤6 plants (every standard map's Step 3) the computed positions are byte-identical to the old code; the two-row actual/future branch is untouched.

### 2. Rules dialog said nothing about the Manhattan deck cycle

Requested by Mike: the dialog now describes the full market lifecycle in **Map Specific Rules** (Bureaucracy discard pile → first-depletion reshuffle → biggest future plant under the deck → second-depletion whole-market-buyable + smallest plant removed each round). The Step 1 summary line ("Bureaucracy: remove highest power plant from market") was wrong for Manhattan in every stage and is now Manhattan-aware.

## Verification

- Engine: 58/58 specs, tsc clean, lint 0 errors (engine change is display text only).
- Viewer compiles clean; visual check of a simulated post-collapse 8-plant market: two rows of 4, all plants visible and sorted, highlight covers all 8.
- Replay safety: viewer layout + inert rule strings only — no state-trajectory change for in-flight games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
