### PR TITLE
Start the Manhattan deck's next cycle the moment it runs dry mid-round

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -2,7 +2,9 @@ import { expect } from 'chai';
 import 'mocha';
 import { availableMoves, computeRegionGraph, regionPickable } from './available-moves';
 import {
+    addPowerPlant,
     applyAustraliaStep3Shift,
+    applyManhattanDepletionOnEmptyDeck,
     applyManhattanMarketLifecycle,
     ended,
     getPowerPlant,
@@ -955,6 +957,62 @@ describe('Engine', () => {
             G.actualMarket.map((p) => p.number),
             'smallest plant (3) boxed; the rest stay sorted ascending'
         ).to.deep.equal([4, 5, 6, 9]);
+    });
+
+    it('should start a fresh Manhattan deck mid-round when the draw deck runs dry in an auction', () => {
+        const mkt = (...nums: number[]): PowerPlant[] => nums.map((n) => getPowerPlant(n));
+        const base = () =>
+            setup(5, { map: 'Manhattan', variant: 'recharged', randomizeMap: false }, 'manhattan-midround-depletion');
+
+        // Reproduces ManhattanJune28 (Mike's report): stage 0, the deck is empty
+        // mid-auction with every big plant parked on the recycle pile, the buyable
+        // market decayed to three (the "top row") and four sitting in the future market
+        // (the "bottom row"). The next post-buy refill must NOT stall: it reshuffles the
+        // recycle pile into a fresh deck (first depletion → stage 1), draws the one owed
+        // replacement, and restores the cheapest-four-buyable split. Pre-fix addPowerPlant
+        // early-returned on the empty deck and left the market frozen — "the new deck
+        // should start, but it didn't."
+        let G = base();
+        G.actualMarket = mkt(19, 22, 23);
+        G.futureMarket = mkt(31, 33, 37, 38);
+        G.powerPlantsDeck = [];
+        G.manhattanRecyclePile = mkt(46, 35, 39, 36, 44, 42, 40, 34, 50, 32);
+        G.manhattanDepletion = 0;
+        G.plantDiscountActive = false;
+        addPowerPlant(G);
+        expect(G.manhattanDepletion, 'deck ran dry → first depletion fires mid-round').to.equal(1);
+        expect(G.manhattanRecyclePile!.length, 'recycle pile reshuffled into the deck').to.equal(0);
+        expect(G.powerPlantsDeck.length, 'fresh deck exists (10 recycled − 1 drawn)').to.equal(9);
+        expect(G.actualMarket.length + G.futureMarket.length, 'market refilled to 8').to.equal(8);
+        expect(G.actualMarket.length, 'cheapest four are buyable again').to.equal(4);
+
+        // Inert while the deck still has cards — no premature depletion.
+        G = base();
+        G.actualMarket = mkt(19, 22, 23, 31);
+        G.futureMarket = mkt(33, 37, 38);
+        G.powerPlantsDeck = mkt(40, 42);
+        G.manhattanRecyclePile = mkt(50);
+        G.manhattanDepletion = 0;
+        applyManhattanDepletionOnEmptyDeck(G);
+        expect(G.manhattanDepletion, 'deck still has cards → no depletion').to.equal(0);
+        expect(G.powerPlantsDeck.length, 'deck untouched').to.equal(2);
+        expect(G.manhattanRecyclePile!.length, 'recycle pile untouched').to.equal(1);
+
+        // Stage 1, empty deck, no recycle pile → second depletion mid-round: the whole
+        // market becomes buyable (sorted), exactly as the Bureaucracy path would do.
+        G = base();
+        G.actualMarket = mkt(22, 30, 40);
+        G.futureMarket = mkt(25);
+        G.powerPlantsDeck = [];
+        G.manhattanRecyclePile = [];
+        G.manhattanDepletion = 1;
+        applyManhattanDepletionOnEmptyDeck(G);
+        expect(G.manhattanDepletion, 'stage 1 empty deck → second depletion').to.equal(2);
+        expect(G.futureMarket.length, 'no future market once everything is buyable').to.equal(0);
+        expect(
+            G.actualMarket.map((p) => p.number),
+            'whole market buyable and sorted'
+        ).to.deep.equal([22, 25, 30, 40]);
     });
 
     it('should block Manhattan spaces by player count, transitable but unbuildable', () => {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -2232,7 +2232,18 @@ function updatePlayerCapacity(player: Player) {
     });
 }
 
-function addPowerPlant(G: GameState) {
+export function addPowerPlant(G: GameState): void {
+    // Manhattan: the draw deck can run dry mid-round during an auction, not only at
+    // Bureaucracy. Fire the depletion transition the instant it does, so the first
+    // depletion's reshuffle (or the second depletion's whole-market-buyable collapse)
+    // happens when it should instead of stalling the market until the end of the round
+    // — the "3 in the top row, 4 in the bottom, the new deck should start but it
+    // didn't" report on ManhattanJune28. The helper only reshuffles/collapses; the
+    // draw below still owns the single post-buy refill, so the market can't double-fill.
+    if (G.map.name == 'Manhattan' && G.powerPlantsDeck.length == 0) {
+        applyManhattanDepletionOnEmptyDeck(G);
+    }
+
     let powerPlant = G.powerPlantsDeck.shift();
 
     if (powerPlant) {
@@ -2477,6 +2488,43 @@ export function applyManhattanMarketLifecycle(G: GameState) {
                 event: `Removing the smallest plant, Power Plant ${removed.number}, from the game.`,
             });
         }
+    }
+}
+
+// Fire Manhattan's deck-depletion transition the instant the draw deck runs dry,
+// wherever that happens — in particular during an auction purchase's refill, not
+// only the Bureaucracy lifecycle above. It mirrors the two depletion arms of
+// applyManhattanMarketLifecycle:
+//   • first depletion  (stage 0, a recycle pile exists) → reshuffle that pile into a
+//     fresh deck and advance to stage 1; the caller's own draw then refills the market.
+//   • second depletion (stage 1) → collapse the whole market into the buyable (actual)
+//     market, sorted, and advance to stage 2; no deck remains to draw from.
+// Unlike the Bureaucracy path it deliberately does NOT draw/refill — the sole caller
+// (addPowerPlant) owns the single post-buy draw, so the market cannot double-fill.
+export function applyManhattanDepletionOnEmptyDeck(G: GameState): void {
+    if (G.map.name != 'Manhattan' || G.powerPlantsDeck.length > 0) {
+        return;
+    }
+    G.manhattanRecyclePile ??= [];
+    G.manhattanDepletion ??= 0;
+
+    if (G.manhattanDepletion == 0 && G.manhattanRecyclePile.length > 0) {
+        G.powerPlantsDeck = shuffle(G.manhattanRecyclePile, G.seed + ':manhattan-depletion-1');
+        G.manhattanRecyclePile = [];
+        G.manhattanDepletion = 1;
+        G.log.push({
+            type: 'event',
+            event: 'The draw deck is empty — reshuffling the recycle pile into a new deck.',
+        });
+    } else if (G.manhattanDepletion == 1) {
+        G.manhattanDepletion = 2;
+        const market = [...G.actualMarket, ...G.futureMarket].sort((a, b) => a.number - b.number);
+        G.actualMarket = market;
+        G.futureMarket = [];
+        G.log.push({
+            type: 'event',
+            event: 'The deck is empty for the second time — the entire market is now buyable.',
+        });
     }
 }
 


### PR DESCRIPTION
## The bug

Manhattan's power-plant market runs on **deck depletions**, not step changes. The two depletion transitions —

1. **first depletion:** deck runs dry → reshuffle the recycle pile into a fresh deck (stage 0 → 1)
2. **second depletion:** deck runs dry again → the whole market becomes buyable (stage 1 → 2)

— only ran inside the **Bureaucracy** lifecycle (`applyManhattanMarketLifecycle`). But a Manhattan deck routinely runs dry *mid-round*, during the auction, as players buy plants faster than the two-per-round drain. When that happened the market **stalled**: no reshuffle fired, the buyable (`actualMarket`) market decayed below four as each win removed a plant with no replacement, and every big plant stayed stranded on the recycle pile until the end of the round.

Mike reported it on **ManhattanJune28**:

> 3 plants in the top row and 4 in the bottom row — the new deck should start, but it didn't. That bug may persist in the current version.

He's exactly right. `/api/gameplay/ManhattanJune28` confirmed the stored state: stage 0, `powerPlantsDeck` empty, ten plants (32–50) parked on `manhattanRecyclePile`, and players offered a **two-plant** buyable market — `actualMarket [22,23]`, `futureMarket [31,33,37,38]`. It isn't a soft-lock (the game recovers at the next Bureaucracy), but players are stuck bidding on a decayed market for the rest of the round — enough that four of them voted to cancel.

## The fix

Fire the depletion transition the instant the deck empties, from the auction refill path (`addPowerPlant`) rather than only at Bureaucracy. A small helper, `applyManhattanDepletionOnEmptyDeck`, reshuffles (first depletion) or collapses the market (second depletion) and **deliberately does not draw** — `addPowerPlant` still owns the single post-buy refill, so the market cannot double-fill (the class of bug fixed in #100).

- `applyManhattanMarketLifecycle` is **untouched** and stays the backstop for a deck that empties during its own peel/refill.
- Manhattan's Bureaucracy routes *exclusively* through the lifecycle helper, so the new trigger only ever fires during auction buys — no double-fire.
- Manhattan-gated throughout; no other map reaches Step-3-less deck exhaustion, so nothing else changes.

## Testing

- **Regression test** (`should start a fresh Manhattan deck mid-round…`) replicates June28's exact market and is teeth-checked: it fails without the fix (the reshuffle never fires, `manhattanDepletion` stays 0) and passes with it. Also covers the stage-1 → 2 mid-round collapse and the deck-still-has-cards no-op.
- **25-game AI soak** with a buyable-market *choice-point* invariant: **8–10 stalls per run → 0**, all games still end cleanly, the market never exceeds 8. Pre-fix the soak reproduced June28's exact `2/6 market, deck 0, recycle 12` stuck state.
- `tsc --noEmit` clean · `npm test` 59 passing · `eslint` 0 errors.

## Deploy note ⚠️

This changes the replayed **trajectory** of a Manhattan game (the reshuffle now fires earlier), so it's the same class as #102: please **duplicate `powergrid` to the next descriptor version** and point that at the new engine/viewer, leaving in-progress games on their current version. It will **not** retroactively fix ManhattanJune28 / Manhattanredo — they're pinned to descriptor v4 (engine 1.15.10) and stay there. This protects everyone's *next* Manhattan game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
