### PR TITLE
Bremen: spell out deck preparation in the rules dialog

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -740,6 +740,40 @@ describe('Engine', () => {
         expect(G.garbageMarket, 'Bremen garbage fills $3–$8').to.equal(16);
     });
 
+    it('should build the Bremen deck: eight low plants to the market, one on top, the rest shuffled in', () => {
+        // Players asked whether Bremen was stacking every low ("plug") plant on top of
+        // the deck. It follows the recharged setup: eight open the market, one is
+        // placed on top of the deck and the leftovers are shuffled into it. This pins
+        // that structure — and that the leftovers really do land all over the deck.
+        const leftoverPositions = new Set<number>();
+        for (const pc of [2, 3, 4, 5, 6]) {
+            for (const seed of ['a', 'b', 'c', 'd']) {
+                const G = setup(
+                    pc,
+                    { map: 'Bremen', variant: 'recharged', randomizeMap: false },
+                    `bremen-plugs-${pc}-${seed}`
+                );
+                const market = [...G.actualMarket, ...G.futureMarket];
+                const deck = G.powerPlantsDeck.map((p) => p.number);
+                expect(market.length, `Bremen ${pc}P: opening market of 8`).to.equal(8);
+                expect(
+                    market.every((p) => p.number <= 15),
+                    `Bremen ${pc}P: market is low plants`
+                ).to.be.true;
+                expect(deck[deck.length - 1], `Bremen ${pc}P: Step 3 on the bottom`).to.equal(99);
+                // No player-count reduction beyond Bremen's own removals (9, plus 31
+                // and 50 for 2–4 players).
+                expect(market.length + deck.length, `Bremen ${pc}P: deck size`).to.equal(
+                    powerPlants.length - (pc <= 4 ? 11 : 9)
+                );
+                const low = deck.map((n, i) => (n <= 15 ? i : -1)).filter((i) => i >= 0);
+                expect(low[0], `Bremen ${pc}P: one low plant guaranteed on top`).to.equal(0);
+                low.slice(1).forEach((i) => leftoverPositions.add(i));
+            }
+        }
+        expect(leftoverPositions.size, 'leftover low plants are spread through the deck').to.be.greaterThan(5);
+    });
+
     it('should price Bremen builds by summed district costs (node-weighted, asymmetric)', () => {
         // 5P so all five regions (all 25 districts) are in play.
         const G = setup(5, { map: 'Bremen', variant: 'recharged', randomizeMap: false }, 'bremen-build-cost');

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -220,9 +220,11 @@ export const map: GameMap = {
     startingResources: [22, 16, 16, 0],
     startingSupply: [22, 22, 22, 0],
     // Bremen plays with fewer power plants. Remove 11, 17, 23, 28, 34, 36, 38, 39,
-    // 46 (this includes every nuclear plant); 2–4 players also remove 31 and 50.
-    // The opening market is then drawn from the remaining "weak" pool (≤15) per the
-    // recharged convention, and NO further player-count deck reduction is applied.
+    // 46 — every uranium-burning plant (11/17/23/28/34/39) plus the three plants that
+    // power 7 cities (36/38/46); 2–4 players also remove 31 and 50. The opening
+    // market is then drawn from the remaining "weak" pool (≤15) per the recharged
+    // convention — 8 open the market, one goes on top of the deck and the leftovers
+    // are shuffled in — and NO further player-count deck reduction is applied.
     setupDeck(numPlayers: number, variant: string, rng: seedrandom.prng) {
         const removed = new Set([11, 17, 23, 28, 34, 36, 38, 39, 46]);
         if (numPlayers <= 4) {
@@ -272,8 +274,17 @@ export const map: GameMap = {
         'through), plus the cheapest building cost (8 / 14 / 20 Elektro) in the new ' +
         'district. (on your 1st placement if A has 1 and B has 3 then A to B is ' +
         '8+3+8=19, and B to A is 8+1+8=17, meaning it is asymmetrical) Small ' +
-        'districts have only two spaces (8 / 14) and can hold just two networks. ' +
-        'No nuclear: nuclear power plants and uranium are not used. Step 2 ' +
-        'begins once a player has 5 connected districts (4 for 6 players); the game ' +
-        'ends when a player connects 13 districts (12 for 5 players, 11 for 6).',
+        'districts have only two spaces (8 / 14) and can hold just two networks.\n' +
+        'No uranium: uranium is never sold, and every plant that burns it is removed ' +
+        'from the game. Plant 50 needs no fuel, so it stays in the deck with 5 or 6 ' +
+        'players.\n' +
+        'Deck preparation: power plants 11, 17, 23, 28, 34, 36, 38, 39 and 46 are ' +
+        'removed before setup — the six uranium plants plus the three plants that ' +
+        'power 7 cities. With 2 to 4 players, plants 31 and 50 are removed as well. ' +
+        'No further power plants are removed for the number of players. The opening ' +
+        'market of eight is then drawn from the low plants (numbered 15 or less); of ' +
+        'the low plants left over, one is placed on top of the draw deck and the rest ' +
+        'are shuffled into it, with the Step 3 card on the bottom.\n' +
+        'Step 2 begins once a player has 5 connected districts (4 for 6 players); the ' +
+        'game ends when a player connects 13 districts (12 for 5 players, 11 for 6).',
 };


### PR DESCRIPTION
Bremen's rules dialog never described deck preparation. Two reports came in from live play:

- **"There should be a comment that the 7 plants are removed."** Bremen boxes nine plants before setup and the dialog only mentioned the nuclear ones.
- **"Top of deck = every plug card?"** — in a live 5P game (`BremenJuly20`) the opening market of eight low plants was followed by the deck's next four cards *also* being low plants, so every low plant was seen in round 1 with none left to come.

## The deck was fine

Verified before changing anything, two ways:

1. **Replayed two finished live games from their revealed seeds** (`BremenJuly18` 4P, `BremenJune15` 5P) against this engine. The setup deck comes out **card for card identical** to the live draw order — all 24 and 26 cards, diverging only where the Step 3 card is logged differently. In both, the leftover low plants sat at deck positions 0/13/20/22 and 0/10/11/21, i.e. shuffled through the deck as intended.
2. **Monte Carlo, 50,000 setups per player count.** The opening market is always eight low plants; exactly one low plant is always on top of the deck (by design — the recharged setup); the rest are uniformly distributed (flat histogram across all 22/24 shuffled slots). The observed rate of "all leftovers in the very next slots" is 0.038% at 5P against a theoretical 0.049% — **1 in 2024**, which is exactly the odds one of the reporters worked out by hand. It was luck, not a bug.

## What this changes

Nothing mechanical — the engine diff is inert strings plus a new spec.

- **`mapSpecificRules`** gains a **Deck preparation** paragraph: the nine removed plants named (the six uranium plants plus the three that power 7 cities), plus 31 and 50 for 2–4 players; that no further plants are removed for the player count; and the market/deck structure — eight low plants open the market, one goes on top of the deck, the rest are shuffled in, Step 3 on the bottom.
- **The uranium line is corrected.** It said "nuclear power plants and uranium are not used", but plant 50 burns no fuel and stays in the deck with 5–6 players (confirmed in the live `BremenJune15` deck). It now says so.
- The text is split into paragraphs; the dialog already renders `mapSpecificRules` with `white-space: pre-wrap`, the same way Japan's multi-line rules do.

## Coverage

New spec `should build the Bremen deck: eight low plants to the market, one on top, the rest shuffled in` runs every player count × four seeds and pins: market of eight low plants, exactly one low plant guaranteed on top, leftovers spread through the deck, Step 3 on the bottom, and total deck size showing no extra player-count reduction.

Teeth-checked — stacking the leftovers on top instead of shuffling them in makes it fail (`3` distinct positions instead of `> 5`).

`tsc` clean, **65 engine specs passing**, `npm run lint` 0 errors.

Note: `mapSpecificRules` is part of the stored game state, so the new text appears in games created after the bump, not in ones already in flight.
