### PR TITLE
Mark the no-nuclear regions on the other restricted maps

### DIFF
--- a/engine/src/maps/northerneurope.ts
+++ b/engine/src/maps/northerneurope.ts
@@ -58,6 +58,9 @@ export enum Cities {
 
 export const map: GameMap = {
     name: 'Northern Europe',
+    // Nuclear plants are banned in Norway (red) and Denmark (orange) — see the
+    // restriction in available-moves. The viewer draws the struck-through markers.
+    noUraniumRegions: [Regions.Red, Regions.Orange],
     cities: [
         { name: Cities.Oulu, region: Regions.Brown, x: 514, y: 376 },
         { name: Cities.Kuopid, region: Regions.Brown, x: 551, y: 474 },

--- a/engine/src/maps/spainportugal.ts
+++ b/engine/src/maps/spainportugal.ts
@@ -61,6 +61,9 @@ export enum Cities {
 
 export const map: GameMap = {
     name: 'Spain & Portugal',
+    // Nuclear plants are banned in Portugal (yellow) — see the restriction in
+    // available-moves. The viewer draws the struck-through nuclear marker there.
+    noUraniumRegions: [Regions.Yellow],
     cities: [
         { name: Cities.Evora, region: Regions.Yellow, x: 890, y: 1780 },
         { name: Cities.Faro, region: Regions.Yellow, x: 822, y: 2348 },

--- a/engine/src/maps/ukireland.ts
+++ b/engine/src/maps/ukireland.ts
@@ -61,6 +61,9 @@ export enum Cities {
 
 export const map: GameMap = {
     name: 'UK & Ireland',
+    // Nuclear plants are banned in the Republic of Ireland (green) — see the
+    // restriction in available-moves. The viewer draws the struck-through marker.
+    noUraniumRegions: [Regions.Green],
     cities: [
         { name: Cities.Norwich, region: Regions.Red, island: 'gb', x: 646, y: 702 },
         { name: Cities.London1, region: Regions.Red, island: 'gb', x: 554, y: 756 },


### PR DESCRIPTION
Central Europe already shows the struck-through nuclear marker; extend it to the other maps that ban nuclear plants in some regions, by setting the generic noUraniumRegions field the viewer already renders:

- Spain & Portugal: yellow (Portugal)
- UK & Ireland: green (Republic of Ireland)
- Northern Europe: red (Norway), orange (Denmark)

Each list is the complement of the nuclear-allowed regions enforced per-map in available-moves, cross-referenced in comments. No rendering changes — the marker placement is the same generic, self-adjusting logic added with Central Europe.