### PR TITLE
feat: export moveAI for bot players

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -1,5 +1,5 @@
 export { availableMoves, AvailableMoves } from './src/available-moves';
-export { currentPlayers, ended, move, playersSortedByScore, reconstructState, setup, stripSecret } from './src/engine';
+export { currentPlayers, ended, move, moveAI, playersSortedByScore, reconstructState, setup, stripSecret } from './src/engine';
 export { Phase } from './src/gamestate';
 export type { GameState, Player } from './src/gamestate';
 export { LogItem } from './src/log';

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -1,5 +1,14 @@
 export { availableMoves, AvailableMoves } from './src/available-moves';
-export { currentPlayers, ended, move, moveAI, playersSortedByScore, reconstructState, setup, stripSecret } from './src/engine';
+export {
+    currentPlayers,
+    ended,
+    move,
+    moveAI,
+    playersSortedByScore,
+    reconstructState,
+    setup,
+    stripSecret,
+} from './src/engine';
 export { Phase } from './src/gamestate';
 export type { GameState, Player } from './src/gamestate';
 export { LogItem } from './src/log';

--- a/engine/wrapper.ts
+++ b/engine/wrapper.ts
@@ -27,7 +27,7 @@ export async function move(G: GameState, move: Move, player: number): Promise<Ga
     return G;
 }
 
-export { ended, scores, stripSecret } from './src/engine';
+export { ended, moveAI, scores, stripSecret } from './src/engine';
 
 export function rankings(G: GameState): number[] {
     const sortedPlayers = playersSortedByScore(G);


### PR DESCRIPTION
## Summary

- Re-export `moveAI(G, playerNumber)` (already defined in `engine/src/engine.ts`, used by `dropPlayer` to auto-play dropped players) from the engine package entry `engine/index.ts`, alongside `move`.
- Also re-export it from the platform adapter `engine/wrapper.ts` so the Boardgamers game-server can drive bot players via its optional `Engine.moveAI` hook (`moveAI?(data, player): Promise<GameData> | GameData`).

## Verification

- `pnpm run build` ✅ (`dist/index.js` / `dist/index.d.ts` contain `moveAI`)
- `pnpm run lint` ✅ (0 errors; the 11 warnings are pre-existing)
- `pnpm run test` ✅ (65 passing)
- Confirmed `moveAI` is importable as a function from both `powergrid-engine` entry and `wrapper.ts` via a ts-node smoke test.