### PR TITLE
Add "Deck build" setup text to map rules; India original: random top card

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -368,6 +368,25 @@ describe('Engine', () => {
         expect(G.powerPlantsDeck[step3Idx + 2].number).to.not.equal(99);
     });
 
+    it('should start the India original deck with a random plant on top', () => {
+        // India removes plant 11 from the game, so the old code's splice(2, 1)
+        // — written for the standard list where index 2 is plant 13 — landed on
+        // plant 14 and pinned it to the top of every deck. The rule (Mike,
+        // 2026-08-13) is that India sets NO plant aside: a random plant starts
+        // on top. Pre-fix this sweep sees plant 14 on top for every seed.
+        const tops = new Set<number>();
+        for (let seed = 0; seed < 10; seed++) {
+            const G = setup(4, { map: 'India', variant: 'original', randomizeMap: false }, `india-top-${seed}`);
+            expect(
+                G.powerPlantsDeck.some((p) => p.number == 11),
+                'plant 11 must stay removed'
+            ).to.be.false;
+            expect(G.powerPlantsDeck[G.powerPlantsDeck.length - 1].number, 'Step 3 stays on the bottom').to.equal(99);
+            tops.add(G.powerPlantsDeck[0].number);
+        }
+        expect(tops.size, `top cards across seeds: ${[...tops].join(',')}`).to.be.greaterThan(1);
+    });
+
     it('should never strand a UK & Ireland region from the rest of its landmass', () => {
         // The region picker may split Great Britain from Ireland (no sea edge —
         // the cross-island surcharge bridges them), but the regions chosen WITHIN

--- a/engine/src/maps/australia.ts
+++ b/engine/src/maps/australia.ts
@@ -285,5 +285,8 @@ export const map: GameMap = {
         'times in one turn. ' +
         'Metropolises: Melbourne and Sydney each consist of two cities (1 and 2) ' +
         'connected by a 0-cost edge. ' +
-        'Regions need not be adjacent: any combination of regions may be in play.',
+        'Regions need not be adjacent: any combination of regions may be in play.\n' +
+        'Deck build - power plant 17 is removed from the game; the five uranium ' +
+        'mines (11, 23, 28, 34, 39) stay in the deck. Otherwise standard setup ' +
+        'for both variants.',
 };

--- a/engine/src/maps/brazil.ts
+++ b/engine/src/maps/brazil.ts
@@ -306,5 +306,13 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules: 'Play with all garbage power plants.',
+    mapSpecificRules:
+        'Play with all garbage power plants.\n' +
+        'Deck build recharged - power plants 6 and 14 always start in the ' +
+        'market; the other six market plants are drawn from the remaining low ' +
+        'plants. Garbage plants above 14 are set aside during the player-count ' +
+        'removal and shuffled back in, so no garbage plant ever leaves the game.\n' +
+        'Deck build original - both 13 and 14 are set aside; after the ' +
+        'player-count removal (garbage plants excluded and shuffled back in), ' +
+        '13 goes on top of the deck with 14 directly below it.',
 };

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -278,13 +278,16 @@ export const map: GameMap = {
         'No uranium: uranium is never sold, and every plant that burns it is removed ' +
         'from the game. Plant 50 needs no fuel, so it stays in the deck with 5 or 6 ' +
         'players.\n' +
-        'Deck preparation: power plants 11, 17, 23, 28, 34, 36, 38, 39 and 46 are ' +
-        'removed before setup — the six uranium plants plus the three plants that ' +
-        'power 7 cities. With 2 to 4 players, plants 31 and 50 are removed as well. ' +
-        'No further power plants are removed for the number of players. The opening ' +
-        'market of eight is then drawn from the low plants (numbered 15 or less); of ' +
-        'the low plants left over, one is placed on top of the draw deck and the rest ' +
-        'are shuffled into it, with the Step 3 card on the bottom.\n' +
         'Step 2 begins once a player has 5 connected districts (4 for 6 players); the ' +
-        'game ends when a player connects 13 districts (12 for 5 players, 11 for 6).',
+        'game ends when a player connects 13 districts (12 for 5 players, 11 for 6).\n' +
+        'Deck build recharged - power plants 11, 17, 23, 28, 34, 36, 38, 39 and 46 ' +
+        'are removed before setup — the six uranium plants plus the three plants ' +
+        'that power 7 cities. With 2 to 4 players, plants 31 and 50 are removed as ' +
+        'well. No further power plants are removed for the number of players. The ' +
+        'opening market of eight is then drawn from the low plants (numbered 15 or ' +
+        'less); of the low plants left over, one is placed on top of the draw deck ' +
+        'and the rest are shuffled into it, with the Step 3 card on the bottom.\n' +
+        'Deck build original - same removals; the market is the fixed 3-6 / 7-10 ' +
+        '(none of these are removed on Bremen), plant 13 is placed on top of the ' +
+        'deck and the Step 3 card on the bottom.',
 };

--- a/engine/src/maps/china.ts
+++ b/engine/src/maps/china.ts
@@ -264,5 +264,12 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'The power plant deck is arranged as follows: plants from 3-30 in order, plants from 31-35 and step 3 card shuffled, plants from 36-50 shuffled.\nThe same set of plants are removed in every game.\nThere are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.',
+        'There are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.\n' +
+        'Deck build - the same plants are removed every game: with 2-3 players ' +
+        '3, 4, 9, 11, 16, 18, 20, 24, 30, 33, 46; with 4 players 3, 4, 11, 18, ' +
+        '24, 33, 46; with 5-6 players 3, 4, 33. The deck is ordered, not ' +
+        'shuffled: plants 5-30 in ascending order on top, then plants 31-35 ' +
+        'shuffled together with the Step 3 card, then plants 36-50 shuffled on ' +
+        'the bottom. The starting market has one plant per player and the ' +
+        'future market starts empty.',
 };

--- a/engine/src/maps/europe.ts
+++ b/engine/src/maps/europe.ts
@@ -420,7 +420,6 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck: deck };
     },
     mapSpecificRules:
-        'Europe uses the New Power Plants Set 2 deck (cards with a plug on the back). ' +
-        'The power plant market starts as 4 current + 5 future power plants (9 total). ' +
-        'When Step 2 begins, remove the lowest-numbered plant from the current market from the game once and do not replace it; the future market then has 4 plants instead of 5.',
+        'When Step 2 begins, remove the lowest-numbered plant from the current market from the game once and do not replace it; the future market then has 4 plants instead of 5.\n' +
+        'Deck build - Europe uses the New Power Plants Set 2 deck (cards with a plug on the back). The power plant market starts as 4 current + 5 future power plants (9 total), all drawn from the plug plants; the top card of the draw deck is never a plug plant.',
 };

--- a/engine/src/maps/france.ts
+++ b/engine/src/maps/france.ts
@@ -291,5 +291,11 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules: 'Remove power plant 13. Put power plant 11 on top of the deck.',
+    mapSpecificRules:
+        'Deck build recharged - power plant 13 is removed from the game and ' +
+        'power plant 11 always starts in the market. Removal by player count: ' +
+        '2 players remove 6 higher plants, 3 players remove 1 low and 6 higher, ' +
+        '4 players remove 3 higher.\n' +
+        'Deck build original - power plant 13 is removed from the game; power ' +
+        'plant 11 is placed on top of the deck in its place.',
 };

--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -232,7 +232,6 @@ export const map: GameMap = {
         // Except for adjusting the garbage plant cost, the setup is identical to the normal game.
         if (variant == 'original') {
             powerPlantsDeck = powerPlantsDeck.slice(8);
-            const powerPlant13 = powerPlantsDeck.splice(2, 1)[0];
             const step3 = powerPlantsDeck.pop()!;
 
             powerPlantsDeck = shuffle(powerPlantsDeck, rng() + '');
@@ -242,7 +241,9 @@ export const map: GameMap = {
                 powerPlantsDeck = powerPlantsDeck.slice(4);
             }
 
-            powerPlantsDeck.unshift(powerPlant13);
+            // India sets no plant aside for the top of the deck - a random
+            // plant starts there (Mike, 2026-08-13; the old splice landed on
+            // 14 anyway because India's list has no plant 11).
             powerPlantsDeck.push(step3);
 
             actualMarket = [
@@ -289,5 +290,5 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.',
+        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.\nDeck build - power plant 11 is removed from the game. In the original variant no plant is set aside for the top of the deck - a random plant starts on top.',
 };

--- a/engine/src/maps/manhattan.ts
+++ b/engine/src/maps/manhattan.ts
@@ -414,5 +414,10 @@ export const map: GameMap = {
         'becomes available for auction, and each Bureaucracy phase the lowest ' +
         'plant is removed from the game. If the market is completely empty, no ' +
         'more power plants can be bought. The game ends when a player has ' +
-        'connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).',
+        'connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).\n' +
+        'Deck build - at the start of the game, 4 random plug plants are ' +
+        'removed. Of the other 9, 8 are in the starting market and 1 is on ' +
+        'the top of the deck. The rest of the deck is random with no plug ' +
+        'plants. The Step 3 card is removed from the game. For 2-3 players: ' +
+        'also place power plants 20, 22, and 37 into the game box.',
 };

--- a/engine/src/maps/northerneurope.ts
+++ b/engine/src/maps/northerneurope.ts
@@ -187,7 +187,10 @@ export const map: GameMap = {
     mapSpecificRules:
         'Nuclear plants may only be purchased by players with at least one city in Sweden, Finland, or the Baltic States. ' +
         'Players with cities only in Norway or Denmark may not bid on or buy nuclear plants. ' +
-        'Resources start at: coal 3 Elektro, oil 3 Elektro, garbage 5 Elektro, uranium 7 Elektro.',
+        'Resources start at: coal 3 Elektro, oil 3 Elektro, garbage 5 Elektro, uranium 7 Elektro.\n' +
+        'Deck build - standard setup; the regions in play swap in regional ' +
+        'versions of certain power plants (same numbers, different fuel or ' +
+        'output).',
     connections: [
         { nodes: [Cities.Bood, Cities.Tromso], cost: 17 },
         { nodes: [Cities.Tromso, Cities.Oulu], cost: 25 },

--- a/engine/src/maps/quebec.ts
+++ b/engine/src/maps/quebec.ts
@@ -300,5 +300,12 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'Put power plants 13, 18, 22 on top of the deck. Ecological power plants will never be put on the bottom of the deck.',
+        'Ecological power plants will never be put on the bottom of the deck.\n' +
+        'Deck build recharged - the starting market is drawn from the low ' +
+        'plants (including 13); one more low plant goes on top of the deck, ' +
+        'with 18 and 22 placed directly beneath it. Ecological plants (wind ' +
+        'and fusion) are never removed during setup.\n' +
+        'Deck build original - power plants 13, 18, 22 are set aside and ' +
+        'placed on top of the deck (13 topmost); ecological plants are ' +
+        'excluded from the player-count removal.',
 };

--- a/engine/src/maps/russia.ts
+++ b/engine/src/maps/russia.ts
@@ -288,5 +288,16 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules: 'The power plant market is restricted, and the rules for removing old plants are changed.',
+    mapSpecificRules:
+        'The power plant market is restricted, and the rules for removing old ' +
+        'plants are changed.\n' +
+        'Deck build recharged - plants 6 and 14 are removed from the game. The ' +
+        'market has 6 plants (3 current, 3 future) drawn at random from the ' +
+        'low plants; the six undrawn low plants sit shuffled on top of the ' +
+        'deck. Removal by player count (higher plants only): 2 players remove ' +
+        '6, 3 players remove 8, 4 players remove 4.\n' +
+        'Deck build original - plants 6 and 14 are removed from the game; the ' +
+        'market is 3, 4, 5 / 7, 8, 9. Plant 13 goes on top of the deck, then ' +
+        'five shuffled cards (plants 10, 11 and the top three of the deck), ' +
+        'then the rest, with the Step 3 card on the bottom.',
 };

--- a/engine/src/maps/southafrica.ts
+++ b/engine/src/maps/southafrica.ts
@@ -281,6 +281,8 @@ export const map: GameMap = {
         'countries (Namibia, Botswana, Zimbabwe, Mozambique, Eswatini, Lesotho) are ' +
         'available from the start of the game. The 30 Elektro is the complete cost ' +
         '— no house-base cost is added on top. Only a single player can build on ' +
-        'each cross-border space (cap of 1 instead of the standard 3). ' +
-        'Power plant 07 is removed from the deck.',
+        'each cross-border space (cap of 1 instead of the standard 3).\n' +
+        'Deck build - power plant 07 is removed from the game; otherwise ' +
+        'standard setup for both variants (in the original variant the future ' +
+        'market becomes 8, 9, 10, 11).',
 };

--- a/engine/src/maps/spainportugal.ts
+++ b/engine/src/maps/spainportugal.ts
@@ -298,5 +298,8 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'Remove power plants 18, 22 and 27 from the deck. Place them on top of the deck at the start of Step 2.\nYou cannot buy a nuclear power plant if you only have cities in Portugal.',
+        'You cannot buy a nuclear power plant if you only have cities in Portugal.\n' +
+        'Deck build - power plants 18, 22 and 27 are set aside at setup; when ' +
+        'Step 2 begins they are placed on top of the deck (18 topmost, then ' +
+        '22, then 27).',
 };

--- a/engine/src/maps/ukireland.ts
+++ b/engine/src/maps/ukireland.ts
@@ -308,5 +308,7 @@ export const map: GameMap = {
         'until they build a city in Scotland, Wales, England, or Northern Ireland. ' +
         'Early Step 3: the Step 3 card is placed 3rd from last in the deck (two ' +
         'plants below it). Step 2 begins when a player connects their 7th city ' +
-        '(6th for 6 players).',
+        '(6th for 6 players).\n' +
+        'Deck build - standard setup for both variants, except the Step 3 card ' +
+        'is placed third from the bottom of the deck (two plants below it).',
 };


### PR DESCRIPTION
Adds explicit **"Deck build"** setup text to the rules dialog of every map whose deck preparation differs from the base game, per Mike's requested format — `Deck build recharged - ...` / `Deck build original - ...` where the variants differ, a single combined `Deck build - ...` line where the variant setting makes no difference.

**Maps covered (14):** Australia, Brazil, Bremen, China, Europe, France, India, Manhattan, Northern Europe, Quebec, Russia, South Africa, Spain & Portugal, UK & Ireland. Text placed as the last entry of each map's `mapSpecificRules`, verified against each map's `setupDeck` implementation. Maps whose deck build is fully standard (USA, Germany, Italy, Benelux, Central Europe, Baden-Württemberg, Korea, North America, Japan, Middle East) are unchanged.

**India fix (per Mike):** India removes plant 11 from the game, so the original-variant `splice(2, 1)` — written for the standard plant list where index 2 is plant 13 — actually landed on plant 14 and pinned it to the top of every deck. Per Mike's ruling, India sets **no** plant aside: a random plant now starts on top of the original-variant deck.

**Testing:**
- New regression spec sweeps 10 seeds of India/original and asserts the top card varies (plus: plant 11 stays removed, Step 3 stays on the bottom). Teeth-checked: the spec **fails** against the pre-fix engine (plant 14 on top for every seed).
- 66/66 engine specs pass, `tsc --noEmit` clean, `pnpm lint` 0 errors.
- All other changes are inert dialog strings — no behavioral change outside India/original.

**Deploy note:** the string changes are replay-safe for in-flight games; the India change alters original-variant deck generation, so the usual duplicate-to-next-version applies on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
