### PR TITLE
India original: plant 13 on top, found by number

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -368,23 +368,22 @@ describe('Engine', () => {
         expect(G.powerPlantsDeck[step3Idx + 2].number).to.not.equal(99);
     });
 
-    it('should start the India original deck with a random plant on top', () => {
-        // India removes plant 11 from the game, so the old code's splice(2, 1)
-        // — written for the standard list where index 2 is plant 13 — landed on
-        // plant 14 and pinned it to the top of every deck. The rule (Mike,
-        // 2026-08-13) is that India sets NO plant aside: a random plant starts
-        // on top. Pre-fix this sweep sees plant 14 on top for every seed.
-        const tops = new Set<number>();
+    it('should place plant 13 on top of the India original deck', () => {
+        // India removes plant 11 from the game, so the pre-#113 splice(2, 1)
+        // — written for the standard list where index 2 is plant 13 — landed
+        // on plant 14 and pinned IT to the top instead. #113 briefly made the
+        // top random; Mike's follow-up ruling restores the printed rule: 13
+        // goes on top, now found by number rather than by index. This sweep
+        // fails against both prior behaviors (14 on top / random on top).
         for (let seed = 0; seed < 10; seed++) {
             const G = setup(4, { map: 'India', variant: 'original', randomizeMap: false }, `india-top-${seed}`);
+            expect(G.powerPlantsDeck[0].number, 'plant 13 on top').to.equal(13);
             expect(
                 G.powerPlantsDeck.some((p) => p.number == 11),
                 'plant 11 must stay removed'
             ).to.be.false;
             expect(G.powerPlantsDeck[G.powerPlantsDeck.length - 1].number, 'Step 3 stays on the bottom').to.equal(99);
-            tops.add(G.powerPlantsDeck[0].number);
         }
-        expect(tops.size, `top cards across seeds: ${[...tops].join(',')}`).to.be.greaterThan(1);
     });
 
     it('should never strand a UK & Ireland region from the rest of its landmass', () => {

--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -232,6 +232,12 @@ export const map: GameMap = {
         // Except for adjusting the garbage plant cost, the setup is identical to the normal game.
         if (variant == 'original') {
             powerPlantsDeck = powerPlantsDeck.slice(8);
+            // Set aside plant 13 BY NUMBER: the pre-#113 splice(2, 1) assumed
+            // the standard list where index 2 is plant 13, but India has no
+            // plant 11, so it grabbed 14. Standard rule applies (Mike's
+            // follow-up ruling, 2026-08-13): 13 goes on top.
+            const powerPlant13Idx = powerPlantsDeck.findIndex((pp) => pp.number == 13);
+            const powerPlant13 = powerPlantsDeck.splice(powerPlant13Idx, 1)[0];
             const step3 = powerPlantsDeck.pop()!;
 
             powerPlantsDeck = shuffle(powerPlantsDeck, rng() + '');
@@ -241,9 +247,7 @@ export const map: GameMap = {
                 powerPlantsDeck = powerPlantsDeck.slice(4);
             }
 
-            // India sets no plant aside for the top of the deck - a random
-            // plant starts there (Mike, 2026-08-13; the old splice landed on
-            // 14 anyway because India's list has no plant 11).
+            powerPlantsDeck.unshift(powerPlant13);
             powerPlantsDeck.push(step3);
 
             actualMarket = [
@@ -290,5 +294,5 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.\nDeck build - power plant 11 is removed from the game. In the original variant no plant is set aside for the top of the deck - a random plant starts on top.',
+        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.\nDeck build - power plant 11 is removed from the game; otherwise standard setup for both variants (original: plant 13 on top of the deck).',
 };


### PR DESCRIPTION
Follow-up to #113, per Mike's ruling: **original-variant India follows the standard rule after all — plant 13 goes on top of the deck.**

The pre-#113 code intended exactly this but grabbed **plant 14** (a `splice(2, 1)` by index on India's list, which has no plant 11, so every index past 10 is shifted); #113 briefly made the top random. This PR sets 13 aside **by number** (UK&I-style `findIndex`), so the list shape can never shift it again. Recharged India is untouched — a random plug plant on top, as base.

**Testing:** the regression spec now sweeps 10 seeds asserting plant 13 on top every time (plus: 11 stays removed, Step 3 stays on the bottom) — it fails against **both** prior behaviors (14 pinned to the top / random top). 66/66 engine specs, `tsc --noEmit` clean, lint 0 errors. The India "Deck build" dialog line is updated to match.

**Deploy note:** changes original-variant India deck generation (as #113 did) — usual duplicate-to-next-version on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
