### PR TITLE
Stop a resource discard from refilling the power plant market (#67)

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -41,6 +41,37 @@ export interface AvailableMoves {
     [MoveName.Undo]?: boolean[];
 }
 
+/**
+ * Which of coal and oil the player is holding more of than they can store.
+ *
+ * A hybrid plant's capacity is a shared tank, so an overflow of one resource eats into
+ * the other's headroom — but only when the player actually owns a hybrid plant. This
+ * file used to compute that overflow unguarded while the two discard handlers in
+ * engine.ts guarded it, so a player with no hybrid plant who was over on coal got
+ * offered an *oil* discard — oil they might not hold at all, which the handler then
+ * decremented past zero. Both sides read this now, so the moves offered and the moves
+ * executed cannot disagree.
+ */
+export function coalOilOverCapacity(player: Player): ResourceType[] {
+    const over: ResourceType[] = [];
+
+    // `> 0` because an oversubscribed shared tank fails BOTH tests: a player drowning in
+    // oil trips the coal test too, and used to be offered a coal discard while holding
+    // no coal — the handler then decremented it to -1. You can only discard what you
+    // hold, and whichever resource actually caused the overflow is still offered.
+    const oilOverflow = player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
+    if (player.coalLeft > 0 && player.coalCapacity + player.hybridCapacity < player.coalLeft + oilOverflow) {
+        over.push(ResourceType.Coal);
+    }
+
+    const coalOverflow = player.hybridCapacity > 0 ? Math.max(0, player.coalLeft - player.coalCapacity) : 0;
+    if (player.oilLeft > 0 && player.oilCapacity + player.hybridCapacity < player.oilLeft + coalOverflow) {
+        over.push(ResourceType.Oil);
+    }
+
+    return over;
+}
+
 export function availableMoves(G: GameState, player: Player): AvailableMoves {
     const moves = {};
 
@@ -63,16 +94,7 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                     .filter((pp, i) => i != player.powerPlants.length - 1 && !isUraniumMine(G, pp))
                     .map((pp) => pp.number);
             } else {
-                const toDiscard: ResourceType[] = [];
-                let hybridCapacityUsed = Math.max(0, player.oilLeft - player.oilCapacity);
-                if (player.coalCapacity + player.hybridCapacity < player.coalLeft + hybridCapacityUsed) {
-                    toDiscard.push(ResourceType.Coal);
-                }
-
-                hybridCapacityUsed = Math.max(0, player.coalLeft - player.coalCapacity);
-                if (player.oilCapacity + player.hybridCapacity < player.oilLeft + hybridCapacityUsed) {
-                    toDiscard.push(ResourceType.Oil);
-                }
+                const toDiscard: ResourceType[] = coalOilOverCapacity(player);
 
                 if (player.garbageCapacity < player.garbageLeft) {
                     toDiscard.push(ResourceType.Garbage);

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -11,6 +11,7 @@ import {
     getPowerPlant,
     move,
     moveAI,
+    rebuildPlantMarketForChina,
     reconstructState,
     setup,
 } from './engine';
@@ -1880,5 +1881,34 @@ describe('Engine', () => {
                 expect(cityNames, `connection endpoint ${node} exists`).to.include(node);
             }
         }
+    });
+
+    it('should hold the China market at four plants in Step 3 (#67)', () => {
+        // RIO 573 China: "in Step 3, there are always 4 power plants in the power plant
+        // market regardless of the number of players." Steps 1-2 hold the market at
+        // players-1 — five at six players — so the Step 3 branch has to trim down, not
+        // only fill up. Six players is the only count that can exceed four.
+        const G = setup(6, { map: 'China', variant: 'recharged' }, 'china-step3-trim');
+        G.step = 3;
+        G.actualMarket = [5, 6, 7, 8, 9].map((n) => getPowerPlant(n));
+
+        rebuildPlantMarketForChina(G);
+
+        expect(G.actualMarket.length, 'Step 3 market is exactly four').to.equal(4);
+        expect(
+            G.actualMarket.map((p) => p.number),
+            'the smallest plant is the one boxed'
+        ).to.deep.equal([6, 7, 8, 9]);
+    });
+
+    it('should still fill the China Step 3 market up to four when it is short', () => {
+        // The trim must not break the existing fill-up direction.
+        const G = setup(6, { map: 'China', variant: 'recharged' }, 'china-step3-fill');
+        G.step = 3;
+        G.actualMarket = [getPowerPlant(5), getPowerPlant(6)];
+
+        rebuildPlantMarketForChina(G);
+
+        expect(G.actualMarket.length, 'topped back up to four').to.equal(4);
     });
 });

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -26,6 +26,7 @@ import {
     Phase,
     PowerPlant,
     PowerPlantType,
+    ResourceType,
     resupplyUraniumMine,
     sellUraniumMine,
     Variant,
@@ -1910,5 +1911,87 @@ describe('Engine', () => {
         rebuildPlantMarketForChina(G);
 
         expect(G.actualMarket.length, 'topped back up to four').to.equal(4);
+    });
+
+    it('should not draw a plant when an over-capacity player discards resources without buying (#67)', () => {
+        // The draw at the end of the discard chain is the refill for a PURCHASE. But
+        // available-moves offers DiscardResources to any over-capacity player in the
+        // auction phase, purchase or not — so a player carrying resources their plants
+        // can no longer hold triggers a free plant into the market. On China that shows
+        // as a fifth plant in a Step 3 market the rulebook pins at four; on every other
+        // map the extra plant inflates the future market instead.
+        let G = setup(4, { map: 'China', variant: 'recharged' }, 'china-spurious-refill');
+        G.step = 3;
+        G.phase = Phase.Auction;
+        G.actualMarket = [30, 31, 32, 33].map((n) => getPowerPlant(n));
+        G.futureMarket = [];
+        G.chosenPowerPlant = undefined;
+
+        // Nobody has bought anything this phase; this player is simply holding a coal
+        // cube with no coal capacity left to hold it.
+        const idx = G.players[0].id;
+        const player = G.players[idx];
+        player.coalLeft = 1;
+        player.coalCapacity = 0;
+        player.oilLeft = 0;
+        player.oilCapacity = 0;
+        player.hybridCapacity = 0;
+        player.skipAuction = false;
+        G.currentPlayers = [idx];
+        player.availableMoves = availableMoves(G, player);
+
+        expect(player.availableMoves[MoveName.DiscardResources], 'the over-capacity player is asked to discard').to.not
+            .be.undefined;
+
+        G = move(G, { name: MoveName.DiscardResources, data: ResourceType.Coal } as Move, idx);
+
+        expect(G.actualMarket.length, 'a discard with no purchase behind it must not draw a plant').to.equal(4);
+    });
+
+    it('should not ask a player with no hybrid plant to discard a resource they do not hold', () => {
+        // A hybrid plant's capacity is a shared tank, so one resource overflowing eats
+        // into the other's headroom — but only if the player owns a hybrid plant.
+        // available-moves used to skip that guard while the engine applied it, so a coal
+        // overflow made the oil test fail too and offered a discard of oil the player
+        // never had. The engine then decremented it past zero.
+        const G = setup(3, { map: 'Germany' }, 'no-phantom-oil-discard');
+        G.phase = Phase.Auction;
+
+        const player = G.players[0];
+        player.coalLeft = 2;
+        player.coalCapacity = 0;
+        player.oilLeft = 0;
+        player.oilCapacity = 0;
+        player.hybridCapacity = 0;
+        G.currentPlayers = [player.id];
+
+        const offered = availableMoves(G, player)[MoveName.DiscardResources];
+
+        expect(offered, 'the coal overflow is still offered').to.deep.equal([ResourceType.Coal]);
+    });
+
+    it('should clear the whole overflow and return the cubes to the supply when auto-discarding', () => {
+        // The DiscardResources handler used to step down by a single cube and drop it on
+        // the floor. A player over by two stayed over by one, got prompted again later,
+        // and that second discard drew a spurious plant (#67).
+        let G = setup(3, { map: 'Germany' }, 'auto-discard-clears-overflow');
+        G.phase = Phase.Auction;
+
+        const idx = G.players[0].id;
+        const player = G.players[idx];
+        player.coalLeft = 3;
+        player.coalCapacity = 0;
+        player.oilLeft = 0;
+        player.oilCapacity = 0;
+        player.hybridCapacity = 0;
+        G.currentPlayers = [idx];
+        player.availableMoves = availableMoves(G, player);
+
+        const supplyBefore = G.coalSupply;
+
+        G = move(G, { name: MoveName.DiscardResources, data: ResourceType.Coal } as Move, idx);
+
+        expect(G.players[idx].coalLeft, 'the player is left within capacity, not one cube over').to.equal(0);
+        expect(G.coalSupply - supplyBefore, 'every discarded cube goes back to the supply').to.equal(3);
     });
 });

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -2684,7 +2684,7 @@ export function applyAustraliaStep3Shift(G: GameState) {
     });
 }
 
-function rebuildPlantMarketForChina(G: GameState) {
+export function rebuildPlantMarketForChina(G: GameState) {
     /*At the beginning of phase 5, the players fill the power plant market with new power plants. Depending on the
 number of players, the players always add a minimum of 1, 2, or 3 power plants to the market from the supply:
 with 2 and 3 players, add at least 1 power plant.
@@ -2719,6 +2719,15 @@ Exception: with 2 players, add plants until there are 2 in the market.*/
 
     if (G.step == 3) {
         G.actualMarket = G.actualMarket.filter((pp) => pp.type != PowerPlantType.Step3);
+        // RIO 573: "in Step 3, there are always 4 power plants in the power plant market
+        // regardless of the number of players." Steps 1-2 hold the market at players-1,
+        // which is FIVE at six players, so the Step 3 branch has to trim down as well as
+        // fill up. Smallest-first, matching the step 1/2 branch below and the rulebook's
+        // "remove the smallest power plant from the market".
+        while (G.actualMarket.length > 4) {
+            G.actualMarket.shift();
+        }
+
         while (G.actualMarket.length < 4 && G.powerPlantsDeck.length > 0) {
             addPowerPlant(G);
         }

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { cloneDeep, isEqual, range } from 'lodash';
 import seedrandom from 'seedrandom';
-import { availableMoves, computeRegionGraph, regionPickable } from './available-moves';
+import { availableMoves, coalOilOverCapacity, computeRegionGraph, regionPickable } from './available-moves';
 import {
     countHeldPowerPlants,
     GameOptions,
@@ -673,16 +673,14 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                         countHeldPowerPlants(G, winningPlayer) > 4 ||
                         (G.players.length > 2 && countHeldPowerPlants(G, winningPlayer) > 3);
                     if (!overPlantLimit) {
-                        addPowerPlant(G);
+                        refillMarketAfterPurchase(G);
                     }
                     setCurrentPlayer(G, G.discountBonusPlayer);
                 } else if (
                     countHeldPowerPlants(G, winningPlayer) <= 3 ||
                     (G.players.length == 2 && countHeldPowerPlants(G, winningPlayer) == 4)
                 ) {
-                    if (G.map.name != 'China' || G.step == 3) {
-                        addPowerPlant(G);
-                    }
+                    refillMarketAfterPurchase(G);
 
                     toResourcesPhase(G);
                 }
@@ -878,9 +876,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                                 ) {
                                     setCurrentPlayer(G, winningPlayer.id);
                                 } else {
-                                    if (G.map.name != 'China' || G.step == 3) {
-                                        addPowerPlant(G);
-                                    }
+                                    refillMarketAfterPurchase(G);
 
                                     if (G.players.some((p) => !p.skipAuction && !p.isDropped)) {
                                         G.players.forEach((p) => {
@@ -1447,9 +1443,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     )}.`,
                 });
 
-                if (G.map.name != 'China' || G.step == 3) {
-                    addPowerPlant(G);
-                }
+                refillMarketAfterPurchase(G);
 
                 G.players.forEach((p) => {
                     p.bid = 0;
@@ -1462,17 +1456,7 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                     toResourcesPhase(G);
                 }
             } else {
-                const toDiscard: ResourceType[] = [];
-                let hybridCapacityUsed =
-                    player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
-                if (player.coalCapacity + player.hybridCapacity < player.coalLeft + hybridCapacityUsed) {
-                    toDiscard.push(ResourceType.Coal);
-                }
-
-                hybridCapacityUsed = player.hybridCapacity > 0 ? Math.max(0, player.coalLeft - player.coalCapacity) : 0;
-                if (player.oilCapacity + player.hybridCapacity < player.oilLeft + hybridCapacityUsed) {
-                    toDiscard.push(ResourceType.Oil);
-                }
+                const toDiscard: ResourceType[] = coalOilOverCapacity(player);
 
                 if (player.garbageLeft > player.garbageCapacity) {
                     G.garbageSupply += player.garbageLeft - player.garbageCapacity;
@@ -1485,21 +1469,12 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 }
 
                 if (toDiscard.length == 1) {
-                    if (toDiscard[0] == ResourceType.Coal) {
-                        G.coalSupply += player.coalLeft - player.coalCapacity;
-                        player.coalLeft = player.coalCapacity;
-                    } else if (toDiscard[0] == ResourceType.Oil) {
-                        G.oilSupply += player.oilLeft - player.oilCapacity;
-                        player.oilLeft = player.oilCapacity;
-                    }
-
+                    discardDownToCapacity(G, player, toDiscard[0]);
                     toDiscard.pop();
                 }
 
                 if (toDiscard.length == 0) {
-                    if (G.map.name != 'China' || G.step == 3) {
-                        addPowerPlant(G);
-                    }
+                    refillMarketAfterPurchase(G);
                     G.players.forEach((p) => {
                         p.bid = 0;
                         p.passed = p.isDropped;
@@ -1535,31 +1510,15 @@ export function move(G: GameState, move: Move, playerNumber: number, isUndo = fa
                 G.oilSupply++;
             }
 
-            const toDiscard: ResourceType[] = [];
-            let hybridCapacityUsed = player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
-            if (player.coalCapacity + player.hybridCapacity < player.coalLeft + hybridCapacityUsed) {
-                toDiscard.push(ResourceType.Coal);
-            }
-
-            hybridCapacityUsed = player.hybridCapacity > 0 ? Math.max(0, player.coalLeft - player.coalCapacity) : 0;
-            if (player.oilCapacity + player.hybridCapacity < player.oilLeft + hybridCapacityUsed) {
-                toDiscard.push(ResourceType.Oil);
-            }
+            const toDiscard: ResourceType[] = coalOilOverCapacity(player);
 
             if (toDiscard.length == 1) {
-                if (toDiscard[0] == ResourceType.Coal) {
-                    player.coalLeft--;
-                } else if (toDiscard[0] == ResourceType.Oil) {
-                    player.oilLeft--;
-                }
-
+                discardDownToCapacity(G, player, toDiscard[0]);
                 toDiscard.pop();
             }
 
             if (toDiscard.length == 0) {
-                if (G.map.name != 'China' || G.step == 3) {
-                    addPowerPlant(G);
-                }
+                refillMarketAfterPurchase(G);
                 G.players.forEach((p) => {
                     p.bid = 0;
                     p.passed = p.isDropped;
@@ -2740,6 +2699,51 @@ Exception: with 2 players, add plants until there are 2 in the market.*/
     }
 }
 
+/**
+ * Discard just enough of one resource to fit the player's storage, returning the cubes
+ * to the supply.
+ *
+ * The over-capacity test is `capacity + hybrid < held + otherOverflow`, so the largest
+ * legal holding is `capacity + hybrid - otherOverflow`. The DiscardResources handler
+ * used to step down by a single cube instead, which left a player who was over by two
+ * still over by one — they get prompted again later, and that later discard used to
+ * draw a spurious plant into the market (#67). It also dropped the cubes on the floor
+ * rather than returning them to the supply.
+ */
+function discardDownToCapacity(G: GameState, player: Player, resource: ResourceType) {
+    if (resource == ResourceType.Coal) {
+        G.coalSupply += Math.max(0, player.coalLeft - player.coalCapacity);
+        player.coalLeft = Math.min(player.coalLeft, player.coalCapacity);
+    } else if (resource == ResourceType.Oil) {
+        G.oilSupply += Math.max(0, player.oilLeft - player.oilCapacity);
+        player.oilLeft = Math.min(player.oilLeft, player.oilCapacity);
+    }
+}
+
+/**
+ * Draw the replacement plant a completed purchase is owed — and only then.
+ *
+ * `endAuction` marks the purchase; whichever path finishes it consumes the mark. The
+ * mark is what was missing: available-moves offers DiscardResources to ANY player over
+ * capacity during the auction phase, not just a buyer, so a player merely carrying a
+ * resource their plants can no longer hold used to complete a discard and pull a free
+ * plant into the market. On China that surfaced as a fifth plant in a Step 3 market the
+ * rulebook pins at four (#67); elsewhere it inflated the future market instead.
+ */
+function refillMarketAfterPurchase(G: GameState) {
+    if (!G.pendingMarketRefill) {
+        return;
+    }
+
+    G.pendingMarketRefill = false;
+
+    // China refills once per round in Bureaucracy while in steps 1-2 (see
+    // rebuildPlantMarketForChina), not per purchase.
+    if (G.map.name != 'China' || G.step == 3) {
+        addPowerPlant(G);
+    }
+}
+
 function removePowerPlant(G: GameState, powerPlant: PowerPlant) {
     G.actualMarket.splice(
         G.actualMarket.findIndex((pp) => pp.number == powerPlant.number),
@@ -2957,6 +2961,11 @@ function endAuction(G: GameState, winningPlayer: Player, bid: number) {
 
     removePowerPlant(G, G.chosenPowerPlant!);
     G.chosenPowerPlant = G.currentBid = undefined;
+
+    // This purchase is owed exactly one replacement plant. Whichever path finishes the
+    // purchase draws it — immediately, or after the buyer discards down to the plant
+    // limit — and consumes the mark. See refillMarketAfterPurchase.
+    G.pendingMarketRefill = true;
 }
 
 function setPlayerOrder(G: GameState) {
@@ -3160,9 +3169,7 @@ function fastAuction(G: GameState, player: Player, bid: number) {
         ) {
             setCurrentPlayer(G, winningPlayer.id);
         } else {
-            if (G.map.name != 'China' || G.step == 3) {
-                addPowerPlant(G);
-            }
+            refillMarketAfterPurchase(G);
 
             if (G.players.some((p) => !p.skipAuction && !p.isDropped)) {
                 G.players.forEach((p) => {

--- a/engine/src/gamestate.ts
+++ b/engine/src/gamestate.ts
@@ -223,6 +223,7 @@ export interface GameState {
     minimunBid: number;
     plantDiscountActive: boolean;
     discountBonusPlayer?: number; // Manhattan: id of the player who bought the discounted plant and may purchase one more this phase.
+    pendingMarketRefill?: boolean; // A purchase is owed its replacement plant. Set in endAuction, consumed by whichever path finishes the purchase (#67).
     discardSmallestPlant: boolean; // For Benelux map, there are times when we remove the smallest plant.
     nextCardWeak: boolean;
     cardsLeft: number;


### PR DESCRIPTION
Fixes #67.

Mike reported in Aug 2024 that a China game *"got to step 3 but kept five plants in play."* The first commit here trims China's Step 3 market to the four the rulebook requires (RIO 573, stated twice). That was only half of it, and the note left on that commit pointed at the wrong place — this PR corrects it.

## The measurement was noise before the bug was

The soak that produced "3/90 → 1/90 violations" is non-deterministic: `moveAI` picks its moves with raw `Math.random()` (`engine.ts:2090/2103/2107`, and `chooseRandom` at `:2189`), so a game's `seed` only seeds the deck shuffle. Re-running that same file unchanged gave `0/80`, `0/84`, `0/83`, then `1/80` — and that survivor was a **six**-player game, not the two-player one the earlier commit message describes. Both the rate and the player count in it were sampling noise.

Pinning the AI's dice per game made the failure re-findable, and a tripwire inside `addPowerPlant` then named the site: 31 hits across 4000 games, every stack landing on `engine.ts:1501` or `:1561`.

## Root cause

The draw at the end of the over-capacity discard chain is the refill a **purchase** is owed. But `available-moves` offers `DiscardResources` to *any* over-capacity player during the auction phase, purchase or not — so a player merely carrying a resource their plants can no longer hold completed a discard and pulled a free plant into the market. One trip caught it mid-auction with bids still live.

This is shared code, not China's. On China the extra plant lands in `actualMarket`, which is the five-plant Step 3 market. On every other map `addPowerPlant` re-slices, so it inflates the **future** market instead — the same symptom class as #100.

Three defects, feeding each other:

1. **`available-moves` and the engine disagreed.** `available-moves` computed the hybrid-tank overflow unguarded while both engine handlers guarded it with `hybridCapacity > 0`, so a player with no hybrid plant who was over on coal was offered an *oil* discard — and the handler decremented an empty stock to `-1`. Both sides now call one helper, `coalOilOverCapacity`, which also refuses to name a resource the player does not hold (an oversubscribed shared tank fails both tests at once).
2. **The auto-discard under-clamped.** The `DiscardResources` handler stepped down by a single cube and dropped it on the floor, so a player over by two stayed over by one — then got prompted again later, which is what turned the residue into a second draw. It now calls `discardDownToCapacity`, the same clamp-and-return-to-supply its sibling in the `DiscardPowerPlant` handler already used.
3. **The refill had no idea whether a purchase happened.** `endAuction` now marks it (`pendingMarketRefill`) and `refillMarketAfterPurchase` consumes it, so all seven refill sites draw exactly once per purchase and never for a discard with nothing behind it. The `China || step 3` condition those sites each repeated now lives in the helper.

## Verification

77 specs (+3), `tsc` clean, 0 lint errors. Each new spec is teeth-checked against its own fix reverted: the #67 one reads 5 where it wants 4, the offer one still lists `"oil"`, the clamp one leaves the player a cube over.

Because the change is engine-wide, three more things beyond the specs:

- **All three replay fixtures** (Germany, USA, supply) stay green.
- **Differential sweep** — every map × 2–6 players × both variants, 720 games with the AI's dice pinned, run on this branch and on its parent: **707 games byte-identical; 13 changed, every one a game where the discard chain fires. No map's market size changed anywhere.** Games leaving a player holding a negative resource count: **7 → 0**.
- **China specifically** — 1000 seeded games (678 reaching Step 3): 0 violations. 4000 unseeded games (2649 reaching Step 3): 0 violations. The same unseeded harness read 3/1331 and then 8/2631 while the cause was being hunted, and it is teeth-checked — with the first commit's trim removed it reports 7/134.

## Deliberately not fixed here

`discardDownToCapacity` clamps to capacity and ignores the hybrid tank, byte-matching the `DiscardPowerPlant` sibling — which over-discards for a player holding a hybrid plant. Correcting that turns the `supply` replay fixture red, which means the path is live in recorded games, so it wants its own change with its own evidence. It may also belong with #42, which is the other open hybrid-plant accounting issue.

## Deploy note

This changes behaviour, so it is the #102 class: **duplicate-to-next-version** rather than a plain bump. Games in progress on the current descriptor keep their engine and are unaffected.
