### PR TITLE
Only return a state from logSlice when the player is known

### DIFF
--- a/engine/src/wrapper.spec.ts
+++ b/engine/src/wrapper.spec.ts
@@ -465,6 +465,28 @@ describe('wrapper (tentative turns)', () => {
         expect(result.players[result.currentPlayers[0]].availableMoves).to.not.be.null;
     });
 
+    it('should only hand back a state from logSlice when it knows whose it is', async () => {
+        // `GET /gameplay/:id/log` is not logged-in: it resolves the player with
+        // `findIndex`, which is -1 when there is no user. `stripSecret` then blanks
+        // EVERY player's availableMoves, so adopting that state left the acting
+        // player looking at a live board with nothing clickable until they re-entered
+        // the game. Without `state` the viewer falls back to `fetchState`.
+        const G = setup(3, {}, 'wrapper-test-log-slice');
+        const current = G.currentPlayers[0];
+
+        const known = wrapper.logSlice(G, { player: current });
+        expect(known.state, 'a known player still gets the state').to.not.be.undefined;
+        expect(Object.keys(known.state!.players[current].availableMoves!), 'and it keeps their own available moves').to
+            .not.be.empty;
+
+        expect(wrapper.logSlice(G, { player: -1 }).state, 'unresolved user (-1): no state').to.be.undefined;
+        expect(wrapper.logSlice(G, {}).state, 'no player given: no state').to.be.undefined;
+        expect(wrapper.logSlice(G).state, 'no options at all: no state').to.be.undefined;
+
+        // The log itself is public and must keep flowing either way.
+        expect(wrapper.logSlice(G, { player: -1 }).log, 'the log is still served').to.deep.equal(G.log);
+    });
+
     it('should not advance the turn when dropping a player who is not up', async () => {
         const G = setup(3, {}, 'wrapper-test-drop-idle');
         const current = [...G.currentPlayers];

--- a/engine/wrapper.ts
+++ b/engine/wrapper.ts
@@ -224,11 +224,26 @@ export function logLength(G: GameState, _player?: number): number {
 
 export function logSlice(G: GameState, options?: { player?: number; start?: number; end?: number }) {
     const stripped = engine.stripSecret(G, options?.player);
+
+    // `stripSecret` only leaves a player's own `availableMoves` intact for the index it
+    // is given; everyone else is blanked to `{}`. The platform's move route is
+    // logged-in and always passes the mover's index, but `GET /gameplay/:id/log` is not
+    // — it derives the index with `findIndex`, which yields **-1** whenever the user
+    // cannot be resolved. Handing back a `state` built that way tells the acting
+    // player's viewer they have no moves: the board renders and nothing is clickable
+    // until they re-enter the game (which takes the `fetchState` path instead).
+    //
+    // That blanking predates the tentative-turn model and was harmless while the viewer
+    // ignored this payload. Now that the viewer adopts `state` from it, only offer the
+    // state when we actually know whose it is; without it `launch.ts` falls back to
+    // `fetchState`, which is exactly the old behaviour.
+    const playerKnown = options?.player != undefined && options.player >= 0;
+
     return {
         // The full (stripped) state. This is how the acting player's viewer receives
         // tentative states: they are never persisted or broadcast, only returned in the
         // move response's log slice.
-        state: stripped,
+        state: playerKnown ? stripped : undefined,
         log: stripped.log.slice(options?.start, options?.end),
         availableMoves:
             options?.end === undefined


### PR DESCRIPTION
Fixes a refresh regression introduced with the tentative-turn model (#119).

## Symptom

After a page refresh mid-game, the acting player gets a fully rendered board with
**nothing highlighted and nothing clickable**. Leaving the game and re-entering it from
the site restores normal play. Reported from the v10 private beta.

## Cause

`GET /gameplay/:id/log` (boardgamers-mono, `apps/game-server/app/routes/gameplay.ts`) has
no `loggedIn` middleware. It resolves the player with

```ts
const playerIndex = game.players.findIndex((pl) => pl._id.equals(playerId));
```

which yields **-1** whenever the user cannot be resolved. `stripSecret` then blanks *every*
player's `availableMoves` to `{}`, including the player whose turn it is.

That blanking predates this change and was harmless, because the viewer ignored the log
payload's state and always emitted `fetchState`. `launch.ts` now adopts
`logData.data.state` when present — so it inherits the weaker stripping of that route.

Measured against a live v10 game: the log endpoint reported `currentPlayers: [2]` with
`players[2].availableMoves == {}`.

## Fix

`logSlice` offers `state` only when the index actually identifies a player. When it does
not, `state` is omitted and `launch.ts` falls through to its existing `fetchState`
branch — exactly the pre-#119 behaviour. The log itself is still served either way.

The tentative-state channel is deliberately untouched: the move route *is* logged-in and
always passes the mover's index, so mid-turn previews still reach the acting player. The
new spec asserts that a known player still receives the state with their own available
moves intact.

## Verification

- 92 engine specs (+1), `tsc` clean, eslint 0 errors
- The new spec is teeth-checked: it fails on the `player: -1` case without the fix

## Deploying

Engine-only — the viewer needs no bump. The change alters only what `logSlice` returns,
never game state or the log, so it cannot affect the replayed trajectory of a game
already in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)