### PR TITLE
Refetch committed states instead of adopting them from the log payload

### DIFF
--- a/viewer/src/launch.ts
+++ b/viewer/src/launch.ts
@@ -3,6 +3,7 @@ import type { GameState, Move } from 'powergrid-engine';
 import Vue from 'vue';
 import Game from './components/Game.vue';
 import type { Preferences } from './types/ui-data';
+import { shouldAdoptLogState } from './util/turn-buffer';
 
 function launch(selector: string) {
     let params: {
@@ -67,10 +68,11 @@ function launch(selector: string) {
             return;
         }
 
-        if (logData?.data?.state) {
+        if (shouldAdoptLogState(logData?.data?.state)) {
             // Move responses carry the (possibly tentative) resulting state. Tentative
             // states are never persisted or broadcast by the platform — this is the
-            // only way they reach the acting player's viewer.
+            // only way they reach the acting player's viewer. Committed states are
+            // refetched; see shouldAdoptLogState for why adopting them is unsafe.
             params.state = logData.data.state;
             app.$forceUpdate();
         } else {

--- a/viewer/src/util/turn-buffer.ts
+++ b/viewer/src/util/turn-buffer.ts
@@ -12,6 +12,28 @@ import { move as engineMove } from 'powergrid-engine';
  */
 
 /**
+ * Should a state arriving on the `gamelog` channel be applied directly, rather than
+ * refetched?
+ *
+ * Only while it is TENTATIVE. That is the single reason this channel exists: tentative
+ * states are never persisted or broadcast, so the move response is the only way one can
+ * reach the acting player's viewer.
+ *
+ * A committed state is refetched instead, exactly as it was before the tentative-turn
+ * model. The same `gamelog` channel also carries the plain log fetch, and
+ * `GET /gameplay/:id/log` is not logged-in: it resolves the player with `findIndex`,
+ * which yields -1 when there is no user, and `stripSecret` then blanks EVERY player's
+ * `availableMoves`. Adopting that state left the acting player looking at a fully
+ * rendered board with nothing clickable after a page refresh, recovering only by
+ * re-entering the game. `fetchState` asks a route that knows who is asking.
+ */
+export function shouldAdoptLogState(state?: GameState | null): boolean {
+    // Written without optional chaining on purpose: webpack 4's parser rejects `?.` in
+    // this module under the unit-test pipeline.
+    return !!state && state.newTurn === false;
+}
+
+/**
  * Compare a move echoed in a log entry with a buffered one. The engine may annotate
  * the logged copy (`usedPlantDiscount`, `fromSupply`), so only the identity fields
  * count: name, payload, and the stamp given when the move entered the buffer.

--- a/viewer/tests/unit/turn-buffer.spec.ts
+++ b/viewer/tests/unit/turn-buffer.spec.ts
@@ -1,4 +1,10 @@
-import { matchesTurnBuffer, moveMatches, rebaseTurnBuffer, replayTurnBuffer } from '@/util/turn-buffer';
+import {
+    matchesTurnBuffer,
+    moveMatches,
+    rebaseTurnBuffer,
+    replayTurnBuffer,
+    shouldAdoptLogState,
+} from '@/util/turn-buffer';
 import { expect } from 'chai';
 import type { GameState, Move } from 'powergrid-engine';
 import { move as engineMove, MoveName, setup } from 'powergrid-engine';
@@ -16,6 +22,29 @@ describe('turn-buffer', () => {
 
         return { committed, player, choose, bid };
     }
+
+    it('shouldAdoptLogState only adopts a state while it is tentative', () => {
+        const { committed, player, choose } = fixture();
+        const tentative = engineMove(clone(committed), choose, player);
+
+        // The one thing the gamelog state channel exists for
+        expect(shouldAdoptLogState(tentative), "a tentative state is the acting player's own").to.be.true;
+
+        // A committed state on this channel may have come from the plain log fetch,
+        // which is not logged-in: stripSecret blanks every player's availableMoves when
+        // the player index is -1, so adopting it kills the board until the game is
+        // re-entered. Refetch instead.
+        expect(shouldAdoptLogState(committed), 'a committed state is refetched').to.be.false;
+        const blanked = {
+            ...clone(committed),
+            players: committed.players.map((pl) => ({ ...pl, availableMoves: {} })),
+        };
+        expect(shouldAdoptLogState(blanked as GameState), 'especially a blanked one').to.be.false;
+
+        // Engine >= 2.0.1 omits state entirely when it cannot attribute it
+        expect(shouldAdoptLogState(undefined), 'no state at all').to.be.false;
+        expect(shouldAdoptLogState(null), 'null state').to.be.false;
+    });
 
     it('moveMatches ignores engine annotations but not payload or time stamp', () => {
         const { choose } = fixture();


### PR DESCRIPTION
Follow-up to #120, which fixed this engine-side.

The engine fix cannot reach a descriptor version that is already running: an in-place
engine edit is silently ignored. Measured today on v10 — the descriptor doc reads
engine 2.0.1 while the game server still executes 2.0.0, confirmed four times over
several minutes. So an engine fix only lands on a **new** descriptor version. A viewer
bump, by contrast, is read from the descriptor on every page load, so the same guard
applied here reaches players immediately.

## The bug

After a page refresh mid-game the acting player gets a fully rendered board with
nothing highlighted and nothing clickable, recovering only by leaving and re-entering
the game.

The `gamelog` channel carries two different payloads: the move response, whose state
may be tentative, and the plain log fetch. Only the first needs applying directly —
tentative states are never persisted or broadcast, so that response is the only way one
can reach the acting player's viewer. The second is served by `GET /gameplay/:id/log`,
which is **not** logged-in: it resolves the player with `findIndex`, yielding -1 when
there is no user, and `stripSecret` then blanks every player's `availableMoves`.

Measured on a live v10 game: `currentPlayers: [3]` with `players[3].availableMoves == {}`.

## The fix

Adopt a state from this channel only while it is **tentative**; refetch otherwise, which
is what the viewer did before the tentative-turn model. The rule lives in
`shouldAdoptLogState` beside the other turn-buffer predicates, with a unit test.

This fixes the bug against engine **2.0.0** (state always present) as well as **2.0.1**
(state omitted when it cannot be attributed) — both are covered by the test.

## Verification

- 7 viewer unit tests (+1), lib bundle builds clean
- Viewer-only: no engine change, so the engine needs no republish

🤖 Generated with [Claude Code](https://claude.com/claude-code)