### PR TITLE
India: start uranium at $6, and only warn on skipping fuel if none wa…

### DIFF
--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -217,7 +217,7 @@ export const map: GameMap = {
             [2, 3, 2],
         ],
     ],
-    startingResources: [24, 21, 20, 2], // Prices begin at: coal 1 Elektro, oil 2 Elektro, garbage 2 Elektro and uranium 6 Elektro.
+    startingResources: [24, 21, 20, 3], // Prices begin at: coal 1 Elektro, oil 2 Elektro, garbage 2 Elektro and uranium 6 Elektro (price = uraniumPrices[length - count], so 3 uranium -> $6).
     startingSupply: [24, 24, 24, 8], // Use only 8 uranium instead of 12
     maxPriceAvailable: [3, 5, 8], // In step 1, only resources up to $3 can be bought. In step 2, only resources up to $5 can be bought.
     coalPrices: [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8],

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -838,9 +838,16 @@ export default class Game extends Vue {
                     return;
                 }
                 if (this.G.phase == Phase.Resources && !this.canPowerAllPlants(player)) {
-                    this.confirmMessage = 'Are you sure you want to skip buying resources without enough to power all your plants?';
-                    this.confirmVisible = true;
-                    return;
+                    // India's resource market is restrictive (per-step price caps,
+                    // price tiers, one purchase at a time), so a player often can't
+                    // buy enough even when trying. Only warn there when they bought
+                    // nothing this turn — buying some but not enough is a deliberate
+                    // choice, not a slip.
+                    if (this.G.map.name !== 'India' || !this.playerBoughtResourceThisTurn()) {
+                        this.confirmMessage = 'Are you sure you want to skip buying resources without enough to power all your plants?';
+                        this.confirmVisible = true;
+                        return;
+                    }
                 }
 
                 if (
@@ -1409,6 +1416,20 @@ export default class Game extends Vue {
             return false;
         }
         return true;
+    }
+
+    // Whether this player has bought at least one resource during their current
+    // resource-buying turn — i.e. the consecutive run of their own moves at the tail
+    // of the log includes a BuyResource. (In the Resources phase only the current
+    // player acts, so their turn is exactly that tail run.)
+    playerBoughtResourceThisTurn(): boolean {
+        const log = this.G!.log;
+        for (let i = log.length - 1; i >= 0; i--) {
+            const entry = log[i];
+            if (entry.type !== 'move' || entry.player !== this.player) return false;
+            if (entry.move.name === MoveName.BuyResource) return true;
+        }
+        return false;
     }
 
     toggleSound() {


### PR DESCRIPTION
…s bought

Two India fixes:

- Starting uranium price was $7, not the $6 the map comment intends. India's resource price is uraniumPrices[length - count], so a starting count of 2 gives uraniumPrices[6] = $7; bump startingResources uranium to 3 so it reads uraniumPrices[5] = $6. Applies to both variants (shared map object).

- The Resources-phase "skip buying resources without enough to power all your plants?" warning fired whenever a player couldn't power everything. India's market is restrictive (per-step price caps, price tiers, one purchase at a time), so a player often can't buy enough even when trying, and the nag is just noise. On India, only show that warning when the player bought nothing this turn; buying some but not enough is a deliberate choice. Every other map is unchanged.