### PR TITLE
Mobile portrait and rulesPortrait layout for phones, the deck build on every map, and India rules (#123)

### DIFF
--- a/engine/src/maps.ts
+++ b/engine/src/maps.ts
@@ -137,6 +137,12 @@ export interface GameMap {
     // cost (there is no sea edge) and pay 10+position*5 + this surcharge.
     crossIslandSurcharge?: number;
     mapSpecificRules?: string;
+    // How this map's power-plant deck and opening market differ from the standard
+    // build. The rules dialog always shows the standard build for the variant in
+    // play, then this underneath as "On this map"; so write the DIFFERENCE, not a
+    // whole procedure, and omit it entirely when the map builds its deck normally.
+    // A map whose two variants diverge gives one string per variant.
+    deckBuild?: string | { recharged?: string; original?: string };
     // Cities where a player's first house (or second network) must be placed.
     // Used by Japan: only the 6 designated starting cities are valid first builds,
     // and a second disconnected network can only begin in one of these cities.

--- a/engine/src/maps/australia.ts
+++ b/engine/src/maps/australia.ts
@@ -285,8 +285,9 @@ export const map: GameMap = {
         'times in one turn. ' +
         'Metropolises: Melbourne and Sydney each consist of two cities (1 and 2) ' +
         'connected by a 0-cost edge. ' +
-        'Regions need not be adjacent: any combination of regions may be in play.\n' +
-        'Deck build - power plant 17 is removed from the game; the five uranium ' +
+        'Regions need not be adjacent: any combination of regions may be in play.\n',
+    deckBuild:
+        'power plant 17 is removed from the game; the five uranium ' +
         'mines (11, 23, 28, 34, 39) stay in the deck. Otherwise standard setup ' +
         'for both variants.',
 };

--- a/engine/src/maps/brazil.ts
+++ b/engine/src/maps/brazil.ts
@@ -306,13 +306,16 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules:
-        'Play with all garbage power plants.\n' +
-        'Deck build recharged - power plants 6 and 14 always start in the ' +
-        'market; the other six market plants are drawn from the remaining low ' +
-        'plants. Garbage plants above 14 are set aside during the player-count ' +
-        'removal and shuffled back in, so no garbage plant ever leaves the game.\n' +
-        'Deck build original - both 13 and 14 are set aside; after the ' +
-        'player-count removal (garbage plants excluded and shuffled back in), ' +
-        '13 goes on top of the deck with 14 directly below it.',
+    mapSpecificRules: 'Play with all garbage power plants.\n',
+    deckBuild: {
+        recharged:
+            'power plants 6 and 14 always start in the ' +
+            'market; the other six market plants are drawn from the remaining low ' +
+            'plants. Garbage plants above 14 are set aside during the player-count ' +
+            'removal and shuffled back in, so no garbage plant ever leaves the game.',
+        original:
+            'both 13 and 14 are set aside; after the ' +
+            'player-count removal (garbage plants excluded and shuffled back in), ' +
+            '13 goes on top of the deck with 14 directly below it.',
+    },
 };

--- a/engine/src/maps/bremen.ts
+++ b/engine/src/maps/bremen.ts
@@ -279,15 +279,19 @@ export const map: GameMap = {
         'from the game. Plant 50 needs no fuel, so it stays in the deck with 5 or 6 ' +
         'players.\n' +
         'Step 2 begins once a player has 5 connected districts (4 for 6 players); the ' +
-        'game ends when a player connects 13 districts (12 for 5 players, 11 for 6).\n' +
-        'Deck build recharged - power plants 11, 17, 23, 28, 34, 36, 38, 39 and 46 ' +
-        'are removed before setup — the six uranium plants plus the three plants ' +
-        'that power 7 cities. With 2 to 4 players, plants 31 and 50 are removed as ' +
-        'well. No further power plants are removed for the number of players. The ' +
-        'opening market of eight is then drawn from the low plants (numbered 15 or ' +
-        'less); of the low plants left over, one is placed on top of the draw deck ' +
-        'and the rest are shuffled into it, with the Step 3 card on the bottom.\n' +
-        'Deck build original - same removals; the market is the fixed 3-6 / 7-10 ' +
-        '(none of these are removed on Bremen), plant 13 is placed on top of the ' +
-        'deck and the Step 3 card on the bottom.',
+        'game ends when a player connects 13 districts (12 for 5 players, 11 for 6).\n',
+    deckBuild: {
+        recharged:
+            'power plants 11, 17, 23, 28, 34, 36, 38, 39 and 46 ' +
+            'are removed before setup — the six uranium plants plus the three plants ' +
+            'that power 7 cities. With 2 to 4 players, plants 31 and 50 are removed as ' +
+            'well. No further power plants are removed for the number of players. The ' +
+            'opening market of eight is then drawn from the low plants (numbered 15 or ' +
+            'less); of the low plants left over, one is placed on top of the draw deck ' +
+            'and the rest are shuffled into it, with the Step 3 card on the bottom.',
+        original:
+            'same removals; the market is the fixed 3-6 / 7-10 ' +
+            '(none of these are removed on Bremen), plant 13 is placed on top of the ' +
+            'deck and the Step 3 card on the bottom.',
+    },
 };

--- a/engine/src/maps/china.ts
+++ b/engine/src/maps/china.ts
@@ -264,8 +264,9 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'There are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.\n' +
-        'Deck build - the same plants are removed every game: with 2-3 players ' +
+        'There are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.\n',
+    deckBuild:
+        'the same plants are removed every game: with 2-3 players ' +
         '3, 4, 9, 11, 16, 18, 20, 24, 30, 33, 46; with 4 players 3, 4, 11, 18, ' +
         '24, 33, 46; with 5-6 players 3, 4, 33. The deck is ordered, not ' +
         'shuffled: plants 5-30 in ascending order on top, then plants 31-35 ' +

--- a/engine/src/maps/europe.ts
+++ b/engine/src/maps/europe.ts
@@ -420,6 +420,7 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck: deck };
     },
     mapSpecificRules:
-        'When Step 2 begins, remove the lowest-numbered plant from the current market from the game once and do not replace it; the future market then has 4 plants instead of 5.\n' +
-        'Deck build - Europe uses the New Power Plants Set 2 deck (cards with a plug on the back). The power plant market starts as 4 current + 5 future power plants (9 total), all drawn from the plug plants; the top card of the draw deck is never a plug plant.',
+        'When Step 2 begins, remove the lowest-numbered plant from the current market from the game once and do not replace it; the future market then has 4 plants instead of 5.\n',
+    deckBuild:
+        'Europe uses the New Power Plants Set 2 deck (cards with a plug on the back). The power plant market starts as 4 current + 5 future power plants (9 total), all drawn from the plug plants; the top card of the draw deck is never a plug plant.',
 };

--- a/engine/src/maps/france.ts
+++ b/engine/src/maps/france.ts
@@ -291,11 +291,13 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules:
-        'Deck build recharged - power plant 13 is removed from the game and ' +
-        'power plant 11 always starts in the market. Removal by player count: ' +
-        '2 players remove 6 higher plants, 3 players remove 1 low and 6 higher, ' +
-        '4 players remove 3 higher.\n' +
-        'Deck build original - power plant 13 is removed from the game; power ' +
-        'plant 11 is placed on top of the deck in its place.',
+    deckBuild: {
+        recharged:
+            'power plant 13 is removed from the game and ' +
+            'power plant 11 always starts in the market. Removal by player count: ' +
+            '2 players remove 6 higher plants, 3 players remove 1 low and 6 higher, ' +
+            '4 players remove 3 higher.',
+        original:
+            'power plant 13 is removed from the game; power ' + 'plant 11 is placed on top of the deck in its place.',
+    },
 };

--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -294,5 +294,8 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.\nDeck build - power plant 11 is removed from the game; otherwise standard setup for both variants (original: plant 13 on top of the deck).',
+        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.',
+    deckBuild:
+        'power plant 11 is removed from the game; otherwise standard setup for ' +
+        'both variants (original: plant 13 on top of the deck).',
 };

--- a/engine/src/maps/indian.ts
+++ b/engine/src/maps/indian.ts
@@ -185,6 +185,13 @@ export const map: GameMap = {
         { nodes: [Cities.Lakhnau, Cities.Varanasi], cost: 7 },
     ],
     layout: 'Portrait',
+    // Taller than the default Portrait viewBox (1060) because India is the one map
+    // that draws BELOW its resource panel: the red "Step 1"/"Step 2" price-cap
+    // markers sit at y=1050 with their separator lines running to y=1060, i.e. flush
+    // with the bottom edge. Measured at 1 px of margin, so any change to the height
+    // the platform gives the viewer clipped them off (issue #123). Same remedy as
+    // Northern Europe's viewBox in #87.
+    viewBox: [1480, 1100],
     mapPosition: [200, -60],
     adjustRatio: [1.25, 1.25],
     resupply: [
@@ -294,7 +301,7 @@ export const map: GameMap = {
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
     mapSpecificRules:
-        'The power grid will suffer a power outage if too many cities are built in one round, penalizing players $3 per city built.\nPlayers take turns buying one resource at a time. The resource market is limited in steps 1 and 2.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.',
+        'The power grid will suffer a power outage if the number of cities built in one round is more than twice the number of players — 9 or more cities in a 4-player game. Every player is then penalized $3 for each city they own, though income for the round never falls below $0.\nPlayers take turns buying one resource at a time. The resource market is limited by step: only resources costing $3 or less may be bought in step 1, $5 or less in step 2, and the whole market is open from step 3.\nGarbage plants are less efficient. Their cost is one higher, but their storage capacity is not changed.\nPlayers must power as many cities as possible in each round.',
     deckBuild:
         'power plant 11 is removed from the game; otherwise standard setup for ' +
         'both variants (original: plant 13 on top of the deck).',

--- a/engine/src/maps/manhattan.ts
+++ b/engine/src/maps/manhattan.ts
@@ -414,8 +414,9 @@ export const map: GameMap = {
         'becomes available for auction, and each Bureaucracy phase the lowest ' +
         'plant is removed from the game. If the market is completely empty, no ' +
         'more power plants can be bought. The game ends when a player has ' +
-        'connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).\n' +
-        'Deck build - at the start of the game, 4 random plug plants are ' +
+        'connected 18 spaces (17 for 3–4 players, 15 for 5, 14 for 6).\n',
+    deckBuild:
+        'at the start of the game, 4 random plug plants are ' +
         'removed. Of the other 9, 8 are in the starting market and 1 is on ' +
         'the top of the deck. The rest of the deck is random with no plug ' +
         'plants. The Step 3 card is removed from the game. For 2-3 players: ' +

--- a/engine/src/maps/northerneurope.ts
+++ b/engine/src/maps/northerneurope.ts
@@ -187,8 +187,9 @@ export const map: GameMap = {
     mapSpecificRules:
         'Nuclear plants may only be purchased by players with at least one city in Sweden, Finland, or the Baltic States. ' +
         'Players with cities only in Norway or Denmark may not bid on or buy nuclear plants. ' +
-        'Resources start at: coal 3 Elektro, oil 3 Elektro, garbage 5 Elektro, uranium 7 Elektro.\n' +
-        'Deck build - standard setup; the regions in play swap in regional ' +
+        'Resources start at: coal 3 Elektro, oil 3 Elektro, garbage 5 Elektro, uranium 7 Elektro.\n',
+    deckBuild:
+        'standard setup; the regions in play swap in regional ' +
         'versions of certain power plants (same numbers, different fuel or ' +
         'output).',
     connections: [

--- a/engine/src/maps/quebec.ts
+++ b/engine/src/maps/quebec.ts
@@ -299,13 +299,16 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules:
-        'Ecological power plants will never be put on the bottom of the deck.\n' +
-        'Deck build recharged - the starting market is drawn from the low ' +
-        'plants (including 13); one more low plant goes on top of the deck, ' +
-        'with 18 and 22 placed directly beneath it. Ecological plants (wind ' +
-        'and fusion) are never removed during setup.\n' +
-        'Deck build original - power plants 13, 18, 22 are set aside and ' +
-        'placed on top of the deck (13 topmost); ecological plants are ' +
-        'excluded from the player-count removal.',
+    mapSpecificRules: 'Ecological power plants will never be put on the bottom of the deck.\n',
+    deckBuild: {
+        recharged:
+            'the starting market is drawn from the low ' +
+            'plants (including 13); one more low plant goes on top of the deck, ' +
+            'with 18 and 22 placed directly beneath it. Ecological plants (wind ' +
+            'and fusion) are never removed during setup.',
+        original:
+            'power plants 13, 18, 22 are set aside and ' +
+            'placed on top of the deck (13 topmost); ecological plants are ' +
+            'excluded from the player-count removal.',
+    },
 };

--- a/engine/src/maps/russia.ts
+++ b/engine/src/maps/russia.ts
@@ -288,16 +288,18 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules:
-        'The power plant market is restricted, and the rules for removing old ' +
-        'plants are changed.\n' +
-        'Deck build recharged - plants 6 and 14 are removed from the game. The ' +
-        'market has 6 plants (3 current, 3 future) drawn at random from the ' +
-        'low plants; the six undrawn low plants sit shuffled on top of the ' +
-        'deck. Removal by player count (higher plants only): 2 players remove ' +
-        '6, 3 players remove 8, 4 players remove 4.\n' +
-        'Deck build original - plants 6 and 14 are removed from the game; the ' +
-        'market is 3, 4, 5 / 7, 8, 9. Plant 13 goes on top of the deck, then ' +
-        'five shuffled cards (plants 10, 11 and the top three of the deck), ' +
-        'then the rest, with the Step 3 card on the bottom.',
+    mapSpecificRules: 'The power plant market is restricted, and the rules for removing old ' + 'plants are changed.\n',
+    deckBuild: {
+        recharged:
+            'plants 6 and 14 are removed from the game. The ' +
+            'market has 6 plants (3 current, 3 future) drawn at random from the ' +
+            'low plants; the six undrawn low plants sit shuffled on top of the ' +
+            'deck. Removal by player count (higher plants only): 2 players remove ' +
+            '6, 3 players remove 8, 4 players remove 4.',
+        original:
+            'plants 6 and 14 are removed from the game; the ' +
+            'market is 3, 4, 5 / 7, 8, 9. Plant 13 goes on top of the deck, then ' +
+            'five shuffled cards (plants 10, 11 and the top three of the deck), ' +
+            'then the rest, with the Step 3 card on the bottom.',
+    },
 };

--- a/engine/src/maps/southafrica.ts
+++ b/engine/src/maps/southafrica.ts
@@ -281,8 +281,9 @@ export const map: GameMap = {
         'countries (Namibia, Botswana, Zimbabwe, Mozambique, Eswatini, Lesotho) are ' +
         'available from the start of the game. The 30 Elektro is the complete cost ' +
         '— no house-base cost is added on top. Only a single player can build on ' +
-        'each cross-border space (cap of 1 instead of the standard 3).\n' +
-        'Deck build - power plant 07 is removed from the game; otherwise ' +
+        'each cross-border space (cap of 1 instead of the standard 3).\n',
+    deckBuild:
+        'power plant 07 is removed from the game; otherwise ' +
         'standard setup for both variants (in the original variant the future ' +
         'market becomes 8, 9, 10, 11).',
 };

--- a/engine/src/maps/spainportugal.ts
+++ b/engine/src/maps/spainportugal.ts
@@ -297,9 +297,9 @@ export const map: GameMap = {
 
         return { actualMarket, futureMarket, powerPlantsDeck };
     },
-    mapSpecificRules:
-        'You cannot buy a nuclear power plant if you only have cities in Portugal.\n' +
-        'Deck build - power plants 18, 22 and 27 are set aside at setup; when ' +
+    mapSpecificRules: 'You cannot buy a nuclear power plant if you only have cities in Portugal.\n',
+    deckBuild:
+        'power plants 18, 22 and 27 are set aside at setup; when ' +
         'Step 2 begins they are placed on top of the deck (18 topmost, then ' +
         '22, then 27).',
 };

--- a/engine/src/maps/ukireland.ts
+++ b/engine/src/maps/ukireland.ts
@@ -308,7 +308,8 @@ export const map: GameMap = {
         'until they build a city in Scotland, Wales, England, or Northern Ireland. ' +
         'Early Step 3: the Step 3 card is placed 3rd from last in the deck (two ' +
         'plants below it). Step 2 begins when a player connects their 7th city ' +
-        '(6th for 6 players).\n' +
-        'Deck build - standard setup for both variants, except the Step 3 card ' +
+        '(6th for 6 players).\n',
+    deckBuild:
+        'standard setup for both variants, except the Step 3 card ' +
         'is placed third from the bottom of the deck (two plants below it).',
 };

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -31,6 +31,47 @@
                 />
             </g>
 
+            <!-- The power-plant draw pile. Authored at the market's own origin so
+                 the landscape board is unchanged, but kept as a separate group so
+                 the portrait layout can move it off the market's row. -->
+            <g
+                ref="slotPowerPlantDeck"
+                :transform="
+                    slotT('powerPlantDeck') ||
+                    `translate(${G.map.powerPlantMarketPosition[0]}, ${G.map.powerPlantMarketPosition[1]})`
+                "
+            >
+                <text x="10" y="14" font-weight="600" fill="black">Power Plant Deck:</text>
+                <template v-if="G.cardsLeft > 0">
+                    <rect
+                        v-for="index in G.cardsLeft"
+                        :key="'deckcard' + index"
+                        :x="35 + index / 5"
+                        :y="38 - index / 10"
+                        width="60"
+                        height="40"
+                        fill="gray"
+                        stroke="black"
+                        stroke-width="2"
+                        rx="4"
+                    />
+                    <rect
+                        :x="35 + G.cardsLeft / 5"
+                        :y="38 - G.cardsLeft / 10"
+                        width="60"
+                        height="40"
+                        :fill="G.nextCardWeak ? 'gray' : 'lightgray'"
+                        stroke="black"
+                        stroke-width="2"
+                        rx="4"
+                    >
+                        <title>
+                            {{ G.cardsLeft }} cards left{{ G.nextCardWeak ? ', next is an initial plant' : '' }}
+                        </title>
+                    </rect>
+                </template>
+            </g>
+
             <g ref="slotPowerPlantMarket" :transform="slotT('powerPlantMarket')">
                 <PowerPlantMarket
                     ref="powerPlantMarket"
@@ -601,7 +642,11 @@ import { formatDuration } from '../util/time';
 const STACK_ROWS: string[][] = [
     ['cityCount', 'playerOrder'],
     ['map'],
-    ['buttons', 'roundInfo'],
+    // Everything that is chrome or reference-only shares ONE row, so the three
+    // markets below can have a row of their own to grow into. John's call at the
+    // phone, 2026-08-19: the market is what you read and tap during an auction;
+    // the draw pile and the round readout are things you glance at.
+    ['buttons', 'roundInfo', 'powerPlantDeck'],
     ['powerPlantMarket'],
     ['resources'],
     ['uraniumMines'],
@@ -615,6 +660,20 @@ const STACK_PAD = 16;
 const STACK_GAP = 28;
 /** A small strip magnified without limit looks broken rather than legible. */
 const STACK_MAX_SCALE = 4;
+/**
+ * Per-slot ceilings, for groups that share a row with something that deserves
+ * the space more. The round/step/phase readout is text and only needs to be
+ * readable; the buttons next to it are tap targets and want every pixel.
+ */
+const STACK_SLOT_MAX_SCALE: Record<string, number> = {
+    roundInfo: 2.2,
+    playerOrder: 2.5,
+    // The market is held just short of the full width on purpose. Stretched edge
+    // to edge, "Actual Market" sits under the far left of the screen and the bid
+    // OK button under the far right — the two spots a thumb reaches worst while
+    // holding the phone. Pulling it in centres the whole row within thumb arc.
+    powerPlantMarket: 3.1,
+};
 
 const slotRef = (name: string) => `slot${name[0].toUpperCase()}${name.slice(1)}`;
 const round = (n: number, digits = 2) => Number(n.toFixed(digits));
@@ -1735,12 +1794,16 @@ export default class Game extends Vue {
             const combined = present.reduce((sum, name) => sum + boxes[name].width, 0);
             // One scale per row keeps neighbours visually consistent. The cap stops
             // a small strip (the turn-order token row) from being blown up absurdly.
-            const scale = Math.min(usable / combined, STACK_MAX_SCALE);
-            const rowHeight = Math.max(...present.map((name) => boxes[name].height * scale));
+            const rowScale = Math.min(usable / combined, STACK_MAX_SCALE);
+            // A slot may decline part of that scale so a neighbour keeps the space.
+            const scaleOf = (name: string) => Math.min(rowScale, STACK_SLOT_MAX_SCALE[name] ?? Infinity);
+            const rowWidth = present.reduce((sum, name) => sum + boxes[name].width * scaleOf(name), 0);
+            const rowHeight = Math.max(...present.map((name) => boxes[name].height * scaleOf(name)));
 
-            let x = (STACK_WIDTH - (combined * scale + gaps)) / 2;
+            let x = (STACK_WIDTH - (rowWidth + gaps)) / 2;
             for (const name of present) {
                 const bb = boxes[name];
+                const scale = scaleOf(name);
                 // Centre a shorter slot against the tallest one in its row.
                 const top = y + (rowHeight - bb.height * scale) / 2;
                 transforms[name] =

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['game', { fitToScreen: preferences.fitToScreen }]">
+    <div :class="['game', { fitToScreen: preferences.fitToScreen && !stacked, stacked: stacked }]">
         <div class="statusBar">
             {{ getStatusMessage() }}
         </div>
@@ -10,62 +10,65 @@
             <source src="../audio/notification.mp3" type="audio/mpeg" />
             <source src="../audio/notification.ogg" type="audio/ogg" />
         </audio>
-        <svg
-            v-if="G"
-            id="scene"
-            :viewBox="G.map.viewBox ? `0 0 ${G.map.viewBox[0]} ${G.map.viewBox[1]}` : '0 0 1500 800'"
-            style="width: 100%"
-        >
+        <svg v-if="G" id="scene" :class="{ stacked: stacked }" :viewBox="sceneViewBox" style="width: 100%">
             <rect width="100%" height="100%" x="0" y="0" fill="yellowgreen" />
 
-            <PlayerOrder
-                ref="playerOrder"
-                :transform="`translate(${G.map.playerOrderPosition[0]}, ${G.map.playerOrderPosition[1]})`"
-                :playerColors="playerColors"
-            />
+            <g ref="slotPlayerOrder" :transform="slotT('playerOrder')">
+                <PlayerOrder
+                    ref="playerOrder"
+                    :transform="`translate(${G.map.playerOrderPosition[0]}, ${G.map.playerOrderPosition[1]})`"
+                    :playerColors="playerColors"
+                />
+            </g>
 
-            <CityCount
-                ref="cityCount"
-                :transform="`translate(${G.map.cityCountPosition[0]}, ${G.map.cityCountPosition[1]})`"
-                :playerColors="playerColors"
-                :citiesToEndGame="G.citiesToEndGame"
-                :citiesToStep2="G.map.name === 'Manhattan' ? undefined : G.citiesToStep2"
-            />
+            <g ref="slotCityCount" :transform="slotT('cityCount')">
+                <CityCount
+                    ref="cityCount"
+                    :transform="`translate(${G.map.cityCountPosition[0]}, ${G.map.cityCountPosition[1]})`"
+                    :playerColors="playerColors"
+                    :citiesToEndGame="G.citiesToEndGame"
+                    :citiesToStep2="G.map.name === 'Manhattan' ? undefined : G.citiesToStep2"
+                />
+            </g>
 
-            <PowerPlantMarket
-                ref="powerPlantMarket"
-                :transform="`translate(${G.map.powerPlantMarketPosition[0]}, ${G.map.powerPlantMarketPosition[1]})`"
-                :canBid="canBid()"
-                :canChoose="canChoose()"
-                :chooseablePowerPlants="getChooseablePowerPlants()"
-                :cardsLeft="G.cardsLeft"
-                :minBid="G.currentBid + 1 || G.minimunBid"
-                :maxBid="G.players[player] ? G.players[player].money : 0"
-                :nextCardWeak="G.nextCardWeak"
-                :plantDiscountActive="G.plantDiscountActive"
-                @choosePowerPlant="choosePowerPlant($event)"
-                @bid="bid($event)"
-            />
+            <g ref="slotPowerPlantMarket" :transform="slotT('powerPlantMarket')">
+                <PowerPlantMarket
+                    ref="powerPlantMarket"
+                    :transform="`translate(${G.map.powerPlantMarketPosition[0]}, ${G.map.powerPlantMarketPosition[1]})`"
+                    :canBid="canBid()"
+                    :canChoose="canChoose()"
+                    :chooseablePowerPlants="getChooseablePowerPlants()"
+                    :cardsLeft="G.cardsLeft"
+                    :minBid="G.currentBid + 1 || G.minimunBid"
+                    :maxBid="G.players[player] ? G.players[player].money : 0"
+                    :nextCardWeak="G.nextCardWeak"
+                    :plantDiscountActive="G.plantDiscountActive"
+                    @choosePowerPlant="choosePowerPlant($event)"
+                    @bid="bid($event)"
+                />
+            </g>
 
-            <Map
-                ref="map"
-                :transform="mapTransform"
-                :playerColors="playerColors"
-                :cities="G.map.cities"
-                :connections="G.map.connections"
-                :polygons="G.map.polygons"
-                :buildableCities="getBuildableCities()"
-                :blockedCities="G.blockedCities"
-                :pickableRegions="getPickableRegions()"
-                :noUraniumRegions="G.map.noUraniumRegions"
-                :devBackdrop="G.map.devBackdrop"
-                :mapRotation="G.map.mapRotation || 0"
-                @build="build($event)"
-                @pickRegion="pickRegion($event)"
-            />
+            <g ref="slotMap" :transform="slotT('map')">
+                <Map
+                    ref="map"
+                    :transform="mapTransform"
+                    :playerColors="playerColors"
+                    :cities="G.map.cities"
+                    :connections="G.map.connections"
+                    :polygons="G.map.polygons"
+                    :buildableCities="getBuildableCities()"
+                    :blockedCities="G.blockedCities"
+                    :pickableRegions="getPickableRegions()"
+                    :noUraniumRegions="G.map.noUraniumRegions"
+                    :devBackdrop="G.map.devBackdrop"
+                    :mapRotation="G.map.mapRotation || 0"
+                    @build="build($event)"
+                    @pickRegion="pickRegion($event)"
+                />
+            </g>
 
             <!-- Japan: Free Jump indicator -->
-            <g v-if="G.map.name === 'Japan'">
+            <g v-if="G.map.name === 'Japan'" ref="slotFreeJump" :transform="slotT('freeJump')">
                 <text x="330" y="93" font-size="20" font-weight="bold" fill="black">Free Jump:</text>
                 <template v-for="(fjPlayer, i) in G.players">
                     <g
@@ -98,27 +101,35 @@
                 </template>
             </g>
 
-            <Resources
-                ref="resources"
-                :transform="`translate(${G.map.supplyPosition[0]}, ${G.map.supplyPosition[1]})`"
-                :isUsaRecharged="G.options.variant == 'recharged' && G.map.name == 'USA'"
-                :isMiddleEast="G.map.name == 'Middle East'"
-                :isIndiaResourceMarket="G.map.name == 'India' && G.coalPrices && G.garbagePrices && G.uraniumPrices"
-                :availableSurplusOil="
-                    G.map.name == 'Middle East' ? Math.max(G.oilMarket - G.oilPrices.filter((p) => p > 1).length, 0) : 0
-                "
-                :buyableResources="buyableResources()"
-                :coalStorage="G.coalStorage"
-                :resourceResupply="getResourceResupply()"
-                :resourceResupplyNorth="getResourceResupplyNorth()"
-                @buyResource="buyResource($event)"
-            />
+            <g ref="slotResources" :transform="slotT('resources')">
+                <Resources
+                    ref="resources"
+                    :transform="`translate(${G.map.supplyPosition[0]}, ${G.map.supplyPosition[1]})`"
+                    :isUsaRecharged="G.options.variant == 'recharged' && G.map.name == 'USA'"
+                    :isMiddleEast="G.map.name == 'Middle East'"
+                    :isIndiaResourceMarket="G.map.name == 'India' && G.coalPrices && G.garbagePrices && G.uraniumPrices"
+                    :availableSurplusOil="
+                        G.map.name == 'Middle East'
+                            ? Math.max(G.oilMarket - G.oilPrices.filter((p) => p > 1).length, 0)
+                            : 0
+                    "
+                    :buyableResources="buyableResources()"
+                    :coalStorage="G.coalStorage"
+                    :resourceResupply="getResourceResupply()"
+                    :resourceResupplyNorth="getResourceResupplyNorth()"
+                    @buyResource="buyResource($event)"
+                />
+            </g>
 
             <!-- Australia: uranium-mine selling table. Six price rows $7 (top) →
                  $2 (bottom), two token slots each. Sellers place one token per mine
                  on the highest empty slot; the resource refill removes from the
                  cheap (bottom) end. Lives in the clear upper-left margin. -->
-            <g v-if="G.map.name === 'Australia' && G.uraniumMineMarket" transform="translate(15, 70)">
+            <g
+                v-if="G.map.name === 'Australia' && G.uraniumMineMarket"
+                ref="slotUraniumMines"
+                :transform="slotT('uraniumMines') || 'translate(15, 70)'"
+            >
                 <rect x="0" y="0" width="104" height="430" rx="6" fill="#8aa84a" stroke="#4d6322" stroke-width="3" />
                 <text x="52" y="22" text-anchor="middle" font-weight="700" fill="black" style="font-size: 15px">
                     Uranium
@@ -176,7 +187,12 @@
                 </text>
             </g>
 
-            <g :transform="`translate(${G.map.roundInfoPosition[0]}, ${G.map.roundInfoPosition[1]})`">
+            <g
+                ref="slotRoundInfo"
+                :transform="
+                    slotT('roundInfo') || `translate(${G.map.roundInfoPosition[0]}, ${G.map.roundInfoPosition[1]})`
+                "
+            >
                 <template v-if="gameEnded(G)">
                     <Button
                         :transform="`translate(20, 50)`"
@@ -204,7 +220,10 @@
                 </template>
             </g>
 
-            <g :transform="`translate(${G.map.buttonsPosition[0]}, ${G.map.buttonsPosition[1]})`">
+            <g
+                ref="slotButtons"
+                :transform="slotT('buttons') || `translate(${G.map.buttonsPosition[0]}, ${G.map.buttonsPosition[1]})`"
+            >
                 <PassButton
                     transform="translate(15, 15)"
                     :enabled="canPass()"
@@ -224,28 +243,30 @@
                 <RulesButton transform="translate(110, 95)" @click="rulesVisible = true" />
             </g>
 
-            <template v-for="(playerIndex, i) in adjustedPlayerOrder">
-                <PlayerBoard
-                    :key="'B' + playerIndex"
-                    :transform="`translate(${G.map.playerBoardsPosition[0]}, ${
-                        G.map.playerBoardsPosition[1] + 110 * i
-                    })`"
-                    :player="G.players[playerIndex]"
-                    :color="playerColors[playerIndex]"
-                    :avatar="avatars[playerIndex]"
-                    :owner="playerIndex"
-                    :isCurrentPlayer="isCurrentPlayer(playerIndex)"
-                    :ended="gameEnded(G)"
-                    :isPlayer="player == playerIndex"
-                    :ranking="sortedPlayers.findIndex((x) => x.id == G.players[playerIndex].id) + 1"
-                    :showMoney="player == playerIndex || gameEnded(G) || G.options.showMoney"
-                    :showBid="!G.options.fastBid"
-                    :phase="G.phase"
-                    :isAustralia="G.map.name === 'Australia'"
-                    @powerPlantClick="powerPlantClick($event)"
-                    @discardResource="discardResource($event)"
-                />
-            </template>
+            <g ref="slotPlayerBoards" :transform="slotT('playerBoards')">
+                <template v-for="(playerIndex, i) in adjustedPlayerOrder">
+                    <PlayerBoard
+                        :key="'B' + playerIndex"
+                        :transform="`translate(${G.map.playerBoardsPosition[0]}, ${
+                            G.map.playerBoardsPosition[1] + 110 * i
+                        })`"
+                        :player="G.players[playerIndex]"
+                        :color="playerColors[playerIndex]"
+                        :avatar="avatars[playerIndex]"
+                        :owner="playerIndex"
+                        :isCurrentPlayer="isCurrentPlayer(playerIndex)"
+                        :ended="gameEnded(G)"
+                        :isPlayer="player == playerIndex"
+                        :ranking="sortedPlayers.findIndex((x) => x.id == G.players[playerIndex].id) + 1"
+                        :showMoney="player == playerIndex || gameEnded(G) || G.options.showMoney"
+                        :showBid="!G.options.fastBid"
+                        :phase="G.phase"
+                        :isAustralia="G.map.name === 'Australia'"
+                        @powerPlantClick="powerPlantClick($event)"
+                        @discardResource="discardResource($event)"
+                    />
+                </template>
+            </g>
         </svg>
 
         <div v-if="G" :class="['modal', { visible: logVisible }]">
@@ -371,22 +392,24 @@
             <div class="modal-content">
                 <span class="close" @click="endScoreVisible = false">&times;</span>
                 <div class="modal-title">Final Score</div>
-                <table class="final-score-table">
-                    <tr>
-                        <th><div>Player</div></th>
-                        <th v-for="player in sortedPlayers" :key="'FS' + player.id">
-                            <div :style="'background-color: ' + playerColors[player.id]">{{ player.name }}</div>
-                        </th>
-                    </tr>
-                    <tr v-for="(cat, i) in ['Cities Powered', 'Money', 'Total Cities']" :key="'FC_' + cat">
-                        <td>{{ cat }}</td>
-                        <td v-for="player in sortedPlayers" :key="'FS' + player.id + i">
-                            <div>
-                                {{ i == 0 ? player.citiesPowered : i == 1 ? player.money : player.cities.length }}
-                            </div>
-                        </td>
-                    </tr>
-                </table>
+                <div class="table-scroll">
+                    <table class="final-score-table">
+                        <tr>
+                            <th><div>Player</div></th>
+                            <th v-for="player in sortedPlayers" :key="'FS' + player.id">
+                                <div :style="'background-color: ' + playerColors[player.id]">{{ player.name }}</div>
+                            </th>
+                        </tr>
+                        <tr v-for="(cat, i) in ['Cities Powered', 'Money', 'Total Cities']" :key="'FC_' + cat">
+                            <td>{{ cat }}</td>
+                            <td v-for="player in sortedPlayers" :key="'FS' + player.id + i">
+                                <div>
+                                    {{ i == 0 ? player.citiesPowered : i == 1 ? player.money : player.cities.length }}
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
             </div>
         </div>
 
@@ -394,20 +417,22 @@
             <div class="modal-content">
                 <span class="close" @click="spendingVisible = false">&times;</span>
                 <div class="modal-title">Spending</div>
-                <table class="spending-table">
-                    <tr>
-                        <th><div>Player</div></th>
-                        <th v-for="player in sortedPlayers" :key="'FS' + player.id">
-                            <div :style="'background-color: ' + playerColors[player.id]">{{ player.name }}</div>
-                        </th>
-                    </tr>
-                    <tr v-for="row in spendingRows" :key="'FC_' + row.label">
-                        <td>{{ row.label }}</td>
-                        <td v-for="player in sortedPlayers" :key="'FS' + player.id + row.label">
-                            <div>{{ row.value(player) }}</div>
-                        </td>
-                    </tr>
-                </table>
+                <div class="table-scroll">
+                    <table class="spending-table">
+                        <tr>
+                            <th><div>Player</div></th>
+                            <th v-for="player in sortedPlayers" :key="'FS' + player.id">
+                                <div :style="'background-color: ' + playerColors[player.id]">{{ player.name }}</div>
+                            </th>
+                        </tr>
+                        <tr v-for="row in spendingRows" :key="'FC_' + row.label">
+                            <td>{{ row.label }}</td>
+                            <td v-for="player in sortedPlayers" :key="'FS' + player.id + row.label">
+                                <div>{{ row.value(player) }}</div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
             </div>
         </div>
 
@@ -520,26 +545,28 @@
                         <br />
                         <div>
                             <strong>Map Specific Rules:</strong><br />
-                            <span style="white-space: pre-wrap">{{ G.map.mapSpecificRules }}</span>
+                            <span class="map-specific-rules">{{ G.map.mapSpecificRules }}</span>
                         </div>
                     </template>
                     <br />
                     <div>
                         <strong>Payment Table</strong>
-                        <table class="payment-table">
-                            <tr>
-                                <td><strong>Cities</strong></td>
-                                <template v-for="index in G.citiesToEndGame">
-                                    <td :key="'cities' + index">{{ index - 1 }}</td>
-                                </template>
-                            </tr>
-                            <tr>
-                                <td><strong>Payment</strong></td>
-                                <template v-for="index in G.citiesToEndGame">
-                                    <td :key="'payment' + index">${{ G.paymentTable[index - 1] }}</td>
-                                </template>
-                            </tr>
-                        </table>
+                        <div class="table-scroll">
+                            <table class="payment-table">
+                                <tr>
+                                    <td><strong>Cities</strong></td>
+                                    <template v-for="index in G.citiesToEndGame">
+                                        <td :key="'cities' + index">{{ index - 1 }}</td>
+                                    </template>
+                                </tr>
+                                <tr>
+                                    <td><strong>Payment</strong></td>
+                                    <template v-for="index in G.citiesToEndGame">
+                                        <td :key="'payment' + index">${{ G.paymentTable[index - 1] }}</td>
+                                    </template>
+                                </tr>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -566,6 +593,31 @@ import { LogMove } from 'powergrid-engine/src/log';
 import { Phase, playerTimeUsed, PowerPlant, PowerPlantType, ResourceType } from 'powergrid-engine/src/gamestate';
 import { City } from 'powergrid-engine/src/maps';
 import { formatDuration } from '../util/time';
+
+// Portrait layout: the rows the scene is broken into, top to bottom. Slots on
+// the same row sit side by side and share one scale. Names map to the `slotX`
+// refs on the wrapper groups in the template; a slot whose group is absent for
+// this map (Australia's mine market, Japan's free jump) is simply skipped.
+const STACK_ROWS: string[][] = [
+    ['cityCount', 'playerOrder'],
+    ['map'],
+    ['buttons', 'roundInfo'],
+    ['powerPlantMarket'],
+    ['resources'],
+    ['uraniumMines'],
+    ['freeJump'],
+    ['playerBoards'],
+];
+/** Width of the stacked canvas in scene units — kept at the usual scene width
+ *  so the numbers stay recognisable next to the per-map coordinates. */
+const STACK_WIDTH = 1465;
+const STACK_PAD = 16;
+const STACK_GAP = 28;
+/** A small strip magnified without limit looks broken rather than legible. */
+const STACK_MAX_SCALE = 4;
+
+const slotRef = (name: string) => `slot${name[0].toUpperCase()}${name.slice(1)}`;
+const round = (n: number, digits = 2) => Number(n.toFixed(digits));
 
 @Component({
     created(this: Game) {
@@ -797,6 +849,10 @@ export default class Game extends Vue {
                 this.cityCount.createPieces(this.G!);
                 this.map.createPieces(this.G!);
                 this.resources.createPieces(this.G!);
+                // Pieces are added imperatively, so the groups only reach their
+                // final size here — the portrait layout must measure after this,
+                // not on the state change that triggered it.
+                this.scheduleRelayout();
             });
         }
 
@@ -825,6 +881,9 @@ export default class Game extends Vue {
             setTimeout(() => this.updateUI());
             return;
         }
+
+        // Pieces have finished moving, so the groups are at their settled size.
+        this.scheduleRelayout();
     }
 
     checkPass() {
@@ -1597,6 +1656,129 @@ export default class Game extends Vue {
         return `translate(${mx}, ${my}) rotate(${rotation}, ${cx}, ${cy})`;
     }
 
+    // ── Portrait ("stacked") layout ─────────────────────────────────────────
+    // The whole game is ONE svg laid out in per-map absolute coordinates: board
+    // on the left, market and player boards in a right-hand column, resource
+    // supply along the bottom. That composition assumes a landscape viewport.
+    // On a portrait phone it letterboxes: measured at 390x844 the board drew at
+    // 390x229 and left 73% of the screen empty, with 7x10px city slots and
+    // 21x7px buttons.
+    //
+    // Rather than author a second set of coordinates for 24 maps, we re-use the
+    // ones we already have: each group is measured with getBBox() and mapped
+    // onto a full-width row by a single transform on its wrapper <g>. Nothing
+    // inside the components changes, and on a landscape/desktop viewport no
+    // transform is emitted at all, so those layouts render exactly as before.
+
+    /** True while the portrait row layout is in effect. */
+    stacked = false;
+    /** Height of the stacked canvas, in scene units. */
+    stackHeight = STACK_WIDTH;
+    /** Wrapper transform per slot; empty means "render as authored". */
+    slotTransforms: Record<string, string> = {};
+
+    get sceneViewBox() {
+        if (this.stacked) {
+            return `0 0 ${STACK_WIDTH} ${this.stackHeight}`;
+        }
+        return this.G?.map?.viewBox ? `0 0 ${this.G.map.viewBox[0]} ${this.G.map.viewBox[1]}` : '0 0 1500 800';
+    }
+
+    slotT(name: string): string | undefined {
+        return this.slotTransforms[name];
+    }
+
+    /**
+     * Only portrait viewports are re-laid out. A landscape phone already reads
+     * well (the scene's own aspect ratio is close to the screen's), so leaving
+     * it alone keeps the change surface small.
+     */
+    private shouldStack(): boolean {
+        return window.innerWidth < 900 && window.innerHeight > window.innerWidth * 1.1;
+    }
+
+    relayout() {
+        if (!this.shouldStack()) {
+            if (this.stacked) {
+                this.stacked = false;
+                this.slotTransforms = {};
+            }
+            return;
+        }
+
+        // getBBox() reports a group's box in its OWN user space, i.e. before its
+        // own transform is applied — so measuring is safe even while a previous
+        // stacked transform is in place, and a re-layout never feeds on its own
+        // output.
+        const boxes: Record<string, { x: number; y: number; width: number; height: number }> = {};
+        for (const name of STACK_ROWS.flat()) {
+            const el = this.$refs[slotRef(name)] as SVGGraphicsElement | undefined;
+            if (!el || typeof el.getBBox !== 'function') continue;
+            try {
+                const bb = el.getBBox();
+                if (bb.width > 0 && bb.height > 0) {
+                    boxes[name] = { x: bb.x, y: bb.y, width: bb.width, height: bb.height };
+                }
+            } catch {
+                // Not rendered yet (or detached) — skip; the next relayout catches it.
+            }
+        }
+
+        const transforms: Record<string, string> = {};
+        let y = STACK_PAD;
+        for (const row of STACK_ROWS) {
+            const present = row.filter((name) => boxes[name]);
+            if (!present.length) continue;
+
+            const gaps = STACK_GAP * (present.length - 1);
+            const usable = STACK_WIDTH - 2 * STACK_PAD - gaps;
+            const combined = present.reduce((sum, name) => sum + boxes[name].width, 0);
+            // One scale per row keeps neighbours visually consistent. The cap stops
+            // a small strip (the turn-order token row) from being blown up absurdly.
+            const scale = Math.min(usable / combined, STACK_MAX_SCALE);
+            const rowHeight = Math.max(...present.map((name) => boxes[name].height * scale));
+
+            let x = (STACK_WIDTH - (combined * scale + gaps)) / 2;
+            for (const name of present) {
+                const bb = boxes[name];
+                // Centre a shorter slot against the tallest one in its row.
+                const top = y + (rowHeight - bb.height * scale) / 2;
+                transforms[name] =
+                    `translate(${round(x - bb.x * scale)}, ${round(top - bb.y * scale)}) scale(${round(scale, 4)})`;
+                x += bb.width * scale + STACK_GAP;
+            }
+            y += rowHeight + STACK_GAP;
+        }
+
+        this.stackHeight = Math.round(y + STACK_PAD - STACK_GAP);
+        this.slotTransforms = transforms;
+        this.stacked = true;
+    }
+
+    private scheduleRelayout() {
+        this.$nextTick(() => this.relayout());
+    }
+
+    private onViewportResize = () => this.scheduleRelayout();
+
+    mounted() {
+        window.addEventListener('resize', this.onViewportResize);
+        window.addEventListener('orientationchange', this.onViewportResize);
+        this.scheduleRelayout();
+    }
+
+    beforeDestroy() {
+        window.removeEventListener('resize', this.onViewportResize);
+        window.removeEventListener('orientationchange', this.onViewportResize);
+    }
+
+    // Boards grow as players buy plants, so the row heights are re-derived on
+    // every state change rather than measured once at mount.
+    @Watch('G')
+    onSceneContentChanged() {
+        this.scheduleRelayout();
+    }
+
     get adjustedPlayerOrder() {
         if (!this.G) {
             return [];
@@ -1663,6 +1845,20 @@ ul {
     max-height: calc(100% - 40px);
     flex-grow: 1;
     margin: 40px auto auto auto;
+}
+
+// Portrait: the scene is taller than the viewport by design (each row is scaled
+// to the full width), so it must be allowed to overflow and scroll instead of
+// being squeezed back into one screen.
+.game.stacked {
+    height: auto;
+    align-items: stretch;
+
+    #scene {
+        max-height: none;
+        flex-grow: 0;
+        margin-top: 40px;
+    }
 }
 
 body,
@@ -1766,6 +1962,8 @@ text {
     margin: auto;
     padding: 10px 20px 20px 20px;
     border: 1px solid #888;
+    box-sizing: border-box;
+    max-width: 100%;
 }
 
 @media only screen and (min-width: 1240px) {
@@ -1820,6 +2018,25 @@ text {
     cursor: pointer;
 }
 
+// Printed rules text keeps its authored line breaks, but a long unbroken run
+// (a city list, a URL) must still fold rather than widen the dialog.
+.map-specific-rules {
+    display: block;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+// Tables are naturally wider than a phone (one column per player, plus a wide
+// label column). Without a scroll container they simply overflowed the modal and
+// the far columns were unreachable — on a 6-player game only the last player was
+// visible. The container scrolls; the label column stays pinned so a value never
+// loses its row.
+.table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
 .payment-table {
     border: 1px solid black;
     margin: 5px auto;
@@ -1854,9 +2071,53 @@ text {
 
         td:first-child,
         th:first-child {
+            position: sticky;
+            left: 0;
+            background-color: #fefefe;
+            box-shadow: 2px 0 3px -1px rgba(0, 0, 0, 0.3);
+
             div {
                 width: 250px;
             }
+        }
+    }
+}
+
+// Phone-sized screens: shrink the columns so more than one player fits on
+// screen before any scrolling is needed.
+@media only screen and (max-width: 700px) {
+    .modal-content {
+        padding: 10px;
+    }
+
+    .final-score-table,
+    .spending-table {
+        tr {
+            td,
+            th {
+                div {
+                    width: auto;
+                    min-width: 60px;
+                    padding: 0 6px;
+                    line-height: 32px;
+                }
+            }
+
+            td:first-child,
+            th:first-child {
+                div {
+                    width: auto;
+                    min-width: 0;
+                    max-width: 38vw;
+                    text-align: left;
+                }
+            }
+        }
+    }
+
+    .payment-table {
+        tr td {
+            padding: 0 6px;
         }
     }
 }

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -602,6 +602,17 @@
                     </template>
                     <br />
                     <div>
+                        <strong>Deck build:</strong><br />
+                        <span class="map-specific-rules">{{ standardDeckBuild }}</span>
+                        <template v-if="mapDeckBuild">
+                            <br />
+                            <span class="map-specific-rules"
+                                ><strong>On {{ G.map.name }}:</strong> {{ mapDeckBuild }}</span
+                            >
+                        </template>
+                    </div>
+                    <br />
+                    <div>
                         <strong>Payment Table</strong>
                         <div class="table-scroll">
                             <table class="payment-table">
@@ -708,6 +719,25 @@ const STACK_SLOT_MAX_SCALE: Record<string, number> = {
  */
 const STACK_SLOT_MAX_WIDTH: Record<string, number> = {
     powerPlantMarket: 0.88,
+};
+
+/**
+ * How the deck and opening market are built when a map says nothing special —
+ * i.e. the rule the per-map `deckBuild` notes are differences FROM. Wording is
+ * the legend row of the deck-build grid Mike reviewed on 2026-08-13.
+ */
+const STANDARD_DECK_BUILD: Record<string, string> = {
+    recharged:
+        'Shuffle the 13 low power plants (3-15). Draw 8 and sort them ascending: the 4 cheapest form the ' +
+        'current market, the next 4 the future market. One of the remaining low plants goes face down on ' +
+        'top of the draw deck. Player-count removal: 2 players remove 1 low + 5 higher plants; 3 players ' +
+        'remove 2 low + 6 higher; 4 players remove 1 low + 3 higher; 5-6 players remove none. The leftover ' +
+        'low plants are shuffled into the deck, with the Step 3 card on the bottom.',
+    original:
+        'The market is fixed: power plants 3, 4, 5, 6 are the current market and 7, 8, 9, 10 the future ' +
+        'market. Power plant 13 and the Step 3 card are set aside and the rest of the deck is shuffled, ' +
+        'then 8 random plants are removed for 2-3 players, 4 for 4 players, and none for 5-6 players. ' +
+        'Power plant 13 goes on top of the deck and the Step 3 card on the bottom.',
 };
 
 const slotRef = (name: string) => `slot${name[0].toUpperCase()}${name.slice(1)}`;
@@ -1736,6 +1766,21 @@ export default class Game extends Vue {
             // Every clock is stopped once the game ends, so the banked total is final.
             { label: 'Time Used', value: (p) => formatDuration(playerTimeUsed(p)) },
         ];
+    }
+
+    // The standard deck build for the variant in play. Shown on EVERY map: the
+    // per-map notes are written as differences from it, so without it a line like
+    // "18, 22 and 27 are set aside" tells a new player nothing about the rest.
+    get standardDeckBuild(): string {
+        return STANDARD_DECK_BUILD[this.G?.options.variant ?? 'recharged'] ?? STANDARD_DECK_BUILD.recharged;
+    }
+
+    /** This map's departure from the standard build, or '' when it follows it. */
+    get mapDeckBuild(): string {
+        const deckBuild = this.G?.map.deckBuild;
+        if (!deckBuild) return '';
+        if (typeof deckBuild === 'string') return deckBuild;
+        return deckBuild[(this.G!.options.variant ?? 'recharged') as 'recharged' | 'original'] ?? '';
     }
 
     get mapTransform() {

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -282,6 +282,15 @@
                 <SoundButton transform="translate(110, 13)" :isOn="preferences.sound" @click="toggleSound()" />
                 <HelpButton transform="translate(110, 54)" :isOn="!preferences.disableHelp" @click="toggleHelp()" />
                 <RulesButton transform="translate(110, 95)" @click="rulesVisible = true" />
+                <!-- Only offered where it means something. Shown whenever the
+                     viewport is portrait — not only while stacking is active — so
+                     it can undo its own effect. -->
+                <LayoutButton
+                    v-if="portraitViewport"
+                    transform="translate(15, 138)"
+                    :isOn="stacked"
+                    @click="toggleStackLayout()"
+                />
             </g>
 
             <g ref="slotPlayerBoards" :transform="slotT('playerBoards')">
@@ -622,7 +631,16 @@ import { EventEmitter } from 'events';
 import { matchesTurnBuffer, rebaseTurnBuffer, replayTurnBuffer as replayBuffer } from '../util/turn-buffer';
 import { UIData, Preferences } from '../types/ui-data';
 import { Card, House, Coal, Oil, Garbage, Uranium } from './pieces';
-import { Button, PassButton, UndoButton, LogButton, SoundButton, HelpButton, RulesButton } from './buttons';
+import {
+    Button,
+    PassButton,
+    UndoButton,
+    LogButton,
+    SoundButton,
+    HelpButton,
+    RulesButton,
+    LayoutButton,
+} from './buttons';
 import PlayerBoard from './PlayerBoard.vue';
 import Calculator from './Calculator.vue';
 import PowerPlantMarket from './boards/PowerPlantMarket.vue';
@@ -721,6 +739,7 @@ const round = (n: number, digits = 2) => Number(n.toFixed(digits));
         SoundButton,
         HelpButton,
         RulesButton,
+        LayoutButton,
         Button,
         Calculator,
         PowerPlantMarket,
@@ -1731,6 +1750,13 @@ export default class Game extends Vue {
 
     /** True while the portrait row layout is in effect. */
     stacked = false;
+    /**
+     * True when the viewport is one the row layout applies to, whether or not the
+     * player has it switched on. Kept separate from `stacked` so the toggle stays
+     * visible after someone turns stacking off — otherwise the button that undoes
+     * the choice would disappear along with the layout.
+     */
+    portraitViewport = false;
     /** Height of the stacked canvas, in scene units. */
     stackHeight = STACK_WIDTH;
     /** Wrapper transform per slot; empty means "render as authored". */
@@ -1752,11 +1778,25 @@ export default class Game extends Vue {
      * well (the scene's own aspect ratio is close to the screen's), so leaving
      * it alone keeps the change surface small.
      */
-    private shouldStack(): boolean {
+    private isPortraitViewport(): boolean {
         return window.innerWidth < 900 && window.innerHeight > window.innerWidth * 1.1;
     }
 
+    private shouldStack(): boolean {
+        return this.isPortraitViewport() && this.preferences.stackOnPortrait !== false;
+    }
+
+    toggleStackLayout() {
+        const newVal = !this.stacked;
+
+        this.emitter.emit('update:preference', { name: 'stackOnPortrait', value: newVal });
+        this.preferences.stackOnPortrait = newVal;
+        this.relayout();
+    }
+
     relayout() {
+        this.portraitViewport = this.isPortraitViewport();
+
         if (!this.shouldStack()) {
             if (this.stacked) {
                 this.stacked = false;

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -728,7 +728,8 @@ const STACK_SLOT_MAX_WIDTH: Record<string, number> = {
  */
 const STANDARD_DECK_BUILD: Record<string, string> = {
     recharged:
-        'Shuffle the 13 low power plants (3-15). Draw 8 and sort them ascending: the 4 cheapest form the ' +
+        'Shuffle the 13 low power plants — the "plug plants" (3-15), named for the plug on the back of ' +
+        'the printed cards. Draw 8 and sort them ascending: the 4 cheapest form the ' +
         'current market, the next 4 the future market. One of the remaining low plants goes face down on ' +
         'top of the draw deck. Player-count removal: 2 players remove 1 low + 5 higher plants; 3 players ' +
         'remove 2 low + 6 higher; 4 players remove 1 low + 3 higher; 5-6 players remove none. The leftover ' +

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -284,10 +284,12 @@
                 <RulesButton transform="translate(110, 95)" @click="rulesVisible = true" />
                 <!-- Only offered where it means something. Shown whenever the
                      viewport is portrait — not only while stacking is active — so
-                     it can undo its own effect. -->
+                     it can undo its own effect. Sits under Rules rather than under
+                     Log: the left column's next slot overlaps the turn-order table
+                     on the authored board. -->
                 <LayoutButton
                     v-if="portraitViewport"
-                    transform="translate(15, 138)"
+                    transform="translate(110, 136)"
                     :isOn="stacked"
                     @click="toggleStackLayout()"
                 />
@@ -678,6 +680,12 @@ const STACK_PAD = 16;
 const STACK_GAP = 28;
 /** A small strip magnified without limit looks broken rather than legible. */
 const STACK_MAX_SCALE = 4;
+/**
+ * No single row may fill more than this share of the screen, so the row below it
+ * always peeks and the page reads as scrollable. Without it a tall, narrow board
+ * (Manhattan takes 92% of an iPhone XR) looks like the whole page.
+ */
+const STACK_MAX_ROW_SCREENS = 0.72;
 /**
  * Per-slot ceilings, for groups that share a row with something that deserves
  * the space more. The round/step/phase readout is text and only needs to be
@@ -1823,6 +1831,11 @@ export default class Game extends Vue {
             }
         }
 
+        // A row of `h` scene units renders at h * (innerWidth / STACK_WIDTH) css px,
+        // because the canvas width always maps to the viewport width.
+        const unitsPerScreen = (STACK_MAX_ROW_SCREENS * window.innerHeight * STACK_WIDTH) / window.innerWidth;
+        const heightCapFor = (height: number) => unitsPerScreen / height;
+
         const transforms: Record<string, string> = {};
         let y = STACK_PAD;
         for (const row of STACK_ROWS) {
@@ -1835,8 +1848,10 @@ export default class Game extends Vue {
             // One scale per row keeps neighbours visually consistent. The cap stops
             // a small strip (the turn-order token row) from being blown up absurdly.
             const rowScale = Math.min(usable / combined, STACK_MAX_SCALE);
-            // A slot may decline part of that scale so a neighbour keeps the space.
-            const scaleOf = (name: string) => Math.min(rowScale, STACK_SLOT_MAX_SCALE[name] ?? Infinity);
+            // A slot may decline part of that scale so a neighbour keeps the space,
+            // and no slot may grow past the height budget for one row.
+            const scaleOf = (name: string) =>
+                Math.min(rowScale, STACK_SLOT_MAX_SCALE[name] ?? Infinity, heightCapFor(boxes[name].height));
             const rowWidth = present.reduce((sum, name) => sum + boxes[name].width * scaleOf(name), 0);
             const rowHeight = Math.max(...present.map((name) => boxes[name].height * scaleOf(name)));
 

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -694,11 +694,20 @@ const STACK_MAX_ROW_SCREENS = 0.72;
 const STACK_SLOT_MAX_SCALE: Record<string, number> = {
     roundInfo: 2.2,
     playerOrder: 2.5,
-    // The market is held just short of the full width on purpose. Stretched edge
-    // to edge, "Actual Market" sits under the far left of the screen and the bid
-    // OK button under the far right — the two spots a thumb reaches worst while
-    // holding the phone. Pulling it in centres the whole row within thumb arc.
-    powerPlantMarket: 3.1,
+};
+/**
+ * Share of the canvas width a slot may occupy. The market is held short of the
+ * full width on purpose: stretched edge to edge, "Actual Market" sits under the
+ * far left of the screen and the bid OK button under the far right — the two
+ * spots a thumb reaches worst while holding the phone.
+ *
+ * This has to be a WIDTH budget rather than a scale ceiling, because the market's
+ * own width varies: Benelux authors `actualMarketWidth: 495`, and it shrinks again
+ * in Step 3 once the future market is gone. A fixed scale that centred Bremen left
+ * Benelux at 97% of the canvas, i.e. still touching both edges.
+ */
+const STACK_SLOT_MAX_WIDTH: Record<string, number> = {
+    powerPlantMarket: 0.88,
 };
 
 const slotRef = (name: string) => `slot${name[0].toUpperCase()}${name.slice(1)}`;
@@ -1851,7 +1860,12 @@ export default class Game extends Vue {
             // A slot may decline part of that scale so a neighbour keeps the space,
             // and no slot may grow past the height budget for one row.
             const scaleOf = (name: string) =>
-                Math.min(rowScale, STACK_SLOT_MAX_SCALE[name] ?? Infinity, heightCapFor(boxes[name].height));
+                Math.min(
+                    rowScale,
+                    STACK_SLOT_MAX_SCALE[name] ?? Infinity,
+                    ((STACK_SLOT_MAX_WIDTH[name] ?? Infinity) * usable) / boxes[name].width,
+                    heightCapFor(boxes[name].height)
+                );
             const rowWidth = present.reduce((sum, name) => sum + boxes[name].width * scaleOf(name), 0);
             const rowHeight = Math.max(...present.map((name) => boxes[name].height * scaleOf(name)));
 

--- a/viewer/src/components/boards/PowerPlantMarket.vue
+++ b/viewer/src/components/boards/PowerPlantMarket.vue
@@ -1,33 +1,8 @@
 <template>
     <g>
-        <text x="10" y="14" font-weight="600" fill="black">Power Plant Deck:</text>
-        <template v-if="cardsLeft > 0">
-            <rect
-                v-for="index in cardsLeft"
-                :key="'card' + index"
-                :x="35 + index / 5"
-                :y="38 - index / 10"
-                width="60"
-                height="40"
-                fill="gray"
-                stroke="black"
-                stroke-width="2"
-                rx="4"
-            />
-            <rect
-                :x="35 + cardsLeft / 5"
-                :y="38 - cardsLeft / 10"
-                width="60"
-                height="40"
-                :fill="nextCardWeak ? 'gray' : 'lightgray'"
-                stroke="black"
-                stroke-width="2"
-                rx="4"
-            >
-                <title>{{ cardsLeft }} cards left{{ nextCardWeak ? ', next is an initial plant' : '' }}</title>
-            </rect>
-        </template>
-
+        <!-- The draw pile is rendered by Game.vue as its own group, not here: it is
+             static reference art next to three interactive markets, so the portrait
+             layout needs to be able to place it on a different row. -->
         <text x="165" y="14" font-weight="600" fill="black">Actual Market:</text>
         <template v-for="(card, i) in actualMarketCards">
             <Card

--- a/viewer/src/components/buttons/LayoutButton.vue
+++ b/viewer/src/components/buttons/LayoutButton.vue
@@ -1,0 +1,27 @@
+<template>
+    <g class="button enabled" @click="$emit('click')">
+        <circle cx="15" cy="15" r="15" fill="gainsboro" stroke="black" stroke-width="2px" />
+        <!-- Stacked: three full-width rows. Wide: the authored side-by-side board. -->
+        <template v-if="isOn">
+            <rect x="6" y="7" width="18" height="4" rx="1" fill="black" />
+            <rect x="6" y="13" width="18" height="4" rx="1" fill="black" />
+            <rect x="6" y="19" width="18" height="4" rx="1" fill="black" />
+        </template>
+        <template v-else>
+            <rect x="6" y="7" width="10" height="16" rx="1" fill="black" />
+            <rect x="18" y="7" width="6" height="7" rx="1" fill="black" />
+            <rect x="18" y="16" width="6" height="7" rx="1" fill="black" />
+        </template>
+        <title v-if="isOn">Switch to the full board layout</title>
+        <title v-else>Stack the board into rows</title>
+    </g>
+</template>
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class LayoutButton extends Vue {
+    @Prop()
+    isOn?: boolean;
+}
+</script>

--- a/viewer/src/components/buttons/index.js
+++ b/viewer/src/components/buttons/index.js
@@ -1,9 +1,10 @@
 import Button from './Button.vue';
 import HelpButton from './HelpButton.vue';
+import LayoutButton from './LayoutButton.vue';
 import LogButton from './LogButton.vue';
 import PassButton from './PassButton.vue';
 import SoundButton from './SoundButton.vue';
 import RulesButton from './RulesButton.vue';
 import UndoButton from './UndoButton.vue';
 
-export { Button, HelpButton, LogButton, PassButton, SoundButton, RulesButton, UndoButton };
+export { Button, HelpButton, LayoutButton, LogButton, PassButton, SoundButton, RulesButton, UndoButton };

--- a/viewer/src/launch.ts
+++ b/viewer/src/launch.ts
@@ -21,6 +21,7 @@ function launch(selector: string) {
             adjustPlayerOrder: false,
             undoWholeTurn: true,
             fitToScreen: true,
+            stackOnPortrait: true,
         },
         avatars: [],
     };

--- a/viewer/src/self-contained.ts
+++ b/viewer/src/self-contained.ts
@@ -15,11 +15,14 @@ function launchSelfContained(selector = '#app') {
     // be checked against several maps without editing this file each time, e.g.
     //   ?map=Australia&players=3&variant=original&seed=7
     const params = new URLSearchParams(window.location.search);
+    // Note: randomizeMap short-circuits region selection in setup(), so ticking
+    // both gives a randomized board with no draft. They are alternatives.
     const gameOptions = {
         map: (params.get('map') || 'Bremen') as MapName,
         variant: (params.get('variant') || 'recharged') as Variant,
         showMoney: true,
-        randomizeMap: false,
+        randomizeMap: params.get('randomize') === '1',
+        chooseRegions: params.get('regions') === '1',
     };
     let gameState = setup(Number(params.get('players')) || 6, gameOptions, params.get('seed') || '0');
 

--- a/viewer/src/self-contained.ts
+++ b/viewer/src/self-contained.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { move as execMove, Move, Phase, setup, stripSecret } from 'powergrid-engine';
 import { moveAI } from 'powergrid-engine/src/engine';
+import type { MapName, Variant } from 'powergrid-engine/src/gamestate';
 import launch from './launch';
 
 const delayBase = 0;
@@ -10,7 +11,17 @@ function launchSelfContained(selector = '#app') {
 
     const emitter = launch(selector);
 
-    let gameState = setup(6, { map: 'Bremen', variant: 'recharged', showMoney: true, randomizeMap: false }, '0');
+    // The sandbox game can be steered from the URL so a layout or rules change can
+    // be checked against several maps without editing this file each time, e.g.
+    //   ?map=Australia&players=3&variant=original&seed=7
+    const params = new URLSearchParams(window.location.search);
+    const gameOptions = {
+        map: (params.get('map') || 'Bremen') as MapName,
+        variant: (params.get('variant') || 'recharged') as Variant,
+        showMoney: true,
+        randomizeMap: false,
+    };
+    let gameState = setup(Number(params.get('players')) || 6, gameOptions, params.get('seed') || '0');
 
     // Dev coord-picker example (commented; uncomment + drop a board photo into
     // viewer/public/ to author city coordinates for a new map). See the picker

--- a/viewer/src/types/ui-data.ts
+++ b/viewer/src/types/ui-data.ts
@@ -10,6 +10,9 @@ export type Preferences = {
     adjustPlayerOrder: boolean;
     undoWholeTurn: boolean;
     fitToScreen: boolean;
+    // Portrait phones stack the board into full-width rows. Per player, not per
+    // game: it describes the screen you are holding, not the rules being played.
+    stackOnPortrait: boolean;
 };
 
 export interface Piece {

--- a/viewer/vue.config.js
+++ b/viewer/vue.config.js
@@ -2,5 +2,12 @@ module.exports = {
     devServer: {
         // For gitpod, it needs to be disabled
         disableHostCheck: true,
+        // The dev server sends no cache directives of its own, only a weak ETag,
+        // so a browser is free to heuristically cache the bundle and never
+        // revalidate. On desktop this is hidden by DevTools' "disable cache";
+        // on a phone it shows up as "your fix didn't deploy" after every edit.
+        headers: {
+            'Cache-Control': 'no-store',
+        },
     },
 };


### PR DESCRIPTION
Three related pieces of work on how the game *reads*: a portrait layout for phones, the deck build shown on every map, and the India rules clarification from #123.

No game logic changes. Nothing here affects a move's legality, so none of it is replay-affecting.

Closes #123.

## 1. Portrait layout for phones

The whole board is one SVG laid out in per-map absolute coordinates — map on the left, market and player boards in a right-hand column, resource supply along the bottom. That composition assumes a landscape viewport. Measured on an iPhone XR (414×896):

| | before |
|---|---|
| board drawn | 414×229 — **73% of the screen was empty** |
| city build slots | 7×10 px |
| Pass / Undo / Log | 21×7 px |

(Apple's minimum touch target is 44×44.)

Rather than author a second set of coordinates for 24 maps, each group is measured with `getBBox()` and mapped onto a full-width row by a single transform on a wrapper `<g>`. Nothing inside the components changes, and on a landscape or desktop viewport **no transform is emitted at all** — those layouts render exactly as before, verified pixel-for-pixel at 1440×900.

Rows are: city counter · map · controls + round/step/phase + draw pile · markets · resource supply · (map extras) · player boards.

Resulting scale gains at 414px wide: markets **2.6× → 3.2×**, player boards **3.8×**, resources **1.9×**. Manhattan is the clearest case — a portrait board on a portrait phone, every building cost legible without zooming.

Details worth knowing:

- **Per-slot budgets.** The round/step/phase readout is capped so the buttons beside it keep their size, and the market is capped to **88% of the canvas width** so "Actual Market" and the bid OK button don't sit under the two spots a thumb reaches worst. This is a *width* budget rather than a scale ceiling on purpose: Benelux authors `actualMarketWidth: 495`, and a fixed scale that centred Bremen left Benelux at 97% of the canvas.
- **No row exceeds 72% of the screen**, so the next row always peeks and the page reads as scrollable. Only Manhattan (92%) and Korea (74%) were ever affected; the other 22 maps are unchanged by that rule.
- **The draw pile moved out of `PowerPlantMarket.vue`** into `Game.vue` as its own group, so it can sit on a different row from the three markets it isn't part of. It renders at the identical absolute position, so the landscape board is untouched.
- **`stackOnPortrait` preference, default on**, with a toggle button in the board. The button appears whenever the viewport is portrait — not only while stacking is active — so it can undo its own effect.

Tested across all 24 maps at 2–6 players: every one stacks, no clipping, page heights 1.12–1.83 screens. Also driven through a real 6-player game to round 8 (states generated by `moveAI`) to confirm the rows re-derive as boards grow and the layout never jumps.

### Modal overflow (same theme, independent bug)

The end-of-game tables had **no scroll container**, so on a phone the far columns were unreachable — a 6-player Spending table is 1014px wide inside a 388px modal, and only the last player was visible. Now wrapped in a scroll container with the label column pinned; the table also narrows to 556px on small screens. Same treatment for the payment table in the rules dialog, which was overflowing the dialog by itself.

## 2. Deck build shown on every map

Requested by @mmunson99 and Bob: the per-map "Deck build" notes added in #113 covered 14 maps, and the 10 base-deck maps had nothing.

Filling in the blanks alone wouldn't have been enough. The existing notes are written as *differences from the standard build* — "power plants 18, 22 and 27 are set aside at setup" tells a new player nothing about the rest of the setup. So the standard build was the missing baseline for all 24 maps, not just the 10.

- New `deckBuild?: string | { recharged, original }` on `GameMap`. A map states only its difference, or says nothing.
- The 14 existing notes moved out of `mapSpecificRules` into the new field, wording unchanged. The five variant-split maps became objects, so **only the variant actually being played is shown** — previously both appeared at once.
- The rules dialog gains a permanent **Deck build** section: the standard build for the current variant, then "On \<map\>: …" when the map differs.

The standard text is the legend row of the deck-build grid @mmunson99 reviewed on 2026-08-13, unchanged.

Side effect: France's `mapSpecificRules` is removed, because its only content *was* the deck build.

## 3. India — #123

@eric-hu asked for the specifics behind two rules, and both of his figures were right. One thing the old text got outright wrong:

- The outage trigger is now stated: more than twice the number of players, i.e. 9+ cities in a 4-player game (`citiesBuiltInCurrentRound > players.length * 2`).
- The penalty was described as "$3 per city built". The engine charges **$3 per city the player owns** (`3 * player.cities.length`) and floors income at zero. Both now stated.
- The step price caps are named: $3 in step 1, $5 in step 2, whole market from step 3 (`maxPriceAvailable: [3, 5, 8]`).

His second point was that the red "Step 1"/"Step 2" markers were easy to overlook and, for him, cut off. India is the only map that draws *below* its resource panel: the markers sit at y=1050 with their separator lines running to y=1060, exactly the bottom of the default Portrait viewBox — **measured at 1px of clearance**. That isn't a margin, it's a coincidence, and any change to the height the platform gives the viewer removes them. India now has `viewBox: [1480, 1100]`, giving 31px. Same remedy as Northern Europe's viewBox in #87.

## Also

- The dev server sent **no cache directives** on its bundles, only a weak ETag — invisible on desktop because DevTools disables cache, but on a phone every edit looked like it hadn't deployed. `Cache-Control: no-store` added to `devServer`.
- The dev sandbox now takes `?map=&players=&variant=&seed=` so a change can be checked against several maps without editing `self-contained.ts`.

## Not done, deliberately

- **The map's own tap targets are still small** — city slots go from ~7×10px to ~10×15px. The map row is width-bound, so stacking can't fix that; pinch-zoom is still needed to build.
- **The resource supply row is left as it is.** Splitting the price track into two halves would double the cube size, but Korea has two markets, India has per-step price gating, Middle East has surplus oil and South Africa a storage pool — a "half" isn't a well-defined thing across maps.
