### PR TITLE
Make preferences reactive and inline static assets in build

### DIFF
--- a/viewer/src/launch.ts
+++ b/viewer/src/launch.ts
@@ -15,14 +15,18 @@ function launch(selector: string) {
     } = {
         state: null,
         emitter: new EventEmitter(),
-        preferences: {
+        // Observable so preference changes update the UI immediately: Game receives
+        // this object as a prop, and Vue 2 does not deep-observe prop values coming
+        // from a non-reactive parent — plain-object mutations (the in-game sound/help
+        // toggles, platform preference pushes) would only paint on the next re-render.
+        preferences: Vue.observable({
             sound: true,
             disableHelp: false,
             adjustPlayerOrder: false,
             undoWholeTurn: true,
             fitToScreen: true,
             stackOnPortrait: true,
-        },
+        }),
         avatars: [],
     };
 
@@ -61,7 +65,8 @@ function launch(selector: string) {
         app.$forceUpdate();
     });
     item.addListener('preferences', (data) => {
-        params.preferences = { ...params.preferences, ...data };
+        // Mutate (don't replace) the observable object so the update stays reactive
+        Object.assign(params.preferences, data);
         app.$forceUpdate();
     });
     item.addListener('gamelog', (logData) => {

--- a/viewer/vue.config.js
+++ b/viewer/vue.config.js
@@ -1,3 +1,9 @@
+// The production deploy uploads ONLY dist/powergrid-viewer.umd.min.js and
+// dist/powergrid-viewer.css — nothing else from dist/ is served. Any asset emitted
+// as a separate file (dist/img/*.svg icons, dist/media/*.mp3 audio) would 404, so
+// every static asset must be inlined into the bundles as a data URI.
+const INLINE_ASSETS_LIMIT = 10 * 1024 * 1024;
+
 module.exports = {
     devServer: {
         // For gitpod, it needs to be disabled
@@ -9,5 +15,22 @@ module.exports = {
         headers: {
             'Cache-Control': 'no-store',
         },
+    },
+    chainWebpack: (config) => {
+        // vue-cli's svg rule uses plain file-loader (always emits files); replace it
+        // with url-loader so the icons are inlined. Reuse the url-loader already
+        // resolved for the images rule (it is not hoisted to our node_modules).
+        const urlLoader = config.module.rule('images').use('url-loader').get('loader');
+        config.module.rule('svg').uses.clear();
+        config.module.rule('svg').use('url-loader').loader(urlLoader).options({ limit: INLINE_ASSETS_LIMIT });
+
+        // Raise the inline threshold so audio (and any raster images) inline too
+        // instead of falling back to file-loader above 4 KiB.
+        for (const ruleName of ['images', 'media']) {
+            config.module
+                .rule(ruleName)
+                .use('url-loader')
+                .tap((options) => ({ ...options, limit: INLINE_ASSETS_LIMIT }));
+        }
     },
 };


### PR DESCRIPTION
Two changes:

- make sound & help options reactive in the platform UI
- Inline assets, so powergrid can directly be bundled (when uploading with admin token directly to BGS, without going through npm/CDNs)

They're changes similar to recent changes in Container