### PR TITLE
Preview a move locally before sending it (#131)

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -944,7 +944,7 @@ export default class Game extends Vue {
         return state;
     }
 
-    replaceState(state: GameState, replaceState = true) {
+    replaceState(state: GameState, replaceState = true, playSound = true) {
         if (replaceState) {
             this._futureState = state;
         }
@@ -982,7 +982,7 @@ export default class Game extends Vue {
             });
         }
 
-        if (this.preferences.sound && this.G?.log[this.G?.log.length - 1].type == 'move') {
+        if (playSound && this.preferences.sound && this.G?.log[this.G?.log.length - 1].type == 'move') {
             const move = (this.G?.log[this.G?.log.length - 1] as LogMove).move;
             if (move.name == MoveName.Pass && this.G.currentPlayers.includes(this.player!)) {
                 (document.getElementById('notification')!.cloneNode(true) as HTMLAudioElement).play();
@@ -1385,14 +1385,48 @@ export default class Game extends Vue {
         // replays (and the eventual committed log) reproduce the same times.
         this.turnMoves.push({ ...move, time: Date.now() });
 
+        // Preview the move locally BEFORE sending it. Without this the board — and with
+        // it `availableMoves` — stays frozen on the last server reply, so every click
+        // made while a response is in flight is judged against a stale list. Buy one
+        // resource past what your plants can hold and the platform rejects the whole
+        // replayed buffer with "Wrong argument for the command BuyResource"; the
+        // rejected move then stays in the buffer, so every later action resends it and
+        // fails again until the page is refreshed (#131).
+        //
+        // Replaying the buffer on the committed state is exact: any move with hidden
+        // side effects commits, which ends the buffer (see util/turn-buffer).
+        let preview: GameState | null = null;
+
+        if (this.committedState && this.player != undefined) {
+            const buffered = this.turnMoves.length;
+            preview = this.replayTurnBuffer();
+
+            if (this.turnMoves.length < buffered) {
+                // The engine refused the move we just added, so it never reaches the
+                // server and the board already shows the truth.
+                return;
+            }
+        }
+
         // Send the WHOLE turn so far: the platform is stateless between calls and
         // replays the buffer from the last committed (saved) state.
         this.emitter.emit('move', [...this.turnMoves]);
+
+        // Only adopt a preview that is still TENTATIVE. A committing move (Pass, a bid
+        // that ends an auction) replays hidden outcomes — deck draws, upkeep — on a
+        // state whose deck and seed are stripped, so its preview would flash bogus
+        // results; wait for the server's committed answer instead. The echo of this
+        // same buffer lands next and is authoritative, and it owns the sound, so the
+        // preview stays silent rather than doubling it.
+        if (preview && preview.newTurn === false) {
+            this.replaceState(preview, false, false);
+        }
     }
 
     gameEnded(G: GameState) {
         return ended(G);
     }
+
 
     canMove() {
         return (

--- a/viewer/tests/unit/turn-buffer.spec.ts
+++ b/viewer/tests/unit/turn-buffer.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@/util/turn-buffer';
 import { expect } from 'chai';
 import type { GameState, Move } from 'powergrid-engine';
-import { move as engineMove, MoveName, setup } from 'powergrid-engine';
+import { move as engineMove, moveAI, MoveName, Phase, setup } from 'powergrid-engine';
 
 describe('turn-buffer', () => {
     const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
@@ -157,5 +157,73 @@ describe('turn-buffer', () => {
 
         // The input state is never mutated by a preview
         expect(committed.chosenPowerPlant).to.be.undefined;
+    });
+
+    // The reason the viewer previews a move locally BEFORE sending it (Game.vue
+    // sendMove). These two tests describe the bug that motivated it: eric-hu's #131,
+    // "Wrong argument for the command BuyResource" at the end of a game.
+    it('previewing a move advances availableMoves, which is what disables the next illegal click', () => {
+        const { committed, player, choose } = fixture();
+
+        // The viewer used to judge every click against the last state the SERVER sent.
+        // A click made before the reply landed was therefore built from a stale list.
+        expect(
+            committed.players[player].availableMoves![MoveName.ChoosePowerPlant],
+            'the stale list still offers a plant to choose'
+        ).to.include(choose.data as number);
+
+        // Sending both is what the platform rejects: it replays the WHOLE buffer.
+        expect(() => {
+            let s = engineMove(clone(committed), choose, player);
+            engineMove(s, { ...choose, time: 2000 } as Move, player);
+        }, 'the platform replays the buffer and throws').to.throw();
+
+        // Previewing the buffer locally moves the board on, so the second click is
+        // never offered — the illegal buffer cannot be built in the first place.
+        const { state } = replayTurnBuffer(committed, [choose], player);
+        expect(state.players[player].availableMoves![MoveName.ChoosePowerPlant]).to.be.undefined;
+    });
+
+    it('a preview after every buy stops a resource click going past storage capacity', () => {
+        // Drive a real game to a seat that can buy resources.
+        let G: GameState = setup(4, {}, 'turn-buffer-resources');
+        for (let i = 0; i < 4000; i++) {
+            const seat = G.players.findIndex((p) => p.availableMoves);
+            if (seat < 0) break;
+            if (G.phase === Phase.Resources && G.players[seat].availableMoves![MoveName.BuyResource]) {
+                const stale = G.players[seat].availableMoves![MoveName.BuyResource]!;
+                const target = stale[0];
+
+                // How many of that resource fit? Buy until the engine stops offering it.
+                let previewed: GameState = clone(G);
+                const buffer: Move[] = [];
+                for (let n = 0; n < 40; n++) {
+                    // No optional chaining in this file: webpack 4 parses the unit-test
+                    // bundle and rejects it (same note as util/turn-buffer.ts).
+                    const moves = previewed.players[seat].availableMoves;
+                    const fresh = moves ? moves[MoveName.BuyResource] : undefined;
+                    if (!fresh || !fresh.some((m) => JSON.stringify(m) === JSON.stringify(target))) break;
+                    const buy: Move = { name: MoveName.BuyResource, data: target, time: 1000 + n };
+                    buffer.push(buy);
+                    previewed = replayTurnBuffer(G, buffer, seat).state;
+                }
+                expect(buffer.length, 'the seat can buy at least one cube').to.be.greaterThan(0);
+
+                // WITHOUT a preview the cube stays clickable, so one more click is
+                // buffered and the platform rejects the whole turn.
+                const oneTooMany = [...buffer, { name: MoveName.BuyResource, data: target, time: 9999 } as Move];
+                expect(() => {
+                    let s: GameState = clone(G);
+                    for (const m of oneTooMany) s = engineMove(s, m, seat);
+                }, 'this is the state eric-hu got stuck in').to.throw(/BuyResource/);
+
+                // WITH a preview, the extra click is never offered, and even if one
+                // races in the replay truncates it rather than sending it on.
+                expect(replayTurnBuffer(G, oneTooMany, seat).applied).to.deep.equal(buffer);
+                return;
+            }
+            G = moveAI(G, seat);
+        }
+        expect.fail('never reached a seat that could buy resources');
     });
 });


### PR DESCRIPTION
Fixes #131.

### What was happening

`sendMove` pushed the move into the turn buffer and emitted it **without previewing it**, so `this.G` — and with it `availableMoves` — stayed frozen on the last state the server sent. Every click made while a response was in flight was therefore judged against a stale list.

The platform replays the **whole** buffer from the last committed state, so one click past what your plants can hold gets the entire turn rejected. Which resource is left buyable decides the wording: if something else is still affordable you get eric-hu's `Wrong argument for the command BuyResource`, and if nothing is, `You are not allowed to run the command BuyResource`.

Two things turned that from a flicker into something sticky:

* the viewer has **no error path at all**, so nothing removes the offending move again — it stays in the buffer and every later action resends it and fails the same way;
* a refresh is the only thing that empties the buffer, which is exactly the recovery eric-hu found.

### The fix

Preview the buffer locally before emitting it — which is what `undo()` already does. The replay is exact: a move with hidden side effects commits, and committing ends the buffer, so a tentative replay never touches the stripped deck or seed.

Only a still-tentative preview is adopted. A committing move (Pass, a bid that ends an auction) would replay deck draws and upkeep on a state whose deck and seed are stripped, so its preview would flash bogus results; the server's committed answer is waited for instead. The preview is also silent — the authoritative echo of the same buffer lands next and owns the sound, and playing it twice would double it.

A welcome side effect: the board now responds to every tap instead of waiting for a round trip, which is most noticeable on a phone.

### Evidence

Simulating the click loop over **258 seats** (10 maps × 2/4/6 players × rounds 1/5/8), one click past the limit on every offered resource:

| | buffers sent | rejected by the platform |
|---|---|---|
| before | 492 | **492** (270 of them with eric-hu's exact wording) |
| after | 492 | **0** |

And in a real browser, driving the actual component with the sandbox silenced so no reply ever arrives — i.e. every tap inside the race window. The seat holds 1 coal with capacity 4, so three buys are legal:

| | before | after |
|---|---|---|
| 4th tap still offered by the viewer | `true` | **`false`** |
| buffers emitted | 1, 2, 3, **4** ← rejected | 1, 2, 3 |
| coal held after the taps | **1** (board never moved) | **4** |

### Tests

Two, in `viewer/tests/unit/turn-buffer.spec.ts`. They cover the mechanism the fix leans on rather than the wiring: that previewing a move advances `availableMoves` so the next illegal click is never offered, and that a resource buy past storage capacity is truncated by the replay instead of reaching the server. The wiring itself is covered by the browser run above.

Viewer only — engine untouched.
