### PR TITLE
Portrait: draw the resource market as one box per source

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -178,12 +178,76 @@
                 />
             </g>
 
+            <!-- Australia: the same uranium-mine selling table laid on its side for
+                 portrait. A 104x430 strip is the worst possible shape for a full-width
+                 row — it can only grow until its HEIGHT fills the row, so it ends up a
+                 sliver with the whole width beside it empty. Turned through 90° the six
+                 prices run left to right in the same order they run top to bottom, and
+                 the row is filled by something worth reading. -->
+            <g
+                v-if="stacked && G.map.name === 'Australia' && G.uraniumMineMarket"
+                ref="slotUraniumMines"
+                :transform="slotT('uraniumMines') || 'translate(15, 70)'"
+            >
+                <rect x="0" y="0" width="620" height="146" rx="6" fill="#8aa84a" stroke="#4d6322" stroke-width="3" />
+                <text x="310" y="26" text-anchor="middle" font-weight="700" fill="black" style="font-size: 22px">
+                    Uranium mine market
+                </text>
+                <g v-for="col in 6" :key="'uraniumCol' + col" :transform="`translate(${10 + (col - 1) * 100}, 0)`">
+                    <text x="50" y="56" text-anchor="middle" font-weight="700" fill="black" style="font-size: 20px">
+                        ${{ 8 - col }}
+                    </text>
+                    <rect
+                        x="21"
+                        y="66"
+                        width="26"
+                        height="26"
+                        rx="3"
+                        fill="goldenrod"
+                        stroke="#4d6322"
+                        stroke-width="1.5"
+                    />
+                    <rect
+                        x="53"
+                        y="66"
+                        width="26"
+                        height="26"
+                        rx="3"
+                        fill="goldenrod"
+                        stroke="#4d6322"
+                        stroke-width="1.5"
+                    />
+                    <circle
+                        v-if="(G.uraniumMineMarket[6 - col] || 0) >= 1"
+                        cx="34"
+                        cy="79"
+                        r="10"
+                        fill="#46c655"
+                        stroke="#1f5c25"
+                        stroke-width="2"
+                    />
+                    <circle
+                        v-if="(G.uraniumMineMarket[6 - col] || 0) >= 2"
+                        cx="66"
+                        cy="79"
+                        r="10"
+                        fill="#46c655"
+                        stroke="#1f5c25"
+                        stroke-width="2"
+                    />
+                </g>
+                <line x1="10" y1="108" x2="610" y2="108" stroke="#4d6322" stroke-width="1" />
+                <text x="310" y="132" text-anchor="middle" font-weight="700" fill="#22340f" style="font-size: 18px">
+                    refill −{{ G.map.uraniumMineResupply[G.players.length - 2][G.step - 1] }}/rnd
+                </text>
+            </g>
+
             <!-- Australia: uranium-mine selling table. Six price rows $7 (top) →
                  $2 (bottom), two token slots each. Sellers place one token per mine
                  on the highest empty slot; the resource refill removes from the
                  cheap (bottom) end. Lives in the clear upper-left margin. -->
             <g
-                v-if="G.map.name === 'Australia' && G.uraniumMineMarket"
+                v-if="!stacked && G.map.name === 'Australia' && G.uraniumMineMarket"
                 ref="slotUraniumMines"
                 :transform="slotT('uraniumMines') || 'translate(15, 70)'"
             >
@@ -736,6 +800,9 @@ const STACK_SLOT_MAX_SCALE: Record<string, number> = {
  */
 const STACK_SLOT_MAX_WIDTH: Record<string, number> = {
     powerPlantMarket: 0.88,
+    // The box market is one tall stack of full-width buttons; run edge to edge it
+    // reads as though it had been cropped rather than laid out.
+    resources: 0.94,
 };
 
 /**

--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -143,7 +143,23 @@
             </g>
 
             <g ref="slotResources" :transform="slotT('resources')">
+                <!-- On a phone the printed price track is a strip of unreadable
+                     columns, so the stacked layout swaps it for one box per buyable
+                     source. Landscape and desktop keep the printed board exactly as
+                     it was — this is an either/or, never an overlay. -->
+                <ResourceBoxes
+                    v-if="stacked"
+                    :transform="`translate(${G.map.supplyPosition[0]}, ${G.map.supplyPosition[1]})`"
+                    :gameState="G"
+                    :player="player"
+                    :isUsaRecharged="G.options.variant == 'recharged' && G.map.name == 'USA'"
+                    :buyableResources="buyableResources()"
+                    :resourceResupply="getResourceResupply()"
+                    :resourceResupplyNorth="getResourceResupplyNorth()"
+                    @buyResource="buyResource($event)"
+                />
                 <Resources
+                    v-else
                     ref="resources"
                     :transform="`translate(${G.map.supplyPosition[0]}, ${G.map.supplyPosition[1]})`"
                     :isUsaRecharged="G.options.variant == 'recharged' && G.map.name == 'USA'"
@@ -660,6 +676,7 @@ import PowerPlantMarket from './boards/PowerPlantMarket.vue';
 import PlayerOrder from './boards/PlayerOrder.vue';
 import CityCount from './boards/CityCount.vue';
 import Map from './boards/Map.vue';
+import ResourceBoxes from './boards/ResourceBoxes.vue';
 import Resources from './boards/Resources.vue';
 import { LogMove } from 'powergrid-engine/src/log';
 import { Phase, playerTimeUsed, PowerPlant, PowerPlantType, ResourceType } from 'powergrid-engine/src/gamestate';
@@ -794,7 +811,8 @@ const round = (n: number, digits = 2) => Number(n.toFixed(digits));
         PlayerOrder,
         CityCount,
         Map,
-        Resources
+        Resources,
+        ResourceBoxes
     },
 })
 export default class Game extends Vue {
@@ -974,7 +992,8 @@ export default class Game extends Vue {
                 this.playerOrder.createPieces(this.G!);
                 this.cityCount.createPieces(this.G!);
                 this.map.createPieces(this.G!);
-                this.resources.createPieces(this.G!);
+                // Absent while the portrait layout is showing the box market instead.
+                this.resources?.createPieces(this.G!);
                 // Pieces are added imperatively, so the groups only reach their
                 // final size here — the portrait layout must measure after this,
                 // not on the state change that triggered it.
@@ -2000,6 +2019,19 @@ export default class Game extends Vue {
         this.stackHeight = Math.round(y + STACK_PAD - STACK_GAP);
         this.slotTransforms = transforms;
         this.stacked = true;
+    }
+
+    /**
+     * Entering or leaving the stacked layout swaps the printed resource track for the
+     * box market, which is a different shape entirely. `relayout` sets `stacked` last,
+     * so the swap only reaches the DOM a tick later — by which point the row heights
+     * it just solved for describe the component that is no longer there. Measure again
+     * once the swap has landed. This settles after one extra pass: the second run
+     * leaves `stacked` unchanged, so it does not re-trigger.
+     */
+    @Watch('stacked')
+    onStackedChanged() {
+        this.scheduleRelayout();
     }
 
     private scheduleRelayout() {

--- a/viewer/src/components/boards/ResourceBoxes.vue
+++ b/viewer/src/components/boards/ResourceBoxes.vue
@@ -21,8 +21,14 @@
                 </text>
 
                 <text x="4" y="42" fill="#3a2c08" style="font-size: 24px; letter-spacing: 1px">CURRENT PRICE</text>
-                <text x="250" y="42" fill="#3a2c08" style="font-size: 24px; letter-spacing: 1px">
-                    BUYABLE AT THIS PRICE
+                <text
+                    :x="CUBE_BAND_CENTRE"
+                    y="42"
+                    text-anchor="middle"
+                    fill="#3a2c08"
+                    style="font-size: 24px; letter-spacing: 1px"
+                >
+                    AT THIS PRICE
                 </text>
                 <text
                     :x="BOX_W - 4"
@@ -81,14 +87,14 @@
                     <circle
                         v-for="n in row.atPrice"
                         :key="'cube' + n"
-                        :cx="266 + (n - 1) * 44"
+                        :cx="cubeX(row.atPrice, n)"
                         :cy="58"
                         r="17"
                         :fill="row.color"
                         stroke="black"
                         stroke-width="2"
                     />
-                    <text v-if="row.flat && row.cubes > 0" x="266" y="66" fill="#3a2c08" style="font-size: 22px">
+                    <text v-if="row.flat && row.cubes > 0" x="300" y="66" fill="#3a2c08" style="font-size: 22px">
                         every cube at this price
                     </text>
 
@@ -122,12 +128,15 @@ import { GameState } from 'powergrid-engine';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { BuyMove, ResourceBlock, resourceBlocks } from '../../util/resource-rows';
 
-const BOX_W = 760;
+const BOX_W = 700;
 const BOX_H = 104;
 const BOX_GAP = 8;
 /** Block title + column captions above the first box. */
 const HEAD_H = 62;
 const BLOCK_GAP = 30;
+const CUBE_PITCH = 44;
+/** Middle of the band between the price block and the cubes-left count. */
+const CUBE_BAND_CENTRE = 420;
 
 /**
  * The portrait resource market.
@@ -163,6 +172,12 @@ export default class ResourceBoxes extends Vue {
     BOX_H = BOX_H;
     BOX_GAP = BOX_GAP;
     HEAD_H = HEAD_H;
+    CUBE_BAND_CENTRE = CUBE_BAND_CENTRE;
+
+    /** Centre the cube cluster in that band, however many cubes there are. */
+    cubeX(count: number, n: number): number {
+        return CUBE_BAND_CENTRE - ((count - 1) * CUBE_PITCH) / 2 + (n - 1) * CUBE_PITCH;
+    }
 
     get step(): number {
         return this.gameState.step;

--- a/viewer/src/components/boards/ResourceBoxes.vue
+++ b/viewer/src/components/boards/ResourceBoxes.vue
@@ -1,0 +1,197 @@
+<template>
+    <g>
+        <template v-for="(block, b) in blocks">
+            <g :key="'block' + b" :transform="`translate(0, ${block.y})`">
+                <text v-if="block.title" x="4" y="16" font-weight="700" fill="black" style="font-size: 26px">
+                    {{ block.title }}
+                </text>
+
+                <!-- Restock, as the printed refill card reads it: one number per row,
+                     in the same order the rows are drawn. -->
+                <text
+                    v-if="block.restock"
+                    :x="BOX_W - 4"
+                    y="16"
+                    text-anchor="end"
+                    font-weight="600"
+                    fill="#3a2c08"
+                    style="font-size: 24px"
+                >
+                    Restock {{ block.restock }}
+                </text>
+
+                <text x="4" y="42" fill="#3a2c08" style="font-size: 24px; letter-spacing: 1px">CURRENT PRICE</text>
+                <text x="250" y="42" fill="#3a2c08" style="font-size: 24px; letter-spacing: 1px">
+                    BUYABLE AT THIS PRICE
+                </text>
+                <text
+                    :x="BOX_W - 4"
+                    y="42"
+                    text-anchor="end"
+                    fill="#3a2c08"
+                    style="font-size: 24px; letter-spacing: 1px"
+                >
+                    CUBES LEFT
+                </text>
+
+                <g
+                    v-for="(row, r) in block.rows"
+                    :key="'row' + r"
+                    :transform="`translate(0, ${HEAD_H + r * (BOX_H + BOX_GAP)})`"
+                    :class="[{ canClick: row.buyable }]"
+                    @click="row.buyable && $emit('buyResource', row.move)"
+                >
+                    <rect
+                        :width="BOX_W"
+                        :height="BOX_H"
+                        rx="6"
+                        :fill="row.cubes > 0 ? 'darkgoldenrod' : '#9c8236'"
+                        :stroke="row.buyable ? '#1e63d0' : '#6b5312'"
+                        :stroke-width="row.buyable ? 5 : 2"
+                        :opacity="row.cubes > 0 ? 1 : 0.55"
+                    />
+                    <!-- Whole box is the tap target, cubes and all. -->
+                    <rect
+                        v-if="row.buyable"
+                        :width="BOX_W"
+                        :height="BOX_H"
+                        rx="6"
+                        fill="transparent"
+                        pointer-events="all"
+                    />
+
+                    <text x="18" y="26" font-weight="700" fill="black" style="font-size: 22px; letter-spacing: 1px">
+                        {{ row.label }}
+                    </text>
+
+                    <template v-if="row.price != null">
+                        <text x="18" y="80" font-weight="700" fill="black" style="font-size: 26px">$</text>
+                        <text x="40" y="84" font-weight="700" fill="black" style="font-size: 46px">
+                            {{ row.price }}
+                        </text>
+                        <text v-if="row.next != null" x="132" y="80" fill="#3a2c08" style="font-size: 22px">
+                            then ${{ row.next }}
+                        </text>
+                    </template>
+                    <text v-else x="18" y="78" font-weight="700" fill="black" style="font-size: 28px">out</text>
+
+                    <!-- One dot per cube still buyable at the current price. A pool
+                         with no price track behind it has no such number: every cube
+                         in it costs the same, so say that instead of drawing dots. -->
+                    <circle
+                        v-for="n in row.atPrice"
+                        :key="'cube' + n"
+                        :cx="266 + (n - 1) * 44"
+                        :cy="58"
+                        r="17"
+                        :fill="row.color"
+                        stroke="black"
+                        stroke-width="2"
+                    />
+                    <text v-if="row.flat && row.cubes > 0" x="266" y="66" fill="#3a2c08" style="font-size: 22px">
+                        every cube at this price
+                    </text>
+
+                    <text
+                        :x="BOX_W - 18"
+                        y="68"
+                        text-anchor="end"
+                        font-weight="700"
+                        fill="black"
+                        style="font-size: 40px"
+                    >
+                        {{ row.cubes }}
+                    </text>
+                    <text :x="BOX_W - 18" y="90" text-anchor="end" fill="#3a2c08" style="font-size: 20px">LEFT</text>
+
+                    <!-- India caps which prices are on sale per step; a row above the
+                         cap is on the board but cannot be bought by anyone yet. -->
+                    <text v-if="row.capped" x="130" y="96" fill="#7a1d12" font-weight="600" style="font-size: 20px">
+                        step {{ step }} sells to ${{ maxPrice }}
+                    </text>
+
+                    <title>{{ row.title }}</title>
+                </g>
+            </g>
+        </template>
+    </g>
+</template>
+
+<script lang="ts">
+import { GameState } from 'powergrid-engine';
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { BuyMove, ResourceBlock, resourceBlocks } from '../../util/resource-rows';
+
+const BOX_W = 760;
+const BOX_H = 104;
+const BOX_GAP = 8;
+/** Block title + column captions above the first box. */
+const HEAD_H = 62;
+const BLOCK_GAP = 30;
+
+/**
+ * The portrait resource market.
+ *
+ * The printed price track is a beautiful object and an unreadable one on a phone:
+ * eight to ten columns of three-cube slots, drawn at whatever width the map author
+ * chose and then squeezed into a strip. This draws the same market as one box per
+ * buyable source, carrying only what a purchase actually needs — what the next cube
+ * costs, how many are left at that price, how many are left at all.
+ *
+ * Every number comes out of the engine state rather than the printed geometry, so the
+ * map-specific markets come along for free: Europe's nine price columns, Korea's two
+ * sides, Australia's Step-3 CO2 shift (the engine rewrites the price array and the box
+ * is only ever a view of it), India's per-step price cap, South Africa's $8 storage
+ * pool, USA recharged's $8-from-supply once the track is bare.
+ *
+ * Which rows a player may actually tap is NOT decided here: `buyableResources` is the
+ * engine's own availableMoves, so money, storage capacity, the hybrid tank and Korea's
+ * side lock are all accounted for already. The row model itself lives in
+ * `util/resource-rows`, where it can be tested against the engine's own arithmetic.
+ */
+@Component
+export default class ResourceBoxes extends Vue {
+    @Prop() gameState!: GameState;
+    @Prop() buyableResources?: BuyMove[];
+    @Prop() resourceResupply?: (number | string)[];
+    @Prop() resourceResupplyNorth?: (number | string)[];
+    @Prop() isUsaRecharged?: boolean;
+    /** The seat looking at the board — only needed for Central Europe's Wien discount. */
+    @Prop() player?: number;
+
+    BOX_W = BOX_W;
+    BOX_H = BOX_H;
+    BOX_GAP = BOX_GAP;
+    HEAD_H = HEAD_H;
+
+    get step(): number {
+        return this.gameState.step;
+    }
+
+    get maxPrice(): number {
+        const table = (this.gameState.map as { maxPriceAvailable?: number[] }).maxPriceAvailable;
+        return table ? table[this.gameState.step - 1] : 16;
+    }
+
+    get blocks(): (ResourceBlock & { y: number })[] {
+        let y = 0;
+        return resourceBlocks(this.gameState, {
+            player: this.player,
+            buyable: this.buyableResources,
+            resupply: this.resourceResupply,
+            resupplyNorth: this.resourceResupplyNorth,
+            isUsaRecharged: this.isUsaRecharged,
+        }).map((block) => {
+            const placed = { ...block, y };
+            y += HEAD_H + block.rows.length * (BOX_H + BOX_GAP) - BOX_GAP + BLOCK_GAP;
+            return placed;
+        });
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.canClick {
+    cursor: pointer;
+}
+</style>

--- a/viewer/src/util/resource-rows.ts
+++ b/viewer/src/util/resource-rows.ts
@@ -192,18 +192,21 @@ function rowsFor(G: GameState, north: boolean, opts: RowOptions): ResourceRow[] 
         rows.push(marketRow(G, 'coal', north, opts));
     }
 
+    // South Africa: used coal returns to a storage pool below the market and can
+    // always be bought back at $8, alongside whatever the track is charging. It sits
+    // directly under the market coal rather than at the bottom of the list, so the two
+    // coal prices are read together — the track is usually the cheaper of the two and
+    // that should be obvious without hunting.
+    if (!north && G.coalStorage !== undefined) {
+        rows.push(flatRow(G, G.coalStorage, true, 'Coal (from storage)', opts));
+    }
+
     rows.push(marketRow(G, 'oil', north, opts));
     rows.push(marketRow(G, 'garbage', north, opts));
 
     // Korea's north side has no uranium row.
     if (!north && uraniumOnTrack(G)) {
         rows.push(marketRow(G, 'uranium', north, opts));
-    }
-
-    // South Africa: used coal returns to a storage pool below the market and can
-    // always be bought back at $8, alongside whatever the track is charging.
-    if (!north && G.coalStorage !== undefined) {
-        rows.push(flatRow(G, G.coalStorage, true, 'Coal (from storage)', opts));
     }
 
     return rows;

--- a/viewer/src/util/resource-rows.ts
+++ b/viewer/src/util/resource-rows.ts
@@ -1,0 +1,243 @@
+import type { GameState } from 'powergrid-engine';
+
+/**
+ * The row model behind the portrait resource market (`boards/ResourceBoxes.vue`).
+ *
+ * Kept out of the component so it can be tested against the engine directly: every
+ * row's `price` is the money the engine will actually take for the next cube bought
+ * from that source, and `resource-rows.spec.ts` asserts exactly that by buying one.
+ *
+ * Written without optional chaining: webpack 4 parses the unit-test bundle and
+ * rejects `?.` (same note as `util/turn-buffer.ts`).
+ */
+
+export type BuyMove = { resource: string; side?: 'north' | 'south'; fromStorage?: boolean };
+
+export interface ResourceRow {
+    label: string;
+    color: string;
+    /** What a tap sends. Identical in shape to the engine's BuyResource payload. */
+    move: BuyMove;
+    /** What the engine charges for the next cube here, or null when it is empty. */
+    price: number | null;
+    /** The price once the cubes at the current price run out. */
+    next: number | null;
+    /** How many cubes are still on sale at `price`. Zero for a flat pool. */
+    atPrice: number;
+    /** Cubes left in this source altogether. */
+    cubes: number;
+    buyable: boolean;
+    /** On the board but above the per-step price cap, so nobody may buy it yet. */
+    capped: boolean;
+    /** A flat-price pool with no track behind it: every cube costs the same. */
+    flat: boolean;
+    title: string;
+}
+
+export interface ResourceBlock {
+    title?: string;
+    restock?: string;
+    rows: ResourceRow[];
+}
+
+export const RESOURCE_COLORS: Record<string, string> = {
+    coal: '#6b2028',
+    oil: '#15130f',
+    garbage: '#f2d024',
+    uranium: '#dc2626',
+};
+
+/** The engine's own defaults, for maps that do not author their own arrays. */
+const DEFAULT_PRICES: Record<string, number[]> = {
+    coal: [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    oil: [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    garbage: [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    uranium: [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16],
+};
+
+const FLAT_POOL_PRICE = 8;
+
+export interface RowOptions {
+    /** The seat reading the board — only needed for Central Europe's Wien discount. */
+    player?: number;
+    buyable?: BuyMove[];
+    /** Resupply for this step, indexed coal / oil / garbage / uranium. */
+    resupply?: (number | string)[];
+    resupplyNorth?: (number | string)[];
+    isUsaRecharged?: boolean;
+}
+
+function capitalize(s: string): string {
+    return s[0].toUpperCase() + s.slice(1);
+}
+
+function isKorea(G: GameState): boolean {
+    return G.coalPricesNorth !== undefined;
+}
+
+/** India and friends only sell up to a per-step price. 16 = no cap in practice. */
+function maxPrice(G: GameState): number {
+    const table = (G.map as { maxPriceAvailable?: number[] }).maxPriceAvailable;
+    return table ? table[G.step - 1] : 16;
+}
+
+function pricesFor(G: GameState, resource: string, north: boolean): number[] {
+    const bag = G as unknown as Record<string, number[] | undefined>;
+    const authored = bag[resource + 'Prices' + (north ? 'North' : '')];
+    return authored !== undefined ? authored : DEFAULT_PRICES[resource];
+}
+
+function cubesIn(G: GameState, resource: string, north: boolean): number {
+    const bag = G as unknown as Record<string, number | undefined>;
+    const count = bag[resource + 'Market' + (north ? 'North' : '')];
+    return count === undefined ? 0 : count;
+}
+
+function sameMove(a: BuyMove, b: BuyMove): boolean {
+    return a.resource === b.resource && a.side === b.side && !!a.fromStorage === !!b.fromStorage;
+}
+
+/**
+ * Central Europe sells garbage a dollar cheaper to whoever holds Wien — and the
+ * engine really does charge the lower price, not just offer the move. The box shows
+ * the price THIS player would pay, because that is the only number a tap can act on.
+ */
+function wienDiscount(G: GameState, resource: string, player: number | undefined): number {
+    if (resource !== 'garbage' || G.map.name !== 'Central Europe' || player === undefined) return 0;
+    const me = G.players[player];
+    if (!me) return 0;
+    return me.cities.some((c) => c.name === 'Wien') ? 1 : 0;
+}
+
+function marketRow(G: GameState, resource: string, north: boolean, opts: RowOptions): ResourceRow {
+    const prices = pricesFor(G, resource, north);
+    const cubes = cubesIn(G, resource, north);
+    // Cubes fill from the dear end, so the next one sold is at `length - cubes`.
+    // Clamped only so a market holding more cubes than its track has slots reads as
+    // the cheapest price rather than as a blank — the engine indexes the same array
+    // the same way, so it could not price such a state either. Middle East's "surplus
+    // oil" is not that case: its track is the full 24 and the surplus IS the $1 end.
+    const idx = Math.max(0, prices.length - cubes);
+
+    let price: number | null = null;
+    let atPrice = 0;
+    let next: number | null = null;
+
+    if (cubes > 0) {
+        price = prices[idx] - (north ? 0 : wienDiscount(G, resource, opts.player));
+        for (let i = idx; i < prices.length && prices[i] === prices[idx]; i++) atPrice++;
+        for (let i = idx; i < prices.length; i++) {
+            if (prices[i] !== prices[idx]) {
+                next = prices[i] - (north ? 0 : wienDiscount(G, resource, opts.player));
+                break;
+            }
+        }
+    }
+
+    const move: BuyMove = isKorea(G) ? { resource, side: north ? 'north' : 'south' } : { resource };
+
+    return {
+        label: capitalize(resource),
+        color: RESOURCE_COLORS[resource],
+        move,
+        price,
+        next,
+        atPrice,
+        cubes,
+        buyable: !!opts.buyable && opts.buyable.some((b) => sameMove(b, move)),
+        capped: price !== null && price > maxPrice(G),
+        flat: false,
+        title:
+            cubes > 0
+                ? `${capitalize(resource)} — $${price} each, ${atPrice} at that price, ${cubes} left`
+                : `${capitalize(resource)} — market empty`,
+    };
+}
+
+/** South Africa's storage pool and USA recharged's supply: a flat $8, no track. */
+function flatRow(G: GameState, cubes: number, fromStorage: boolean, label: string, opts: RowOptions): ResourceRow {
+    const move: BuyMove = fromStorage ? { resource: 'coal', fromStorage: true } : { resource: 'coal' };
+    return {
+        label,
+        color: RESOURCE_COLORS.coal,
+        move,
+        price: cubes > 0 ? FLAT_POOL_PRICE : null,
+        next: null,
+        atPrice: 0,
+        cubes,
+        buyable: !!opts.buyable && opts.buyable.some((b) => sameMove(b, move)),
+        capped: cubes > 0 && FLAT_POOL_PRICE > maxPrice(G),
+        flat: true,
+        title: `${label} — $${FLAT_POOL_PRICE} each, ${cubes} left`,
+    };
+}
+
+/**
+ * Does this map sell uranium on the main track at all? Australia moves it to a
+ * separate mine market and Bremen has no nuclear, so on both the row would be a
+ * permanently empty box.
+ */
+function uraniumOnTrack(G: GameState): boolean {
+    return G.map.name !== 'Australia' && G.map.name !== 'Bremen';
+}
+
+function rowsFor(G: GameState, north: boolean, opts: RowOptions): ResourceRow[] {
+    const rows: ResourceRow[] = [];
+
+    // USA recharged keeps selling coal at a flat $8 out of the supply once the printed
+    // track is bare, so the row would otherwise read "out" while the move is on offer.
+    if (!north && opts.isUsaRecharged && G.coalMarket === 0 && G.coalSupply > 0) {
+        rows.push(flatRow(G, G.coalSupply, false, 'Coal (from supply)', opts));
+    } else {
+        rows.push(marketRow(G, 'coal', north, opts));
+    }
+
+    rows.push(marketRow(G, 'oil', north, opts));
+    rows.push(marketRow(G, 'garbage', north, opts));
+
+    // Korea's north side has no uranium row.
+    if (!north && uraniumOnTrack(G)) {
+        rows.push(marketRow(G, 'uranium', north, opts));
+    }
+
+    // South Africa: used coal returns to a storage pool below the market and can
+    // always be bought back at $8, alongside whatever the track is charging.
+    if (!north && G.coalStorage !== undefined) {
+        rows.push(flatRow(G, G.coalStorage, true, 'Coal (from storage)', opts));
+    }
+
+    return rows;
+}
+
+/**
+ * The resupply table is indexed coal / oil / garbage / uranium, and the track rows
+ * are drawn in that order — so the numbers line up with the boxes below them. Rows
+ * that are not part of the printed track (the flat pools) get no number.
+ */
+function restockText(table: (number | string)[] | undefined, rows: ResourceRow[]): string | undefined {
+    if (!table) return undefined;
+    const numbers = rows.filter((r) => !r.flat).map((r, i) => table[i]);
+    return numbers.every((n) => n === undefined) ? undefined : numbers.filter((n) => n !== undefined).join(' / ');
+}
+
+export function resourceBlocks(G: GameState, opts: RowOptions = {}): ResourceBlock[] {
+    const blocks: ResourceBlock[] = [];
+
+    if (isKorea(G)) {
+        const northRows = rowsFor(G, true, opts);
+        blocks.push({
+            title: 'North Market',
+            restock: restockText(opts.resupplyNorth, northRows),
+            rows: northRows,
+        });
+    }
+
+    const southRows = rowsFor(G, false, opts);
+    blocks.push({
+        title: isKorea(G) ? 'South Market' : undefined,
+        restock: restockText(opts.resupply, southRows),
+        rows: southRows,
+    });
+
+    return blocks;
+}

--- a/viewer/tests/unit/resource-rows.spec.ts
+++ b/viewer/tests/unit/resource-rows.spec.ts
@@ -1,0 +1,205 @@
+import { resourceBlocks } from '@/util/resource-rows';
+import { expect } from 'chai';
+import type { GameState } from 'powergrid-engine';
+import { availableMoves, move as engineMove, moveAI, MoveName, Phase, setup } from 'powergrid-engine';
+
+/**
+ * The portrait market shows a price on every box. The only way that number can be
+ * trusted is to spend it: buy one cube from each row and check the engine took
+ * exactly what the box said it would.
+ *
+ * This is the check that would have caught Central Europe, where the engine sells
+ * garbage a dollar cheaper to whoever holds Wien — the price on the board and the
+ * price a given player pays are not the same number.
+ */
+describe('resource-rows', () => {
+    const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+    // moveAI draws from raw Math.random, not the game seed, so an unpinned walk to a
+    // mid-game position lands somewhere different every run — and on India it can walk
+    // into the known Bureaucracy dead-end and never arrive at all. Pin the dice for the
+    // walk so the positions these tests describe are the same ones every time.
+    const realRandom = Math.random;
+    const pinDice = (dice: number) => {
+        let s = dice >>> 0;
+        Math.random = () => {
+            s = (s * 1664525 + 1013904223) >>> 0;
+            return s / 4294967296;
+        };
+    };
+    afterEach(() => {
+        Math.random = realRandom;
+    });
+
+    /** Play until `seat` is buying resources in at least `minRound`. */
+    function resourcesSeat(map: string, players: number, seed: string, minRound: number, seat: number, dice = 1) {
+        pinDice(dice);
+        let G: GameState = setup(players, { map, variant: 'recharged' } as never, seed);
+        for (let i = 0; i < 40000; i++) {
+            const moves = G.players[seat].availableMoves;
+            if (G.round >= minRound && G.phase === Phase.Resources && moves && moves[MoveName.BuyResource]) return G;
+            const idx = G.players.findIndex((p) => p.availableMoves);
+            if (idx < 0) return null;
+            try {
+                G = moveAI(G, idx);
+            } catch {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    // map, players, seed, min round, pinned dice
+    const boards: [string, number, string, number, number][] = [
+        ['Germany', 4, '5', 4, 1],
+        ['Korea', 4, '2', 5, 1],
+        ['India', 4, '7', 6, 7],
+        ['South Africa', 4, '3', 5, 1],
+        ['Australia', 4, '7', 8, 1],
+        ['Europe', 4, '1', 5, 1],
+        ['Middle East', 4, '3', 4, 1],
+        ['Bremen', 4, '0', 5, 1],
+        ['USA', 4, '3', 8, 1],
+        ['Central Europe', 4, '4', 5, 1],
+    ];
+
+    it('every price a box shows is the money the engine actually takes', () => {
+        const seat = 1;
+        let rowsChecked = 0;
+
+        for (const [map, players, seed, minRound, dice] of boards) {
+            const G = resourcesSeat(map, players, seed, minRound, seat, dice);
+            expect(G, `${map} never reached a resource-buying seat`).to.not.be.null;
+
+            const buyable = G!.players[seat].availableMoves![MoveName.BuyResource]!;
+            const blocks = resourceBlocks(G!, {
+                player: seat,
+                buyable,
+                isUsaRecharged: G!.options.variant === 'recharged' && G!.map.name === 'USA',
+            });
+
+            for (const block of blocks) {
+                for (const row of block.rows) {
+                    if (!row.buyable) continue;
+                    const before = G!.players[seat].money;
+                    const after = engineMove(
+                        clone(G!),
+                        { name: MoveName.BuyResource, data: row.move, time: 1 } as never,
+                        seat
+                    );
+                    expect(before - after.players[seat].money, `${map}: ${row.label} box says $${row.price}`).to.equal(
+                        row.price
+                    );
+                    rowsChecked++;
+                }
+            }
+        }
+
+        expect(rowsChecked, 'no buyable rows were exercised at all').to.be.greaterThan(15);
+    });
+
+    it('the Wien garbage discount reaches the box, not just the engine', () => {
+        const seat = 1;
+        const G = resourcesSeat('Central Europe', 4, '4', 5, seat);
+        expect(G, 'no Central Europe seat').to.not.be.null;
+
+        const priceOf = (state: GameState) => {
+            const rows = resourceBlocks(state, { player: seat }).flatMap((b) => b.rows);
+            return rows.find((r) => r.label === 'Garbage')!.price;
+        };
+
+        const withoutWien = clone(G!);
+        withoutWien.players[seat].cities = withoutWien.players[seat].cities.filter((c) => c.name !== 'Wien');
+        const printed = priceOf(withoutWien);
+
+        // Give the seat Wien and nothing else changes.
+        const withWien = clone(withoutWien);
+        withWien.players[seat].cities.push({ name: 'Wien', region: 'red' } as never);
+
+        expect(priceOf(withWien), 'a Wien holder pays a dollar less').to.equal(printed! - 1);
+
+        // And the engine agrees, which is the whole reason the box may show it. The
+        // two states were edited by hand, so re-derive what each seat may do before
+        // asking the engine to act — `move` checks the payload against that list.
+        const buy = { name: MoveName.BuyResource, data: { resource: 'garbage' }, time: 1 };
+        const paidFrom = (state: GameState) => {
+            state.players[seat].availableMoves = availableMoves(state, state.players[seat]);
+            state.currentPlayers = [seat];
+            return state.players[seat].money - engineMove(clone(state), buy as never, seat).players[seat].money;
+        };
+        expect(paidFrom(withoutWien), 'the engine charges the printed price without Wien').to.equal(printed);
+        expect(paidFrom(withWien), 'and a dollar less with it').to.equal(printed! - 1);
+    });
+
+    it('a map with no uranium on the track gets no uranium box', () => {
+        for (const [map, expected] of [
+            ['Australia', false],
+            ['Bremen', false],
+            ['Germany', true],
+        ] as [string, boolean][]) {
+            const G = setup(4, { map, variant: 'recharged' } as never, '7');
+            const labels = resourceBlocks(G).flatMap((b) => b.rows.map((r) => r.label));
+            expect(labels.includes('Uranium'), `${map} uranium row`).to.equal(expected);
+        }
+    });
+
+    it('Korea gets one block per side, and only the south side sells uranium', () => {
+        const G = setup(4, { map: 'Korea', variant: 'recharged' } as never, '2');
+        const blocks = resourceBlocks(G, { resupply: ['3', '2', '1', '1'], resupplyNorth: ['2', '1', '1'] });
+
+        expect(blocks.map((b) => b.title)).to.deep.equal(['North Market', 'South Market']);
+        expect(blocks[0].rows.map((r) => r.label)).to.deep.equal(['Coal', 'Oil', 'Garbage']);
+        expect(blocks[1].rows.map((r) => r.label)).to.deep.equal(['Coal', 'Oil', 'Garbage', 'Uranium']);
+        expect(blocks[0].rows.every((r) => r.move.side === 'north')).to.be.true;
+        expect(blocks[1].rows.every((r) => r.move.side === 'south')).to.be.true;
+
+        // The restock numbers line up with the boxes drawn under them.
+        expect(blocks[0].restock).to.equal('2 / 1 / 1');
+        expect(blocks[1].restock).to.equal('3 / 2 / 1 / 1');
+    });
+
+    it("South Africa's storage pool is its own row at a flat price", () => {
+        const G = setup(4, { map: 'South Africa', variant: 'recharged' } as never, '3');
+        G.coalStorage = 6;
+        const rows = resourceBlocks(G).flatMap((b) => b.rows);
+        const storage = rows.find((r) => r.move.fromStorage)!;
+
+        expect(storage, 'a storage row exists').to.not.be.undefined;
+        expect(storage.price).to.equal(8);
+        expect(storage.flat, 'no price track behind it').to.be.true;
+        // Dots would claim only some cubes are at this price. They all are.
+        expect(storage.atPrice).to.equal(0);
+        expect(storage.cubes).to.equal(6);
+        // It does not steal a restock number from the printed rows.
+        const block = resourceBlocks(G, { resupply: ['5', '2', '2', '2'] })[0];
+        expect(block.restock).to.equal('5 / 2 / 2 / 2');
+    });
+
+    it('a row above the per-step price cap is shown, and flagged as unbuyable', () => {
+        const G = setup(4, { map: 'India', variant: 'recharged' } as never, '7');
+        expect(G.step, 'India starts in step 1').to.equal(1);
+        expect((G.map as { maxPriceAvailable?: number[] }).maxPriceAvailable![0], 'step 1 cap').to.equal(3);
+
+        G.uraniumMarket = 1; // drives the next uranium cube to the dear end of the track
+        const uranium = resourceBlocks(G)
+            .flatMap((b) => b.rows)
+            .find((r) => r.label === 'Uranium')!;
+
+        expect(uranium.price! > 3, 'the next cube is above the cap').to.be.true;
+        expect(uranium.capped).to.be.true;
+        expect(uranium.buyable, 'nobody may buy it yet').to.be.false;
+    });
+
+    it('an empty market reads as out rather than as free', () => {
+        const G = setup(4, { map: 'Germany', variant: 'recharged' } as never, '5');
+        G.coalMarket = 0;
+        const coal = resourceBlocks(G)
+            .flatMap((b) => b.rows)
+            .find((r) => r.label === 'Coal')!;
+
+        expect(coal.price).to.be.null;
+        expect(coal.next).to.be.null;
+        expect(coal.atPrice).to.equal(0);
+        expect(coal.cubes).to.equal(0);
+    });
+});


### PR DESCRIPTION
Continues the portrait work from #125/#126, and answers eric-hu's #127 discussion from the other side.

### Why

The printed price track is a beautiful object and an unreadable one on a phone. Eight to ten price columns of three-cube slots, drawn at whatever width the map author chose, get squeezed into a strip: the cubes end up a few pixels across, and telling which price column a cube is standing in becomes guesswork.

So on portrait the track is replaced by **one box per buyable source**, carrying only what a purchase actually needs — what the next cube costs, what it costs after that, how many are left at that price, how many are left at all. Each box is the whole tap target.

Landscape and desktop are untouched. This is an either/or on the stacked layout, never an overlay, and a player who switches the portrait layout off gets the printed board back. **Verified by pixel comparison**: landscape screenshots on three maps are byte-identical to master.

### What comes along for free

Every number comes out of the engine state rather than the printed geometry, so the map-specific markets need no special cases:

- **Korea** — two labelled blocks, north correctly without a uranium row, each with its own restock line
- **Australia** — the Step-3 CO2 shift (the engine rewrites the price array; the box is only ever a view of it), no uranium row
- **India** — the per-step price cap named on the rows it locks
- **South Africa** — the $8 storage pool as its own row, directly under market coal so the two prices are read together
- **USA recharged** — $8-from-supply once the track is bare
- **Europe / North America** — nine price columns, **Bremen** — no nuclear

What a player may tap is not decided here either: `buyableResources` is the engine's own `availableMoves`, so money, storage capacity, the hybrid tank and Korea's side lock are already accounted for.

### Two things a box has to get right that the printed board never had to

- A **flat-price pool** has no "buyable at this price" number, because every cube in it costs the same. It says so rather than drawing an arbitrary three dots.
- **Central Europe sells garbage a dollar cheaper to whoever holds Wien**, and the engine really does charge the lower price. A box shows the price *this* player would pay, because that is the only number a tap can act on.

### Tests

The row model lives in `util/resource-rows` rather than in the component so it can be tested against the engine directly — and that is what the spec does: **for every buyable row on ten maps, buy one cube and assert the engine took exactly what the box said it would.** Both halves teeth-checked: an off-by-one in the price index fails it, and so does dropping the Wien discount.

### Measured

On an iPhone XR (414x896), every box renders **381x57 css px** on every map, against a 44x44 guideline. Korea's seven rows are the tallest at 504px, inside the peek budget. No horizontal overflow at 2, 4 or 6 players. A tap dispatched at real screen coordinates on South Africa's storage box emits `{resource: coal, fromStorage: true}`.

Australia's uranium mine market was turned through 90 degrees for this layout: a 104x430 strip is the worst possible shape for a full-width row, since it can only grow until its HEIGHT fills the row. Australia's page went from 2.05 screens to **1.62**. Landscape keeps the vertical strip exactly as it was.

Viewer only — engine untouched.
