### PR TITLE
India: let a player pass when they cannot fire anything

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -708,8 +708,19 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
                 moves[MoveName.UsePowerPlant] = toUse;
             }
 
-            // For India map, players must power as many cities as possible.
-            if (G.map.name != 'India' || player.citiesPowered >= player.targetCitiesPowered! || player.isAI) {
+            // For India map, players must power as many cities as possible — but "as
+            // many as possible" is already satisfied once there is nothing left that
+            // CAN be fired. Without that last clause a player who runs out of fuel
+            // short of their target is offered no move at all: not a plant, not Pass.
+            // Bureaucracy is simultaneous, so the whole table then waits on a seat with
+            // nothing to click. Bots never hit it (isAI is an escape here), which is
+            // why it only ever bites humans.
+            if (
+                G.map.name != 'India' ||
+                player.citiesPowered >= player.targetCitiesPowered! ||
+                player.isAI ||
+                toUse.length === 0
+            ) {
                 moves[MoveName.Pass] = [true];
             }
             break;

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -1973,4 +1973,44 @@ describe('Engine', () => {
         expect(G.players[idx].coalLeft, 'the player is left within capacity, not one cube over').to.equal(0);
         expect(G.coalSupply - supplyBefore, 'every discarded cube goes back to the supply').to.equal(3);
     });
+    it('should let an India player pass when they cannot fire anything, target or not', () => {
+        // India requires powering as many cities as possible, which was read as "you
+        // may not pass below your target". A player who then runs out of fuel short of
+        // that target was offered NOTHING: no plant, no pass. Bureaucracy is
+        // simultaneous, so the whole table waits on a seat with nothing to click.
+        //
+        // Both halves need the player to actually OWN a plant that burns something:
+        // with an empty hand, or a wind/nuclear plant that needs no fuel, the first
+        // assertion would pass for the wrong reason.
+        const seatWith = (fuel: number) => {
+            const G = setup(2, { map: 'India', variant: 'recharged', randomizeMap: false }, 'india-deadlock');
+            G.phase = Phase.Bureaucracy;
+            const player = G.players[G.players[0].id];
+            G.currentPlayers = [player.id];
+
+            const burner = G.actualMarket
+                .concat(G.futureMarket)
+                .find((p) => p.type === PowerPlantType.Coal || p.type === PowerPlantType.Oil);
+            expect(burner, 'the opening market always holds a coal or oil plant').to.not.be.undefined;
+
+            player.powerPlants = [burner!];
+            player.powerPlantsNotUsed = [burner!.number];
+            player.coalLeft = fuel;
+            player.oilLeft = fuel;
+            player.citiesPowered = 0;
+            player.targetCitiesPowered = 3;
+            player.availableMoves = availableMoves(G, player);
+            return player;
+        };
+
+        const dry = seatWith(0);
+        expect(dry.availableMoves![MoveName.UsePowerPlant], 'no fuel, so its plant cannot be fired').to.be.undefined;
+        expect(dry.availableMoves![MoveName.Pass], 'so passing has to be legal, or there is no legal move at all').to
+            .not.be.undefined;
+
+        // The requirement still bites while a plant CAN still be fired.
+        const fed = seatWith(20);
+        expect(fed.availableMoves![MoveName.UsePowerPlant], 'fuelled, so its plant can be fired').to.not.be.undefined;
+        expect(fed.availableMoves![MoveName.Pass], 'and while one can, India still refuses the pass').to.be.undefined;
+    });
 });


### PR DESCRIPTION
### A human can be frozen out of an India game

India requires powering as many cities as possible, and that was implemented as "you may not pass while below your target". A player who runs out of fuel short of that target is then offered **nothing** in Bureaucracy: no plant to fire, no pass. Nothing to click at all.

Bureaucracy is simultaneous, so the whole table waits on that seat until they are dropped for inactivity.

Bots never hit it — `player.isAI` is an explicit escape on the same line — which is exactly why it survived: it only ever bites humans, and only on India.

### How often

With the AI dice pinned, five player counts x six games each:

| | dead-ended |
|---|---|
| humans, India | **24/30** |
| bots, India | 0/30 |
| humans, every other map | 0/30 |

### The fix

"As many cities as possible" is already satisfied once there is nothing left that CAN be fired. That is the added clause. Afterwards humans go **24/30 -> 0/30**.

### Evidence it changes nothing else

Differential sweep, 23 maps x 2-6 players x 3 pinned dice = **345 games**, comparing outcome, move count, final round/step and a state hash with the clock fields stripped:

**333 identical, and the only 12 that differ are the India games that used to freeze.**

### On the test

The regression spec is teeth-checked against the old behaviour. Worth saying that its first draft **passed for the wrong reason** — at setup a player owns no plants at all, so "cannot fire anything" was vacuously true. It now hands the seat a coal or oil plant from the opening market, so the no-fuel case is a real one, and asserts the other direction too: while a plant CAN still be fired, India still refuses the pass.

Engine change: needs an engine bump and duplicate-to-next-version.
