### PR TITLE
South Africa: storage coal only when the track has nothing cheaper

### DIFF
--- a/engine/src/available-moves.ts
+++ b/engine/src/available-moves.ts
@@ -300,15 +300,23 @@ export function availableMoves(G: GameState, player: Player): AvailableMoves {
             }
 
             // South Africa: $8 flat coal from the storage pool below the market.
-            // Always available alongside the regular market option (not gated on
-            // market being empty), as long as there are cubes in storage.
+            // Only on offer while the market has no coal going cheaper — you cannot
+            // reach past a $4 cube on the track to pay $8 for a stored one (Mike's
+            // ruling, 2026-08-24). The printed track tops out at $8, so in practice
+            // storage opens once the market reaches its last price band or empties.
+            // This mirrors USA recharged's $8-from-supply, which was already gated on
+            // the market being bare.
             if (allowSouth && G.coalStorage !== undefined && G.coalStorage > 0) {
                 const hybridCapacityUsed =
                     player.hybridCapacity > 0 ? Math.max(0, player.oilLeft - player.oilCapacity) : 0;
+                const coalPrices = G.coalPrices ?? prices[ResourceType.Coal];
+                const marketPrice =
+                    G.coalMarket > 0 ? coalPrices[coalPrices.length - G.coalMarket] : Number.POSITIVE_INFINITY;
                 if (
                     player.money >= 8 &&
                     player.coalCapacity + player.hybridCapacity > hybridCapacityUsed + player.coalLeft &&
-                    8 <= maxPriceAvailable
+                    8 <= maxPriceAvailable &&
+                    marketPrice >= 8
                 ) {
                     toBuy.push({ resource: ResourceType.Coal, fromStorage: true });
                 }

--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -33,6 +33,7 @@ import {
 import { Cities as ChinaCities, map as chinaMap } from './maps/china';
 import { Move, MoveName } from './move';
 import { powerPlants } from './powerPlants';
+import prices from './prices';
 
 describe('Engine', () => {
     it('should setup a game correctly', () => {
@@ -2012,5 +2013,48 @@ describe('Engine', () => {
         const fed = seatWith(20);
         expect(fed.availableMoves![MoveName.UsePowerPlant], 'fuelled, so its plant can be fired').to.not.be.undefined;
         expect(fed.availableMoves![MoveName.Pass], 'and while one can, India still refuses the pass').to.be.undefined;
+    });
+
+    it('should only offer South Africa storage coal when nothing on the track is cheaper', () => {
+        // Mike's ruling, 2026-08-24: you cannot reach past a cheap cube on the printed
+        // track to pay $8 for a stored one. The track tops out at $8, so storage opens
+        // once the market reaches its last band or empties. Mirrors USA recharged's
+        // $8-from-supply, which was already gated on the market being bare.
+        const seat = (coalMarket: number) => {
+            const G = setup(2, { map: 'South Africa', variant: 'recharged', randomizeMap: false }, 'sa-storage');
+            G.phase = Phase.Resources;
+            const player = G.players[G.players[0].id];
+            G.currentPlayers = [player.id];
+            G.coalStorage = 6;
+            G.coalMarket = coalMarket;
+            player.money = 100;
+            player.coalCapacity = 20;
+            player.coalLeft = 0;
+            player.availableMoves = availableMoves(G, player);
+            const buys = player.availableMoves[MoveName.BuyResource] ?? [];
+            return {
+                storage: buys.some((b) => b.fromStorage),
+                market: buys.some((b) => b.resource === ResourceType.Coal && !b.fromStorage),
+                price: G.coalPrices
+                    ? G.coalPrices[G.coalPrices.length - coalMarket]
+                    : prices[ResourceType.Coal][prices[ResourceType.Coal].length - coalMarket],
+            };
+        };
+
+        // A full track: the next cube is $1, so $8 storage is off the table.
+        const cheap = seat(24);
+        expect(cheap.price, 'a full track sells its next cube at $1').to.equal(1);
+        expect(cheap.market, 'the market itself is buyable').to.be.true;
+        expect(cheap.storage, 'and storage is not, while $1 coal is sitting there').to.be.false;
+
+        // Down to the last band, where the track charges $8 too.
+        const dear = seat(3);
+        expect(dear.price, 'the last three cubes are the $8 band').to.equal(8);
+        expect(dear.storage, 'nothing is cheaper now, so storage opens').to.be.true;
+
+        // And an empty track leaves storage as the only coal there is.
+        const bare = seat(0);
+        expect(bare.market, 'no cubes left on the track').to.be.false;
+        expect(bare.storage, 'storage is still there at $8').to.be.true;
     });
 });


### PR DESCRIPTION
### Mike's ruling

The $8 storage pool should not be on offer while there is cheaper coal sitting on the printed track. You cannot reach past a $4 cube to pay $8 for a stored one.

It had been available unconditionally whenever storage held cubes, which made a strictly worse purchase one tap away all game. What surfaced it was the portrait layout, where the two coal sources sit as two boxes and it read as a real choice rather than a trap.

The track tops out at $8, so in practice storage now opens once the market reaches its last price band or empties. This is the same shape as **USA recharged's $8-from-supply, which was already gated on the market being bare** — so the two flat pools finally behave alike.

### Replay impact, measured

This removes a legal move, so in principle a recorded game containing one would fail a fresh replay. Across 30 South Africa AI games (5 player counts x 6 pinned dice):

| | count |
|---|---|
| $8 storage buys made | 58 |
| ...while the market was EMPTY (still legal) | **58** |
| ...while the market was also at $8 (still legal) | 0 |
| ...while cheaper coal existed (**refused now**) | **0** |

The AI takes the cheapest option, so it never made the wasteful buy.

**Note the regime, though:** that says nothing about a human, who could have made it in a live game. Deploy as duplicate-to-next-version, as behavioural changes do.

Differential sweep, 23 maps x 2-6 players x 3 pinned dice = 345 games: **345 identical, 0 changed.**

### Test

Teeth-checked against the old behaviour, covering all three bands: a full track ($1 next) refuses storage, the last band ($8) opens it, and an empty track leaves storage as the only coal there is.

Engine change: needs an engine bump and duplicate-to-next-version.
