### PR TITLE
Take back a resource bought earlier in the same turn (#127)

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -156,7 +156,9 @@
                     :buyableResources="buyableResources()"
                     :resourceResupply="getResourceResupply()"
                     :resourceResupplyNorth="getResourceResupplyNorth()"
+                    :bufferedBuys="bufferedBuys"
                     @buyResource="buyResource($event)"
+                    @unbuyResource="unbuyResource($event)"
                 />
                 <Resources
                     v-else
@@ -174,7 +176,9 @@
                     :coalStorage="G.coalStorage"
                     :resourceResupply="getResourceResupply()"
                     :resourceResupplyNorth="getResourceResupplyNorth()"
+                    :bufferedBuys="bufferedBuys"
                     @buyResource="buyResource($event)"
+                    @unbuyResource="unbuyResource($event)"
                 />
             </g>
 
@@ -721,7 +725,13 @@ import { Vue, Component, Prop, Watch, Provide, ProvideReactive, Ref } from 'vue-
 import { MoveName, ended, playersSortedByScore, reconstructState } from 'powergrid-engine';
 import type { GameState, LogItem, Move, Player } from 'powergrid-engine';
 import { EventEmitter } from 'events';
-import { matchesTurnBuffer, rebaseTurnBuffer, replayTurnBuffer as replayBuffer } from '../util/turn-buffer';
+import {
+    bufferedBuyCounts,
+    lastBuyIndex,
+    matchesTurnBuffer,
+    rebaseTurnBuffer,
+    replayTurnBuffer as replayBuffer,
+} from '../util/turn-buffer';
 import { UIData, Preferences } from '../types/ui-data';
 import { Card, House, Coal, Oil, Garbage, Uranium } from './pieces';
 import {
@@ -1259,6 +1269,47 @@ export default class Game extends Vue {
             data.fromStorage = payload.fromStorage;
         }
         this.sendMove({ name: MoveName.BuyResource, data });
+    }
+
+    /**
+     * Take back a resource bought earlier in this same turn (#127): a market's empty
+     * spaces are clickable while the buffer still holds a purchase from that source.
+     *
+     * This is not an engine undo — there is no Undo move any more (2.0.0). A tentative
+     * turn lives only in this buffer, so a purchase is taken back by dropping it and
+     * replaying the rest, exactly as `undo()` drops the last move. Removing a buy only
+     * ever frees money and plant capacity, so the remaining buffer always replays.
+     */
+    unbuyResource(payload: { resource: ResourceType, side?: 'north' | 'south', fromStorage?: boolean }) {
+        if (this.paused || !this.committedState) {
+            return;
+        }
+
+        const index = lastBuyIndex(this.turnMoves, payload);
+
+        if (index < 0) {
+            return;
+        }
+
+        this.turnMoves.splice(index, 1);
+
+        if (this.turnMoves.length > 0) {
+            const preview = this.replayTurnBuffer();
+            this.emitter.emit('move', [...this.turnMoves]);
+            this.replaceState(preview, false);
+        } else {
+            // Empty buffer: nothing to send — nothing was ever persisted for this turn,
+            // so the last committed state IS the turn start.
+            this.replaceState(this.committedState, false);
+        }
+    }
+
+    /**
+     * Cubes the turn buffer would give back, per source — how many of each market's
+     * empty spaces are clickable.
+     */
+    get bufferedBuys(): Record<string, number> {
+        return bufferedBuyCounts(this.turnMoves);
     }
 
     bid(bid: number) {

--- a/viewer/src/components/boards/ResourceBoxes.vue
+++ b/viewer/src/components/boards/ResourceBoxes.vue
@@ -116,6 +116,44 @@
                         step {{ step }} sells to ${{ maxPrice }}
                     </text>
 
+                    <!-- A purchase made this turn can be handed back (#127). The box
+                         market has no empty spaces to click — the printed track's
+                         ghosts are exactly what it replaces — so the take-back lives
+                         on a chip, and stops the click reaching the buy target under
+                         it. Sits in the free band above the cubes, and appears whether
+                         or not the row is still buyable: being unable to afford the
+                         next cube is precisely when you want the last one back. -->
+                    <g v-if="canUnbuy(row)" class="canClick" @click.stop="$emit('unbuyResource', row.move)">
+                        <rect
+                            :x="chipBox(row).hx"
+                            :y="chipBox(row).hy"
+                            :width="chipBox(row).hw"
+                            :height="chipBox(row).hh"
+                            fill="transparent"
+                            pointer-events="all"
+                        />
+                        <rect
+                            :x="chipBox(row).x"
+                            :y="chipBox(row).y"
+                            :width="chipBox(row).w"
+                            :height="chipBox(row).h"
+                            rx="10"
+                            fill="#f0e6c8"
+                            stroke="#6b5312"
+                            stroke-width="2"
+                        />
+                        <text
+                            :x="chipBox(row).x + chipBox(row).w / 2"
+                            :y="chipBox(row).y + chipBox(row).h / 2 + 8"
+                            text-anchor="middle"
+                            font-weight="700"
+                            fill="#3a2c08"
+                            :style="`font-size: ${chipBox(row).fontSize}px`"
+                        >
+                            − take back
+                        </text>
+                    </g>
+
                     <title>{{ row.title }}</title>
                 </g>
             </g>
@@ -126,7 +164,8 @@
 <script lang="ts">
 import { GameState } from 'powergrid-engine';
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { BuyMove, ResourceBlock, resourceBlocks } from '../../util/resource-rows';
+import { BuyMove, ResourceBlock, ResourceRow, resourceBlocks } from '../../util/resource-rows';
+import { buySourceKey } from '../../util/turn-buffer';
 
 const BOX_W = 700;
 const BOX_H = 104;
@@ -167,12 +206,35 @@ export default class ResourceBoxes extends Vue {
     @Prop() isUsaRecharged?: boolean;
     /** The seat looking at the board — only needed for Central Europe's Wien discount. */
     @Prop() player?: number;
+    /** Purchases still sitting in this turn's buffer, per source (#127). */
+    @Prop() bufferedBuys?: Record<string, number>;
 
     BOX_W = BOX_W;
     BOX_H = BOX_H;
     BOX_GAP = BOX_GAP;
     HEAD_H = HEAD_H;
     CUBE_BAND_CENTRE = CUBE_BAND_CENTRE;
+
+    /**
+     * Where a row's take-back button sits: in the gap between the price block and the
+     * cubes, and big enough for a thumb (~28 css px tall on a phone).
+     *
+     * The two pool rows carry a long label right across that gap — but they are
+     * flat-priced, so nothing sits below them, and the button drops under the label at
+     * the same size rather than shrinking.
+     */
+    chipBox(row: ResourceRow) {
+        const labelFillsTheTop = row.label.length > 8;
+
+        return labelFillsTheTop
+            ? { x: 130, y: 36, w: 140, h: 52, hx: 120, hy: 32, hw: 164, hh: 60, fontSize: 22 }
+            : { x: 130, y: 6, w: 140, h: 52, hx: 120, hy: 2, hw: 164, hh: 60, fontSize: 22 };
+    }
+
+    /** Does this turn's buffer hold a purchase from this row's source? */
+    canUnbuy(row: ResourceRow): boolean {
+        return !!this.bufferedBuys && !!this.bufferedBuys[buySourceKey(row.move)];
+    }
 
     /** Centre the cube cluster in that band, however many cubes there are. */
     cubeX(count: number, n: number): number {

--- a/viewer/src/components/boards/Resources.vue
+++ b/viewer/src/components/boards/Resources.vue
@@ -75,10 +75,13 @@
                     :key="coal.id"
                     :pieceId="coal.id"
                     :targetState="{ x: coal.x, y: coal.y }"
-                    :canClick="!coal.transparent && canBuyResource('coal', coal.side, coal.fromStorage)"
+                    :canClick="
+                        coal.transparent ? canUnbuy('coal', coal) : canBuyResource('coal', coal.side, coal.fromStorage)
+                    "
                     :transparent="coal.transparent"
+                    :restorable="canUnbuy('coal', coal)"
                     :scale="0.08"
-                    @click="buyResource('coal', coal.side, coal.fromStorage)"
+                    @click="clickResource('coal', coal)"
                 />
             </template>
             <template v-for="oil in oilsNorth">
@@ -86,9 +89,10 @@
                     :key="oil.id"
                     :pieceId="oil.id"
                     :targetState="{ x: oil.x, y: oil.y }"
-                    :canClick="!oil.transparent && canBuyResource('oil', oil.side)"
+                    :canClick="oil.transparent ? canUnbuy('oil', oil) : canBuyResource('oil', oil.side)"
                     :transparent="oil.transparent"
-                    @click="buyResource('oil', oil.side)"
+                    :restorable="canUnbuy('oil', oil)"
+                    @click="clickResource('oil', oil)"
                 />
             </template>
             <template v-for="garbage in garbagesNorth">
@@ -96,9 +100,12 @@
                     :key="garbage.id"
                     :pieceId="garbage.id"
                     :targetState="{ x: garbage.x, y: garbage.y }"
-                    :canClick="!garbage.transparent && canBuyResource('garbage', garbage.side)"
+                    :canClick="
+                        garbage.transparent ? canUnbuy('garbage', garbage) : canBuyResource('garbage', garbage.side)
+                    "
                     :transparent="garbage.transparent"
-                    @click="buyResource('garbage', garbage.side)"
+                    :restorable="canUnbuy('garbage', garbage)"
+                    @click="clickResource('garbage', garbage)"
                 />
             </template>
             <text x="20" y="35" font-weight="700" fill="black" style="font-size: 22px">South Market</text>
@@ -326,10 +333,13 @@
                 :key="coal.id"
                 :pieceId="coal.id"
                 :targetState="{ x: coal.x, y: coal.y }"
-                :canClick="!coal.transparent && canBuyResource('coal', coal.side, coal.fromStorage)"
+                :canClick="
+                    coal.transparent ? canUnbuy('coal', coal) : canBuyResource('coal', coal.side, coal.fromStorage)
+                "
                 :transparent="coal.transparent"
+                :restorable="canUnbuy('coal', coal)"
                 :scale="isIndiaResourceMarket ? 0.06 : 0.08"
-                @click="buyResource('coal', coal.side, coal.fromStorage)"
+                @click="clickResource('coal', coal)"
             />
         </template>
 
@@ -338,9 +348,10 @@
                 :key="oil.id"
                 :pieceId="oil.id"
                 :targetState="{ x: oil.x, y: oil.y }"
-                :canClick="!oil.transparent && canBuyResource('oil', oil.side)"
+                :canClick="oil.transparent ? canUnbuy('oil', oil) : canBuyResource('oil', oil.side)"
                 :transparent="oil.transparent"
-                @click="buyResource('oil', oil.side)"
+                :restorable="canUnbuy('oil', oil)"
+                @click="clickResource('oil', oil)"
             />
         </template>
 
@@ -349,10 +360,11 @@
                 :key="garbage.id"
                 :pieceId="garbage.id"
                 :targetState="{ x: garbage.x, y: garbage.y }"
-                :canClick="!garbage.transparent && canBuyResource('garbage', garbage.side)"
+                :canClick="garbage.transparent ? canUnbuy('garbage', garbage) : canBuyResource('garbage', garbage.side)"
                 :transparent="garbage.transparent"
+                :restorable="canUnbuy('garbage', garbage)"
                 :scale="isIndiaResourceMarket ? 0.8 : 1"
-                @click="buyResource('garbage', garbage.side)"
+                @click="clickResource('garbage', garbage)"
             />
         </template>
 
@@ -361,9 +373,10 @@
                 :key="uranium.id"
                 :pieceId="uranium.id"
                 :targetState="{ x: uranium.x, y: uranium.y }"
-                :canClick="!uranium.transparent && canBuyResource('uranium', uranium.side)"
+                :canClick="uranium.transparent ? canUnbuy('uranium', uranium) : canBuyResource('uranium', uranium.side)"
                 :transparent="uranium.transparent"
-                @click="buyResource('uranium', uranium.side)"
+                :restorable="canUnbuy('uranium', uranium)"
+                @click="clickResource('uranium', uranium)"
             />
         </template>
 
@@ -426,6 +439,7 @@ import { Vue, Component, Prop, Inject } from 'vue-property-decorator';
 import { Coal, Garbage, Oil, Uranium } from '../pieces';
 import { Piece, Preferences } from '../../types/ui-data';
 import { range } from 'lodash';
+import { buySourceKey } from '../../util/turn-buffer';
 
 @Component({
     components: {
@@ -443,6 +457,9 @@ export default class Resources extends Vue {
     // South Africa: number of coal cubes in the storage pool below the market.
     // Undefined on all other maps (panel is hidden).
     @Prop() coalStorage?: number;
+    // Purchases still sitting in this turn's buffer, per source (#127). Each one can be
+    // taken back by clicking the empty space it left behind.
+    @Prop() bufferedBuys?: Record<string, number>;
 
     @Inject() preferences!: Preferences;
 
@@ -452,6 +469,7 @@ export default class Resources extends Vue {
     uraniums: Piece[] = [];
 
     isKorea: boolean = false;
+    coalComesFromSupply: boolean = false;
     isNinePriceMarket: boolean = false;
     // Australia: coal/oil/garbage-only market that can reach $10 after the Step 3
     // CO2 tax. co2TaxActive closes the $1/$2 columns once that shift has happened.
@@ -501,6 +519,7 @@ export default class Resources extends Vue {
                     x,
                     y,
                     transparent: i < (prices.length - market),
+                    ghostRank: (prices.length - market) - i,
                     side: options.side,
                 });
             }
@@ -511,6 +530,10 @@ export default class Resources extends Vue {
     createPieces(gameState: GameState) {
         if (!gameState) return;
 
+        // USA recharged: once the printed track is bare, coal is bought from the $8
+        // supply pile, and a cube taken back returns THERE — so the empty track spaces
+        // must not offer to give it back (#127).
+        this.coalComesFromSupply = !!this.isUsaRecharged && gameState.coalMarket === 0 && gameState.coalSupply > 0;
         this.isAustraliaMarket = gameState.map?.name === 'Australia';
         this.co2TaxActive = this.isAustraliaMarket && gameState.step >= 3;
         this.isBremenMarket = gameState.map?.name === 'Bremen';
@@ -551,6 +574,7 @@ export default class Resources extends Vue {
                     id: `uranium_${i}`,
                     x, y,
                     transparent: i < (uPrices.length - gameState.uraniumMarket),
+                    ghostRank: (uPrices.length - gameState.uraniumMarket) - i,
                     side: 'south',
                 });
             });
@@ -665,7 +689,8 @@ export default class Resources extends Vue {
                             id: 'coal_' + i,
                             x: 672 - 17 * index - 17 * Math.floor(index / 4),
                             y: 48,
-                            transparent: i >= gameState!.coalMarket
+                            transparent: i >= gameState!.coalMarket,
+                            ghostRank: i - (gameState!.coalMarket) + 1,
                         });
                     });
             } else {
@@ -677,6 +702,7 @@ export default class Resources extends Vue {
                             x: 668 - 23.5 * i - 14.5 * Math.floor(i / 3),
                             y: 48,
                             transparent: i >= gameState!.coalMarket,
+                            ghostRank: i - (gameState!.coalMarket) + 1,
                         });
                     });
             }
@@ -720,6 +746,7 @@ export default class Resources extends Vue {
                             x: 651 - 16 * adjustedIndex - 37 * Math.floor(adjustedIndex / 3),
                             y: 70,
                             transparent: i >= availableRegularOil,
+                            ghostRank: i - (availableRegularOil) + 1,
                         });
                     });
             } else {
@@ -731,6 +758,7 @@ export default class Resources extends Vue {
                             x: 651 - 16 * i - 37 * Math.floor(i / 3),
                             y: 70,
                             transparent: i >= gameState!.oilMarket,
+                            ghostRank: i - (gameState!.oilMarket) + 1,
                         });
                     });
             }
@@ -746,6 +774,7 @@ export default class Resources extends Vue {
                             x: 672 - 17 * index - 17 * Math.floor(index / 4),
                             y: 94,
                             transparent: i >= gameState!.garbageMarket,
+                            ghostRank: i - (gameState!.garbageMarket) + 1,
                         });
                     });
             } else {
@@ -757,6 +786,7 @@ export default class Resources extends Vue {
                             x: 668 - 23.5 * i - 14.5 * Math.floor(i / 3),
                             y: 94,
                             transparent: i >= gameState!.garbageMarket,
+                            ghostRank: i - (gameState!.garbageMarket) + 1,
                         });
                     });
             }
@@ -770,7 +800,8 @@ export default class Resources extends Vue {
                             id: 'uranium_' + i,
                             x: 670 - 85 * i,
                             y: 72,
-                            transparent: i >= gameState!.uraniumMarket
+                            transparent: i >= gameState!.uraniumMarket,
+                            ghostRank: i - (gameState!.uraniumMarket) + 1,
                         });
                     });
             } else {
@@ -783,6 +814,7 @@ export default class Resources extends Vue {
                                 x: 750,
                                 y: 91,
                                 transparent: i >= gameState!.uraniumMarket,
+                                ghostRank: i - (gameState!.uraniumMarket) + 1,
                             });
                         } else if (i == 1) {
                             this.uraniums.push({
@@ -790,6 +822,7 @@ export default class Resources extends Vue {
                                 x: 710,
                                 y: 91,
                                 transparent: i >= gameState!.uraniumMarket,
+                                ghostRank: i - (gameState!.uraniumMarket) + 1,
                             });
                         } else if (i == 2) {
                             this.uraniums.push({
@@ -797,6 +830,7 @@ export default class Resources extends Vue {
                                 x: 750,
                                 y: 52,
                                 transparent: i >= gameState!.uraniumMarket,
+                                ghostRank: i - (gameState!.uraniumMarket) + 1,
                             });
                         } else if (i == 3) {
                             this.uraniums.push({
@@ -804,6 +838,7 @@ export default class Resources extends Vue {
                                 x: 710,
                                 y: 52,
                                 transparent: i >= gameState!.uraniumMarket,
+                                ghostRank: i - (gameState!.uraniumMarket) + 1,
                             });
                         } else {
                             this.uraniums.push({
@@ -811,6 +846,7 @@ export default class Resources extends Vue {
                                 x: 1010 - 85 * i,
                                 y: 72,
                                 transparent: i >= gameState!.uraniumMarket,
+                                ghostRank: i - (gameState!.uraniumMarket) + 1,
                             });
                         }
                     });
@@ -834,6 +870,34 @@ export default class Resources extends Vue {
 
     buyResource(resource: string, side?: 'north' | 'south', fromStorage?: boolean) {
         this.$emit('buyResource', { resource, side, fromStorage });
+    }
+
+    /**
+     * Can this empty space give a cube back? Buying empties a track from its cheap end,
+     * so the `n` spaces nearest the fill line hold the `n` purchases this turn's buffer
+     * still has from that source — `ghostRank` counts out from that line.
+     */
+    canUnbuy(resource: string, piece: Piece) {
+        if (!piece.transparent || !piece.ghostRank || !this.bufferedBuys) {
+            return false;
+        }
+
+        if (this.coalComesFromSupply && resource === 'coal' && !piece.fromStorage) {
+            return false;
+        }
+
+        const buffered = this.bufferedBuys[buySourceKey({ resource, side: piece.side, fromStorage: piece.fromStorage })];
+
+        return !!buffered && piece.ghostRank <= buffered;
+    }
+
+    /** A cube buys; the empty space it left takes the purchase back. */
+    clickResource(resource: string, piece: Piece) {
+        if (piece.transparent) {
+            this.$emit('unbuyResource', { resource, side: piece.side, fromStorage: piece.fromStorage });
+        } else {
+            this.buyResource(resource, piece.side, piece.fromStorage);
+        }
     }
 }
 </script>

--- a/viewer/src/components/pieces/Coal.vue
+++ b/viewer/src/components/pieces/Coal.vue
@@ -3,7 +3,7 @@
         :id="elId"
         :class="[{ canClick: canClick }]"
         :transform="`translate(${currentX}, ${currentY}) scale(${scale})`"
-        :opacity="transparent ? 0.3 : 1"
+        :opacity="pieceOpacity"
         @click="canClick && $emit('click')"
     >
         <path

--- a/viewer/src/components/pieces/Garbage.vue
+++ b/viewer/src/components/pieces/Garbage.vue
@@ -3,7 +3,7 @@
         :id="elId"
         :class="[{ canClick: canClick }]"
         :transform="`translate(${currentX}, ${currentY}) scale(${scale})`"
-        :opacity="transparent ? 0.3 : 1"
+        :opacity="pieceOpacity"
         @click="canClick && $emit('click')"
     >
         <path d="M2,5 A9,5,0 0,1 18,5 L18,15 A9,5 0 0,1 2,15Z" fill="none" stroke="black" stroke-miterlimit="0" />

--- a/viewer/src/components/pieces/Oil.vue
+++ b/viewer/src/components/pieces/Oil.vue
@@ -3,7 +3,7 @@
         :id="elId"
         :class="[{ canClick: canClick }]"
         :transform="`translate(${currentX}, ${currentY}) scale(${scale})`"
-        :opacity="transparent ? 0.3 : 1"
+        :opacity="pieceOpacity"
         @click="canClick && $emit('click')"
     >
         <path d="M6,4 A6,4,0 0,1 14,4 L14,16 A6,4 0 0,1 6,16Z" fill="none" stroke="black" />

--- a/viewer/src/components/pieces/Piece.vue
+++ b/viewer/src/components/pieces/Piece.vue
@@ -27,6 +27,12 @@ export default class Piece extends Vue {
     @Prop()
     transparent?: boolean;
 
+    // An empty market space holding a purchase that can still be taken back (#127).
+    // Drawn brighter than a plain empty space so the click target is visible — there
+    // is no hover cursor to discover it with on a phone.
+    @Prop()
+    restorable?: boolean;
+
     @Inject()
     readonly communicator!: EventEmitter;
 
@@ -42,6 +48,14 @@ export default class Piece extends Vue {
     transitionCount = 0;
 
     moving = false;
+
+    get pieceOpacity(): number {
+        if (!this.transparent) {
+            return 1;
+        }
+
+        return this.restorable ? 0.6 : 0.3;
+    }
 
     startTransitioning() {
         if (this.transitioning) {

--- a/viewer/src/components/pieces/Uranium.vue
+++ b/viewer/src/components/pieces/Uranium.vue
@@ -3,7 +3,7 @@
         :id="elId"
         :class="[{ canClick: canClick }]"
         :transform="`translate(${currentX}, ${currentY})`"
-        :opacity="transparent ? 0.3 : 1"
+        :opacity="pieceOpacity"
         @click="canClick && $emit('click')"
     >
         <path d="M3,3 l4,-2 l6,0 l4,2 l0,11 l-4,2 l-6,0 l-4,-2Z" fill="#F00" stroke="black" />

--- a/viewer/src/types/ui-data.ts
+++ b/viewer/src/types/ui-data.ts
@@ -30,6 +30,11 @@ export interface Piece {
     // South Africa: this coal cube sits in the storage pool below the market.
     // Clicking emits buyResource with fromStorage:true (flat $8 buy).
     fromStorage?: boolean;
+    // Empty spaces only: distance from the market's fill line, 1 for the space the
+    // next cube would come back to. A purchase made this turn can be taken back by
+    // clicking the ghost that holds it (#127), so the first `n` ranks are clickable
+    // when the turn buffer holds `n` buys from that source.
+    ghostRank?: number;
 }
 
 export enum PieceType {

--- a/viewer/src/util/turn-buffer.ts
+++ b/viewer/src/util/turn-buffer.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash';
 import type { GameState, LogItem, LogMove, Move } from 'powergrid-engine';
-import { move as engineMove } from 'powergrid-engine';
+import { move as engineMove, MoveName } from 'powergrid-engine';
 
 /**
  * Pure helpers for the viewer's tentative-turn buffer.
@@ -146,4 +146,69 @@ export function replayTurnBuffer(
     }
 
     return { state, applied };
+}
+
+/**
+ * Where a resource purchase came from. The same resource bought from the north or the
+ * south table, or out of South Africa's storage pool, is a different source with its
+ * own cubes — so a decrement must give back a cube from the source that was clicked.
+ */
+export interface BuySource {
+    resource: string;
+    side?: 'north' | 'south';
+    fromStorage?: boolean;
+}
+
+/** Stable key for a buy source, so counts can be looked up per market row or track. */
+export function buySourceKey(source: BuySource): string {
+    return `${source.resource}|${source.side || ''}|${source.fromStorage ? 'storage' : ''}`;
+}
+
+function isBuyFrom(move: Move, source: BuySource): boolean {
+    const data = move.data as BuySource | undefined;
+
+    return (
+        move.name === MoveName.BuyResource &&
+        !!data &&
+        data.resource === source.resource &&
+        (data.side || '') === (source.side || '') &&
+        !!data.fromStorage === !!source.fromStorage
+    );
+}
+
+/**
+ * How many cubes of each source the buffer would give back, keyed by `buySourceKey`.
+ * The market draws one ghost per cube taken off it, so this is also how many of those
+ * ghosts can be clicked to take a purchase back.
+ */
+export function bufferedBuyCounts(turnMoves: Move[]): Record<string, number> {
+    const counts: Record<string, number> = {};
+
+    for (const move of turnMoves) {
+        if (move.name !== MoveName.BuyResource || !move.data) {
+            continue;
+        }
+
+        const key = buySourceKey(move.data as BuySource);
+        counts[key] = (counts[key] || 0) + 1;
+    }
+
+    return counts;
+}
+
+/**
+ * Index of the purchase a decrement click should remove: the LAST buffered buy from
+ * that source. Cubes leave a track cheapest-first, so the last buy is the one the
+ * market hands back — and removing a purchase only ever frees money and plant capacity,
+ * so the rest of the buffer always replays (verified over 653 mid-buffer removals).
+ * Returns -1 when the buffer holds no purchase from that source.
+ */
+export function lastBuyIndex(turnMoves: Move[], source: BuySource): number {
+    for (let i = turnMoves.length - 1; i >= 0; i--) {
+        if (isBuyFrom(turnMoves[i], source)) {
+            return i;
+        }
+    }
+
+    return -1;
 }

--- a/viewer/tests/unit/turn-buffer.spec.ts
+++ b/viewer/tests/unit/turn-buffer.spec.ts
@@ -1,4 +1,7 @@
 import {
+    bufferedBuyCounts,
+    buySourceKey,
+    lastBuyIndex,
     matchesTurnBuffer,
     moveMatches,
     rebaseTurnBuffer,
@@ -220,6 +223,91 @@ describe('turn-buffer', () => {
                 // WITH a preview, the extra click is never offered, and even if one
                 // races in the replay truncates it rather than sending it on.
                 expect(replayTurnBuffer(G, oneTooMany, seat).applied).to.deep.equal(buffer);
+                return;
+            }
+            G = moveAI(G, seat);
+        }
+        expect.fail('never reached a seat that could buy resources');
+    });
+
+    // #127 — eric-hu's decrement. A purchase made this turn is taken back by dropping
+    // it from the buffer and replaying the rest; there is no Undo move to disagree with.
+    it('bufferedBuyCounts counts cubes per source, keeping the two sides and the pool apart', () => {
+        const buy = (data: unknown, time: number): Move => ({ name: MoveName.BuyResource, data, time } as Move);
+        const buffer: Move[] = [
+            buy({ resource: 'coal' }, 1),
+            buy({ resource: 'coal' }, 2),
+            buy({ resource: 'coal', fromStorage: true }, 3),
+            buy({ resource: 'coal', side: 'north' }, 4),
+            buy({ resource: 'oil' }, 5),
+            { name: MoveName.Build, data: { name: 'somewhere', price: 10 }, time: 6 } as Move,
+        ];
+
+        const counts = bufferedBuyCounts(buffer);
+
+        expect(counts[buySourceKey({ resource: 'coal' })], 'two off the printed track').to.equal(2);
+        expect(
+            counts[buySourceKey({ resource: 'coal', fromStorage: true })],
+            "South Africa's pool is its own source"
+        ).to.equal(1);
+        expect(
+            counts[buySourceKey({ resource: 'coal', side: 'north' })],
+            "Korea's north table is its own source"
+        ).to.equal(1);
+        expect(counts[buySourceKey({ resource: 'oil' })]).to.equal(1);
+        expect(counts[buySourceKey({ resource: 'garbage' })], 'nothing bought, nothing to give back').to.be.undefined;
+    });
+
+    it('lastBuyIndex finds the newest buy from that source, and only that source', () => {
+        const buy = (data: unknown, time: number): Move => ({ name: MoveName.BuyResource, data, time } as Move);
+        const buffer: Move[] = [
+            buy({ resource: 'coal' }, 1),
+            buy({ resource: 'oil' }, 2),
+            buy({ resource: 'coal' }, 3),
+            buy({ resource: 'coal', fromStorage: true }, 4),
+        ];
+
+        // Cubes leave a track cheapest-first, so the LAST buy is the one the market
+        // hands back — not the first one, and not a same-resource buy from elsewhere.
+        expect(lastBuyIndex(buffer, { resource: 'coal' })).to.equal(2);
+        expect(lastBuyIndex(buffer, { resource: 'coal', fromStorage: true })).to.equal(3);
+        expect(lastBuyIndex(buffer, { resource: 'oil' })).to.equal(1);
+        expect(lastBuyIndex(buffer, { resource: 'garbage' }), 'nothing to take back').to.equal(-1);
+    });
+
+    it('dropping a buy from the buffer replays to the state where it was never made', () => {
+        let G: GameState = setup(4, {}, 'turn-buffer-unbuy');
+        for (let i = 0; i < 4000; i++) {
+            const seat = G.players.findIndex((p) => p.availableMoves);
+            if (seat < 0) break;
+            if (G.phase === Phase.Resources && G.players[seat].availableMoves![MoveName.BuyResource]) {
+                const target = G.players[seat].availableMoves![MoveName.BuyResource]![0];
+
+                // Buy three cubes of the same source, previewing as the viewer does.
+                let previewed: GameState = clone(G);
+                const buffer: Move[] = [];
+                for (let n = 0; n < 3; n++) {
+                    const moves = previewed.players[seat].availableMoves;
+                    const fresh = moves ? moves[MoveName.BuyResource] : undefined;
+                    if (!fresh || !fresh.some((m) => JSON.stringify(m) === JSON.stringify(target))) break;
+                    buffer.push({ name: MoveName.BuyResource, data: target, time: 1000 + n } as Move);
+                    previewed = replayTurnBuffer(G, buffer, seat).state;
+                }
+                if (buffer.length < 2) {
+                    G = moveAI(G, seat);
+                    continue;
+                }
+
+                const index = lastBuyIndex(buffer, target);
+                expect(index, 'the newest buy of that source').to.equal(buffer.length - 1);
+
+                const shortened = buffer.filter((_, at) => at !== index);
+                const after = replayTurnBuffer(G, shortened, seat);
+
+                // Nothing is left behind: the whole shortened buffer replays, and the
+                // state is the one where that cube was never bought.
+                expect(after.applied.length, 'the rest of the turn still replays').to.equal(shortened.length);
+                expect(after.state).to.deep.equal(replayTurnBuffer(G, buffer.slice(0, -1), seat).state);
                 return;
             }
             G = moveAI(G, seat);


### PR DESCRIPTION
Closes #127 (proposal 2 — decrement a queued purchase).

Clicking an empty space in the resource market gives back a cube bought **this turn**.

### Why this is a small change now

Since 2.0.0 there is no `Undo` move at all — undo is buffer truncation. So a take-back is not a new concept: it drops that one buy from the turn buffer and replays the rest, exactly as `undo()` drops the last move. Removing a purchase only ever frees money and plant capacity, so the remainder always replays — checked over **653 mid-buffer removals across 109 realistic buffers and 8 maps, 0 that broke the remainder and 0 that left the phase**.

That is also why the "unintuitive with the undo stack" worry in the issue doesn't arise: there is no stack for it to disagree with. The turn buffer *is* the tentative turn, and this edits it before it commits.

### Which spaces light up

Only spaces holding your own purchases, and only the ones your cubes actually left — they are drawn brighter than a plain empty space, because there is no hover cursor to discover them with on a phone.

Cubes leave a track from its cheap end, but the two families of market builder index their slots in **opposite directions**, so a rank read from the wrong end would silently light the far side of the board. Every push site now stamps a `ghostRank` counting outward from the fill line it is measured against. Verified across Germany, Korea, India, Australia, Bremen, South Africa, Middle East and Europe: every empty space ranks 1..n exactly once.

Sources stay separate: Korea's north and south tables, and South Africa's storage pool, each hand back their own cubes.

### Portrait

The box market replaced the printed track's empty spaces, so there is nothing there to click. Those rows get a **"− take back"** button instead, sized for a thumb (~76×28 css px with a larger tap area). It stops the click reaching the buy target underneath, and it appears whether or not the row is still buyable — being unable to afford the next cube is exactly when you want the last one back.

### Two sources cannot hand a cube back through the track

South Africa's storage pool and USA-recharged's supply are drawn by count, so a bought cube leaves no space behind. The portrait button covers both. And on a bare USA track — the condition for the supply being offered at all — the coal spaces no longer offer a take-back that would return the cube to the **pile** rather than to the space you clicked.

### Verification

- 3 new specs in `turn-buffer.spec.ts`: source keys keep the two sides and the pool apart; the newest buy of a source is the one taken back; and dropping a buy replays to *the state where it was never made*.
- In a real browser, through actual DOM clicks: buy → market 21→20, $30→$28; click the space it left → both exactly back; click a space holding nothing → nothing happens; a take-back that empties the turn sends nothing (nothing was ever persisted for it); a take-back on an empty buffer is a no-op.
- Portrait button, by DOM click: buffer 2→1 with the refund, which also proves the click does not fall through to the buy underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
