### PR TITLE
Ask again for the viewport when the board is revealed

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -2024,6 +2024,10 @@ export default class Game extends Vue {
      * the choice would disappear along with the layout.
      */
     portraitViewport = false;
+
+    /** Viewport the board was last laid out against, as `WxH` — see onViewportResize. */
+    private lastViewport = '';
+    private viewportObserver: ResizeObserver | null = null;
     /** Height of the stacked canvas, in scene units. */
     stackHeight = STACK_WIDTH;
     /** Wrapper transform per slot; empty means "render as authored". */
@@ -2062,6 +2066,16 @@ export default class Game extends Vue {
         return window.innerWidth < 900 && window.innerHeight > window.innerWidth * 1.1;
     }
 
+    /**
+     * The platform mounts the viewer in an iframe that is `display: none` until the
+     * game state arrives, so the first measurement here is 0x0 — which is not a
+     * landscape phone, it is nothing at all. Answering then would settle the layout
+     * against a viewport that does not exist yet.
+     */
+    private viewportIsMeasurable(): boolean {
+        return window.innerWidth > 0 && window.innerHeight > 0;
+    }
+
     private shouldStack(): boolean {
         return this.isPortraitViewport() && this.preferences.stackOnPortrait !== false;
     }
@@ -2075,6 +2089,11 @@ export default class Game extends Vue {
     }
 
     relayout() {
+        if (!this.viewportIsMeasurable()) {
+            // Still hidden. Whoever reveals us triggers the observer below.
+            return;
+        }
+
         this.portraitViewport = this.isPortraitViewport();
 
         if (!this.shouldStack()) {
@@ -2189,17 +2208,57 @@ export default class Game extends Vue {
         this.$nextTick(() => this.relayout());
     }
 
-    private onViewportResize = () => this.scheduleRelayout();
+    /**
+     * Re-lay out only when the viewport itself changed size. The observer below also
+     * fires for our OWN output — laying out the board changes the document's box — and
+     * without this that would be a loop.
+     */
+    private onViewportResize = () => {
+        const size = `${window.innerWidth}x${window.innerHeight}`;
+
+        if (size === this.lastViewport) {
+            return;
+        }
+
+        this.lastViewport = size;
+        this.scheduleRelayout();
+    };
 
     mounted() {
         window.addEventListener('resize', this.onViewportResize);
         window.addEventListener('orientationchange', this.onViewportResize);
+        window.addEventListener('load', this.onViewportResize);
+
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', this.onViewportResize);
+        }
+
+        // The one signal that does not depend on the browser dispatching an event:
+        // being revealed changes the document's own box. Safari does not reliably fire
+        // `resize` inside an iframe going from `display: none` to visible, and the
+        // board then stays in the landscape layout with no toggle to escape it — the
+        // measurement was taken at 0x0 and nothing ever asked again.
+        if (typeof ResizeObserver !== 'undefined') {
+            this.viewportObserver = new ResizeObserver(this.onViewportResize);
+            this.viewportObserver.observe(document.documentElement);
+        }
+
         this.scheduleRelayout();
     }
 
     beforeDestroy() {
         window.removeEventListener('resize', this.onViewportResize);
         window.removeEventListener('orientationchange', this.onViewportResize);
+        window.removeEventListener('load', this.onViewportResize);
+
+        if (window.visualViewport) {
+            window.visualViewport.removeEventListener('resize', this.onViewportResize);
+        }
+
+        if (this.viewportObserver) {
+            this.viewportObserver.disconnect();
+            this.viewportObserver = null;
+        }
     }
 
     // Boards grow as players buy plants, so the row heights are re-derived on


### PR DESCRIPTION
On a phone the board could load in the landscape layout with **no toggle to leave it**, and no way back short of a reload — sometimes not even then, when the game was opened from the lobby rather than by loading its URL.

### What is actually happening

The platform mounts the viewer in an iframe that is `display: none` until the game state arrives ([`StartedGame.svelte`](https://github.com/boardgamers/boardgamers-mono/blob/main/apps/web/src/components/Game/StartedGame.svelte): `class:hidden={!stateSent}`). Measured on the live site at 390×844:

```
t=0      #game-iframe absent
t=513ms  exists — display:none, 0x0     <- the viewer boots and measures HERE
t=1486ms visible, 390x788
```

So the first measurement inside the frame is `0x0`, and the portrait test —

```js
window.innerWidth < 900 && window.innerHeight > window.innerWidth * 1.1
```

— evaluates `0 < 900 && 0 > 0` → **false**. That is not "this is a landscape phone", it is "there is nothing here to measure", and the viewer settled the layout against it.

Everything after that depended on the browser dispatching `resize` when the iframe was revealed. Chromium does, which is why a fresh load righted itself after a moment. Safari does not do it reliably, which is why arriving from the lobby stayed landscape — the one measurement had already been taken, and nothing ever asked again.

### The change

- `relayout()` declines to answer while there is nothing to measure.
- A `ResizeObserver` on the document asks again the moment being revealed gives it a box. That is the only signal that doesn't depend on an event being dispatched — being shown *is* a layout change.
- `load` and `visualViewport` resize are also listened to, and resize handling is deduplicated by viewport size, because the observer fires for the board's own output too.

### Verification

Reproduced deterministically by mounting the viewer in a hidden iframe with `resize` and `orientationchange` deaf inside it — standing in for a browser that doesn't dispatch one on reveal:

| | before | after |
|---|---|---|
| mounted, hidden | `0x0`, portrait **false** | `0x0`, portrait **false** |
| revealed +100ms | `390x788`, portrait **false** | `390x788`, portrait **true** |
| revealed +2500ms | `390x788`, portrait **false** | `390x788`, portrait **true** |

With events working normally the behaviour is unchanged. Desktop at 1280×900 still lays out landscape. The observer settles in two relayouts and then goes quiet, with no `ResizeObserver loop` errors.

The last mile is a real iPhone opening a game from the lobby — that's what surfaced it, and Chromium can only stand in for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
