### PR TITLE
Send a move the server offered, even when we cannot preview it

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -727,6 +727,7 @@ import type { GameState, LogItem, Move, Player } from 'powergrid-engine';
 import { EventEmitter } from 'events';
 import {
     bufferedBuyCounts,
+    engineRefusedIt,
     lastBuyIndex,
     matchesTurnBuffer,
     rebaseTurnBuffer,
@@ -980,6 +981,9 @@ export default class Game extends Vue {
     // server-side from the last committed state; undo simply shortens it.
     turnMoves: Move[] = [];
 
+    /** Why the last local replay stopped, if it did — see `engineRefusedIt`. */
+    private lastReplayFailure: unknown;
+
     // Last committed state received from the platform. Undo replays the shortened
     // turn buffer from this state; when the buffer empties, the preview resets to it
     // without any server call (the platform's saved state IS the turn start).
@@ -1039,8 +1043,9 @@ export default class Game extends Vue {
      * engine now rejects — possible after a rebase) and returns the preview.
      */
     replayTurnBuffer(): GameState {
-        const { state, applied } = replayBuffer(this.committedState!, this.turnMoves, this.player!);
+        const { state, applied, failure } = replayBuffer(this.committedState!, this.turnMoves, this.player!);
         this.turnMoves = applied;
+        this.lastReplayFailure = failure;
         return state;
     }
 
@@ -1529,11 +1534,20 @@ export default class Game extends Vue {
             return;
         }
 
+        // What the board offered when this click was judged — the same list the
+        // button that produced it was enabled from.
+        const offeredWhenClicked =
+            this.player != undefined && this.G && this.G.players[this.player]
+                ? this.G.players[this.player].availableMoves
+                : undefined;
+        const theServerOfferedThisMove = !!offeredWhenClicked && !!offeredWhenClicked[move.name];
+
         // Stamp the move ONCE, when it enters the turn buffer, so the engine can
         // advance the per-player clocks. The engine never reads the system clock
         // itself — the stamp travels with the move on every resend of the buffer, so
         // replays (and the eventual committed log) reproduce the same times.
-        this.turnMoves.push({ ...move, time: Date.now() });
+        const stamped = { ...move, time: Date.now() };
+        this.turnMoves.push(stamped);
 
         // Preview the move locally BEFORE sending it. Without this the board — and with
         // it `availableMoves` — stays frozen on the last server reply, so every click
@@ -1542,9 +1556,6 @@ export default class Game extends Vue {
         // replayed buffer with "Wrong argument for the command BuyResource"; the
         // rejected move then stays in the buffer, so every later action resends it and
         // fails again until the page is refreshed (#131).
-        //
-        // Replaying the buffer on the committed state is exact: any move with hidden
-        // side effects commits, which ends the buffer (see util/turn-buffer).
         let preview: GameState | null = null;
 
         if (this.committedState && this.player != undefined) {
@@ -1552,9 +1563,31 @@ export default class Game extends Vue {
             preview = this.replayTurnBuffer();
 
             if (this.turnMoves.length < buffered) {
-                // The engine refused the move we just added, so it never reaches the
-                // server and the board already shows the truth.
-                return;
+                // The replay could not carry the move — which is NOT the same thing as
+                // the move being illegal, and telling them apart is the whole job here.
+                //
+                // The state a player holds is stripped of everything they may not see.
+                // A fastBid auction keeps the other players' sealed bids hidden, so the
+                // response that RESOLVES that auction cannot be replayed on this copy at
+                // all: the engine reaches for a bid that was stripped out and throws.
+                // A human is almost always the last to answer — bots reply instantly —
+                // so treating that as a refusal silently swallowed nearly every Pass in
+                // a fastBid auction, with an enabled button and no way to tell.
+                //
+                // So defer to the only authority on legality that this viewer has: the
+                // `availableMoves` the server sent. If it offered the move, send it and
+                // let the server replay it from the full state; just do not pretend to
+                // preview what could not be previewed.
+                const onlyThisMoveWasDropped = this.turnMoves.length === buffered - 1;
+
+                if (engineRefusedIt(this.lastReplayFailure) || !theServerOfferedThisMove || !onlyThisMoveWasDropped) {
+                    // A genuinely stale click (#131): the engine asserted against it on
+                    // a state it could read in full. The board already shows the truth.
+                    return;
+                }
+
+                this.turnMoves.push(stamped);
+                preview = null;
             }
         }
 

--- a/viewer/src/util/turn-buffer.ts
+++ b/viewer/src/util/turn-buffer.ts
@@ -131,21 +131,43 @@ export function replayTurnBuffer(
     committedState: GameState,
     turnMoves: Move[],
     player: number
-): { state: GameState; applied: Move[] } {
+): { state: GameState; applied: Move[]; failure?: unknown } {
     let state: GameState = JSON.parse(JSON.stringify(committedState));
     const applied: Move[] = [];
+    let failure: unknown;
 
     for (const move of turnMoves) {
         try {
             state = engineMove(state, move, player);
         } catch (err) {
             console.error('dropping turn-buffer tail no longer legal on the committed state', move, err);
+            failure = err;
             break;
         }
         applied.push(move);
     }
 
-    return { state, applied };
+    return { state, applied, failure };
+}
+
+/**
+ * Did the engine REFUSE this move, or could this copy of the state simply not carry it?
+ *
+ * The engine refuses with an assertion. A state stripped of what a player may not see —
+ * a fastBid auction's sealed bids — instead fails while reaching for something that was
+ * stripped out, which says nothing at all about legality.
+ */
+export function engineRefusedIt(failure: unknown): boolean {
+    if (!failure) {
+        return false;
+    }
+
+    // Node stamps `code: 'ERR_ASSERTION'`; the browser build of `assert` does not, and
+    // checking only for the code let every illegal move through in the bundle while
+    // passing every test in Node.
+    const err = failure as { name?: string; code?: string };
+
+    return err.name === 'AssertionError' || err.code === 'ERR_ASSERTION';
 }
 
 /**

--- a/viewer/tests/unit/turn-buffer.spec.ts
+++ b/viewer/tests/unit/turn-buffer.spec.ts
@@ -1,6 +1,7 @@
 import {
     bufferedBuyCounts,
     buySourceKey,
+    engineRefusedIt,
     lastBuyIndex,
     matchesTurnBuffer,
     moveMatches,
@@ -10,7 +11,7 @@ import {
 } from '@/util/turn-buffer';
 import { expect } from 'chai';
 import type { GameState, Move } from 'powergrid-engine';
-import { move as engineMove, moveAI, MoveName, Phase, setup } from 'powergrid-engine';
+import { move as engineMove, moveAI, MoveName, Phase, setup, stripSecret } from 'powergrid-engine';
 
 describe('turn-buffer', () => {
     const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
@@ -313,5 +314,57 @@ describe('turn-buffer', () => {
             G = moveAI(G, seat);
         }
         expect.fail('never reached a seat that could buy resources');
+    });
+
+    // A move can fail to replay for two completely different reasons, and the viewer
+    // sends or swallows it on that difference.
+    it('engineRefusedIt tells a refusal from a state that could not carry the move', () => {
+        // Node stamps a code; the browser build of assert does not. Only the name
+        // survives both, and checking the code alone passed every test here while
+        // letting illegal moves through in the bundle.
+        expect(engineRefusedIt({ name: 'AssertionError', code: 'ERR_ASSERTION' }), 'node').to.be.true;
+        expect(engineRefusedIt({ name: 'AssertionError', operator: '==' }), 'browser').to.be.true;
+        expect(engineRefusedIt(new TypeError("Cannot read properties of undefined (reading 'id')"))).to.be.false;
+        expect(engineRefusedIt(undefined)).to.be.false;
+    });
+
+    it('a fastBid pass that resolves the auction cannot be replayed on the player own copy', () => {
+        // The bug behind it: bots answer instantly, so the human is nearly always the
+        // last to respond, and their Pass is the move that RESOLVES the auction —
+        // which reaches for the other players' sealed bids. Those are stripped out of
+        // the copy that player holds, so the replay throws. Treating that as "the
+        // engine refused it" silently swallowed the move with the button still lit.
+        let G: GameState = setup(4, { map: 'Korea', variant: 'recharged', fastBid: true } as never, '1');
+
+        for (let i = 0; i < 40000; i++) {
+            const seat = G.players.findIndex((p) => p.availableMoves);
+            if (seat < 0) break;
+            const moves = G.players[seat].availableMoves;
+            const chosen = G as unknown as { chosenPowerPlant?: unknown; auctioningPlayer?: number };
+
+            if (
+                G.phase === Phase.Auction &&
+                chosen.chosenPowerPlant &&
+                moves &&
+                moves[MoveName.Pass] &&
+                chosen.auctioningPlayer !== seat &&
+                G.currentPlayers.length === 1
+            ) {
+                const pass: Move = { name: MoveName.Pass, data: true, time: 1000 } as Move;
+
+                // The server holds the whole state, and it is a perfectly legal move.
+                expect(() => engineMove(clone(G), pass, seat), 'legal on the full state').to.not.throw();
+
+                // The player's own copy cannot carry it — and NOT because it is illegal.
+                const mine = stripSecret(clone(G), seat);
+                const { applied, failure } = replayTurnBuffer(mine, [pass], seat);
+
+                expect(applied, 'the replay drops it').to.deep.equal([]);
+                expect(engineRefusedIt(failure), 'but the engine never refused it').to.be.false;
+                return;
+            }
+            G = moveAI(G, seat);
+        }
+        expect.fail('never reached a fastBid auction awaiting one last response');
     });
 });


### PR DESCRIPTION
**Passing in a fastBid auction did nothing.** The button was lit, the click was real, and the move never left the browser. Reported by @goldjohn6 mid-game; bidding worked, passing did not.

### Why

Since 2.0.5 every move is replayed locally before being sent, so a click made against a stale list cannot poison the turn (#131). That replay runs on the state **this player holds** — which is stripped of everything they may not see.

A fastBid auction keeps the other players' sealed bids hidden. The response that **resolves** the auction reaches for one of those bids, finds it stripped out, and throws. `sendMove` read the throw as *"the engine refused this move"* and returned without sending:

```js
preview = this.replayTurnBuffer();
if (this.turnMoves.length < buffered) {
    return;          // ← silently, with the button still enabled
}
```

Bots answer instantly, so a human is nearly always the **last** to respond — which means this swallowed almost every Pass in a fastBid auction since 2.0.5.

Measured over 40 such auctions:

| | full state (server) | player's own copy |
|---|---|---|
| Pass | threw 0 | **threw 40** |
| Bid | threw 0 | threw 0 |

`Cannot read properties of undefined (reading 'id')` — which is why bidding worked and passing didn't.

### The change

A failed replay has two very different causes, and only one of them is a refusal:

- the engine **refuses** with an `AssertionError` — that is #131's stale click, and it still drops
- a copy that **cannot carry** the move fails reaching for what was stripped out — that says nothing about legality, so the move is sent unpreviewed and the server replays it from the full state

A move is also still dropped if the server never offered it in `availableMoves`.

### One trap worth naming

The discriminator checks the error's **name**, not its `code`. Node stamps `code: 'ERR_ASSERTION'`; the browser build of `assert` does not. The first version of this checked only the code — it passed every test in Node **while letting illegal moves through in the bundle**. Caught by re-running eric-hu's over-buy case in a real browser, where the buffer reached 4 with only 3 buys legal.

### Verification

- 21 unit tests pass, 2 new: `engineRefusedIt` separates the two failures in both runtimes, and the fastBid pass is shown to be legal on the full state while unreplayable on the player's own.
- In a real browser, driving a real game to a fastBid auction awaiting one last response: clicking Pass now sends `["Pass"]`.
- #131 re-checked in the same browser: clicking a cube six times when three are legal still buffers and sends exactly three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
