### PR TITLE
Portrait: a switch between the box market and the printed price track

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -142,13 +142,21 @@
                 </template>
             </g>
 
+            <g v-if="stacked" ref="slotResourceView" :transform="slotT('resourceView')">
+                <ResourceViewButton :showTrack="showResourceTrack" @select="setResourceView($event)" />
+            </g>
+
             <g ref="slotResources" :transform="slotT('resources')">
                 <!-- On a phone the printed price track is a strip of unreadable
-                     columns, so the stacked layout swaps it for one box per buyable
-                     source. Landscape and desktop keep the printed board exactly as
-                     it was — this is an either/or, never an overlay. -->
+                     columns, so the stacked layout defaults to one box per buyable
+                     source. It is still only a default: the switch above this row
+                     puts the printed track back, because the boxes deliberately
+                     throw away the price ladder and that ladder is most of what
+                     there is to know about uranium. Landscape and desktop keep the
+                     printed board exactly as it was — an either/or, never an
+                     overlay. -->
                 <ResourceBoxes
-                    v-if="stacked"
+                    v-if="stacked && !showResourceTrack"
                     :transform="`translate(${G.map.supplyPosition[0]}, ${G.map.supplyPosition[1]})`"
                     :gameState="G"
                     :player="player"
@@ -744,6 +752,7 @@ import {
     HelpButton,
     RulesButton,
     LayoutButton,
+    ResourceViewButton,
 } from './buttons';
 import PlayerBoard from './PlayerBoard.vue';
 import Calculator from './Calculator.vue';
@@ -771,6 +780,9 @@ const STACK_ROWS: string[][] = [
     // the draw pile and the round readout are things you glance at.
     ['buttons', 'roundInfo', 'powerPlantDeck'],
     ['powerPlantMarket'],
+    // The resource-display switch sits between the two markets rather than in the
+    // icon column: it belongs to the row it changes, and reads as that row's header.
+    ['resourceView'],
     ['resources'],
     ['uraniumMines'],
     ['freeJump'],
@@ -814,6 +826,9 @@ const STACK_SLOT_MAX_WIDTH: Record<string, number> = {
     // The box market is one tall stack of full-width buttons; run edge to edge it
     // reads as though it had been cropped rather than laid out.
     resources: 0.94,
+    // Matched to `resources` on purpose: equal budgets render equal widths, so the
+    // switch and the market below it line up instead of nearly lining up.
+    resourceView: 0.94,
 };
 
 /**
@@ -883,6 +898,7 @@ const round = (n: number, digits = 2) => Number(n.toFixed(digits));
         HelpButton,
         RulesButton,
         LayoutButton,
+        ResourceViewButton,
         Button,
         Calculator,
         PowerPlantMarket,
@@ -2119,6 +2135,43 @@ export default class Game extends Vue {
         this.emitter.emit('update:preference', { name: 'stackOnPortrait', value: newVal });
         this.preferences.stackOnPortrait = newVal;
         this.relayout();
+    }
+
+    /**
+     * Only ever consulted inside the stacked layout — landscape and desktop draw the
+     * printed board regardless, so this preference cannot reach them.
+     */
+    get showResourceTrack(): boolean {
+        return this.preferences.portraitResourceTrack === true;
+    }
+
+    setResourceView(showTrack: boolean) {
+        if (showTrack === this.showResourceTrack) {
+            return;
+        }
+
+        this.emitter.emit('update:preference', { name: 'portraitResourceTrack', value: showTrack });
+        this.preferences.portraitResourceTrack = showTrack;
+    }
+
+    /**
+     * The two resource displays are different shapes, so switching between them
+     * invalidates the row heights the last layout solved for — the same trap as
+     * entering the stacked layout at all. Measure again once the swap has landed.
+     */
+    @Watch('showResourceTrack')
+    onResourceViewChanged() {
+        this.$nextTick(() => {
+            // The printed track fills itself imperatively and `createPieces` only ever
+            // runs on a state update, so a track switched on mid-turn would draw an
+            // EMPTY market until the next move landed — a display that lies. Fill it
+            // before measuring: the cubes are what give the group its size.
+            if (this.G) {
+                this.resources?.createPieces(this.G);
+            }
+
+            this.scheduleRelayout();
+        });
     }
 
     relayout() {

--- a/viewer/src/components/buttons/ResourceViewButton.vue
+++ b/viewer/src/components/buttons/ResourceViewButton.vue
@@ -1,0 +1,68 @@
+<template>
+    <!--
+        Which resource display the portrait layout shows. A labelled either/or rather
+        than an icon: this changes what the whole row below it *is*, and no picture of
+        "boxes" or "a track" is recognisable before you tap it.
+
+        Authored 620x72 so that, held to the same 0.94 width budget as the box market
+        underneath, the two line up edge to edge and each half clears the 44px tap
+        guideline on a 414px-wide phone.
+    -->
+    <g class="resourceView">
+        <g class="button enabled" @click="$emit('select', false)">
+            <rect
+                x="0"
+                y="0"
+                width="306"
+                height="72"
+                rx="6"
+                :fill="showTrack ? 'gainsboro' : '#333'"
+                stroke="black"
+                stroke-width="3"
+            />
+            <text
+                x="153"
+                y="47"
+                text-anchor="middle"
+                font-weight="700"
+                :fill="showTrack ? 'black' : 'white'"
+                style="font-size: 30px"
+            >
+                Buy boxes
+            </text>
+            <title>One box per buyable source: the price you pay, and the whole box is the tap target</title>
+        </g>
+        <g class="button enabled" @click="$emit('select', true)">
+            <rect
+                x="314"
+                y="0"
+                width="306"
+                height="72"
+                rx="6"
+                :fill="showTrack ? '#333' : 'gainsboro'"
+                stroke="black"
+                stroke-width="3"
+            />
+            <text
+                x="467"
+                y="47"
+                text-anchor="middle"
+                font-weight="700"
+                :fill="showTrack ? 'white' : 'black'"
+                style="font-size: 30px"
+            >
+                Price track
+            </text>
+            <title>The printed market board, so the whole price track is visible at once</title>
+        </g>
+    </g>
+</template>
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class ResourceViewButton extends Vue {
+    @Prop()
+    showTrack?: boolean;
+}
+</script>

--- a/viewer/src/components/buttons/index.js
+++ b/viewer/src/components/buttons/index.js
@@ -4,7 +4,18 @@ import LayoutButton from './LayoutButton.vue';
 import LogButton from './LogButton.vue';
 import PassButton from './PassButton.vue';
 import SoundButton from './SoundButton.vue';
+import ResourceViewButton from './ResourceViewButton.vue';
 import RulesButton from './RulesButton.vue';
 import UndoButton from './UndoButton.vue';
 
-export { Button, HelpButton, LayoutButton, LogButton, PassButton, SoundButton, RulesButton, UndoButton };
+export {
+    Button,
+    HelpButton,
+    LayoutButton,
+    LogButton,
+    PassButton,
+    ResourceViewButton,
+    SoundButton,
+    RulesButton,
+    UndoButton,
+};

--- a/viewer/src/launch.ts
+++ b/viewer/src/launch.ts
@@ -26,6 +26,7 @@ function launch(selector: string) {
             undoWholeTurn: true,
             fitToScreen: true,
             stackOnPortrait: true,
+            portraitResourceTrack: false,
         }),
         avatars: [],
     };

--- a/viewer/src/types/ui-data.ts
+++ b/viewer/src/types/ui-data.ts
@@ -13,6 +13,11 @@ export type Preferences = {
     // Portrait phones stack the board into full-width rows. Per player, not per
     // game: it describes the screen you are holding, not the rules being played.
     stackOnPortrait: boolean;
+    // Within the stacked layout, show the printed price track instead of the box
+    // market. The boxes are the buying surface; the track is the reading surface --
+    // it is the only place the whole price ladder is visible at once, which matters
+    // most for uranium, where the cubes are few and the prices far apart.
+    portraitResourceTrack: boolean;
 };
 
 export interface Piece {


### PR DESCRIPTION
Asked for by @coyotte508:

> Hmm I liked the previous resource display on mobile better […] Being able to visualize the whole track esp for resources like nuclear fuel
> (or a way to swipe to see the track)

He is right, and the reason is specific. The box market (#134) is the **buying** surface — one box per buyable source, the price *this* player pays, and the whole box a tap target. What it deliberately throws away is the **price ladder**: how far the next cube is, where the fuel actually sits. On maps where a resource is scarce and its prices are far apart, that ladder is most of what there is to know. India's Step 1 / Step 2 lines exist only on the printed track.

So the boxes stay the default and stop being the only option.

### The switch

A two-way switch in its own row **between the plant market and the resource row** — it belongs to the row it changes, and reads as that row's header. Held to the same `0.94` width budget as the market below it, so the two share an edge instead of nearly sharing one.

Measured at 414×896 (iPhone XR): **188 × 44 css px per half**, on the 44px tap guideline.

Taps in the track view keep working exactly as they do on desktop. A click has never carried a price — the engine always takes the cheapest available — so any cube of a resource is the same move. A viewer that ignored a legal move would be the #131 class of bug.

### A bug this surfaced

The printed track fills itself imperatively, and `createPieces()` only ever ran on a **state update**. A track switched on mid-turn therefore drew an **empty market** until the next move landed — and on Korea it was worse, because `isKorea` is set *inside* `createPieces`, so the entire North Market went missing too. It is now filled on the switch, before measuring: the cubes are what give the group its size.

### Landscape and desktop are untouched

The switch renders only inside the stacked layout, and the preference cannot reach any other layout.

Verified rather than asserted. The first pixel A/B said Korea and Northern Europe were identical and India differed by 3620 px — so I ran the control, master against master:

|                 | control (same code) | test (master vs branch) |
|-----------------|--------------------:|------------------------:|
| Korea           |             2865 px |                    0 px |
| India           |                0 px |                 3620 px |
| Northern Europe |             2578 px |                    0 px |

The noise was larger than the effect, in the same screen region: `moveAI` runs on raw `Math.random` and the sandbox bots move on timers, so every capture catches a different game state. That check could not have detected a real regression.

Re-run with the dice pinned (seeded PRNG injected before document load) and waiting on a scene fingerprint instead of a duration, the noise floor drops to **0 px on all three maps** — and against that floor:

**Landscape 1280×800: 0 differing pixels on Korea, India and Northern Europe.**

The scene DOM differs by exactly 7 characters, which is the `<!---->` placeholder Vue leaves where a false `v-if` was.

### Also checked

- **Round trips**: boxes → track → boxes → track → boxes → track on **Korea, India, Northern Europe, Australia and South Africa**. Both displays populated every time, and the solved scene height is identical on every repeat — the layout settles rather than drifting. The second track mount is a fresh component, which is the exact path that drew an empty market before the fix.
- Australia's horizontal uranium mine market and South Africa's coal-storage pool both render correctly alongside the track.
- `vue-cli-service test:unit` 21/21, type-check clean.
- Played end to end on Korea, India and Northern Europe.

### One pre-existing thing this makes visible

On Korea's South Market and on Northern Europe, the printed board draws **four resource rows in a space laid out for three** and the cubes physically overlap — uranium sits wedged inside the oil band. That is not new, but the toggle puts it in front of phone users. The fix underneath it is a clean four-row tier at pitch 17.5, which fits the existing printed box with no enlargement, and would improve landscape too. Happy to open that separately.

No version bump in this PR.
