### PR TITLE
Read the player order without rewriting it (#141)

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -766,6 +766,7 @@ import { LogMove } from 'powergrid-engine/src/log';
 import { Phase, playerTimeUsed, PowerPlant, PowerPlantType, ResourceType } from 'powergrid-engine/src/gamestate';
 import { City } from 'powergrid-engine/src/maps';
 import { formatDuration } from '../util/time';
+import { playerOrderForDisplay } from '../util/player-order';
 
 // Portrait layout: the rows the scene is broken into, top to bottom. Slots on
 // the same row sit side by side and share one scale. Names map to the `slotX`
@@ -2355,19 +2356,7 @@ export default class Game extends Vue {
     }
 
     get adjustedPlayerOrder() {
-        if (!this.G) {
-            return [];
-        }
-
-        if (!this.preferences.adjustPlayerOrder) {
-            return this.G.players.map((_p, i) => i); // 0 1 2 3 ...
-        }
-
-        if (this.G.phase == Phase.Auction) {
-            return this.G.playerOrder;
-        }
-
-        return this.G.playerOrder.reverse();
+        return playerOrderForDisplay(this.G, this.preferences.adjustPlayerOrder);
     }
 
     getResourceResupply() {

--- a/viewer/src/util/player-order.ts
+++ b/viewer/src/util/player-order.ts
@@ -1,0 +1,44 @@
+// `Phase` comes from the package root (the built `dist`), never from
+// `powergrid-engine/src/gamestate`: webpack 4 parses the engine SOURCE for the
+// unit-test bundle and dies on its `??`. Game.vue can import the source because the
+// app build does not; a file with a spec beside it cannot.
+import type { GameState } from 'powergrid-engine';
+import { Phase } from 'powergrid-engine';
+
+/**
+ * The order the player boards are stacked in (`Game.vue`'s `adjustedPlayerOrder`).
+ *
+ * Two different orders sit on this board and they are easy to confuse -- the issue
+ * that produced this file (#141) was exactly that confusion:
+ *
+ *  - TABLE order: where a player sits. Fixed for the whole game. This is what the
+ *    boards show when the preference is off, and it is why bidding "out of turn
+ *    order" is usually not a bug at all.
+ *  - TURN order (`G.playerOrder`): recomputed every round from cities and largest
+ *    plant. The auction runs down it; resources and building run back UP it.
+ *
+ * Kept out of the component so it can be tested against a real engine state, the
+ * same way `util/resource-rows.ts` is -- and because the component version could not
+ * be tested at all, which is how it stayed wrong.
+ *
+ * Written without optional chaining: webpack 4 parses the unit-test bundle and
+ * rejects `?.` (same note as `util/turn-buffer.ts`).
+ */
+export function playerOrderForDisplay(G: GameState | null | undefined, adjustPlayerOrder: boolean): number[] {
+    if (!G) {
+        return [];
+    }
+
+    if (!adjustPlayerOrder) {
+        return G.players.map((_p, i) => i); // 0 1 2 3 ...
+    }
+
+    // Copy before reversing. `Array.reverse` works in place, so reading the order off
+    // the state used to rewrite it -- see `player-order.spec.ts`. The engine already
+    // spreads before it reverses, in both places it walks the order backwards.
+    if (G.phase == Phase.Auction) {
+        return [...G.playerOrder];
+    }
+
+    return [...G.playerOrder].reverse();
+}

--- a/viewer/tests/unit/player-order.spec.ts
+++ b/viewer/tests/unit/player-order.spec.ts
@@ -1,0 +1,97 @@
+import { playerOrderForDisplay } from '@/util/player-order';
+import { expect } from 'chai';
+import type { GameState } from 'powergrid-engine';
+import { moveAI, Phase, setup } from 'powergrid-engine';
+
+/**
+ * #141. coyotte508 reported that toggling "adjust player order" on and off lands on
+ * inconsistent states. The cause is that the viewer read the order by REVERSING the
+ * game state's array in place, so every read edited the thing it was reading.
+ *
+ * These tests are about that property, not about the arrow of the order: reading a
+ * value must be repeatable, and must leave the board alone.
+ */
+describe('player-order', () => {
+    const realRandom = Math.random;
+    const pinDice = (dice: number) => {
+        let s = dice >>> 0;
+        Math.random = () => {
+            s = (s * 1664525 + 1013904223) >>> 0;
+            return s / 4294967296;
+        };
+    };
+    afterEach(() => {
+        Math.random = realRandom;
+    });
+
+    /** A real mid-game state, in `phase`, whose playerOrder is genuinely permuted. */
+    function stateIn(phase: Phase, dice = 1): GameState {
+        pinDice(dice);
+        let G: GameState = setup(4, { map: 'Germany', variant: 'recharged' } as never, '5');
+        for (let i = 0; i < 40000; i++) {
+            // Round 2+ so the order has been re-derived from cities at least once.
+            if (G.round >= 3 && G.phase === phase) return G;
+            const idx = G.players.findIndex((p) => p.availableMoves);
+            if (idx < 0) break;
+            G = moveAI(G, idx);
+        }
+        throw new Error(`never reached ${phase}`);
+    }
+
+    it('reading the order does not edit the game state', () => {
+        const G = stateIn(Phase.Resources);
+        const before = [...G.playerOrder];
+
+        playerOrderForDisplay(G, true);
+
+        // PlayerOrder.vue draws the goldenrod 1-6 track straight off G.playerOrder, in
+        // a $nextTick that runs AFTER this getter has been evaluated for the render.
+        // A getter that mutates therefore prints the track backwards on the board.
+        expect(G.playerOrder, 'the display read rewrote the turn order').to.deep.equal(before);
+    });
+
+    it('reading the order twice gives the same answer', () => {
+        const G = stateIn(Phase.Resources);
+
+        // Copy the first read. A getter that returns the state's own array hands back
+        // the SAME object twice, so comparing the two references compares a value to
+        // itself and passes no matter how wrong it is -- this test did exactly that
+        // until the copy was added.
+        const first = [...playerOrderForDisplay(G, true)];
+        const second = playerOrderForDisplay(G, true);
+
+        expect(second, 'two reads of one unchanged state disagreed').to.deep.equal(first);
+    });
+
+    it('survives the toggle coyotte508 screenshotted: on, off, on', () => {
+        const G = stateIn(Phase.Resources);
+
+        const on = [...playerOrderForDisplay(G, true)];
+        playerOrderForDisplay(G, false);
+        const onAgain = playerOrderForDisplay(G, true);
+
+        expect(onAgain, 'the setting means something different on its second activation').to.deep.equal(on);
+    });
+
+    it('stacks the boards in the order each phase actually plays', () => {
+        const auction = stateIn(Phase.Auction);
+        expect(playerOrderForDisplay(auction, true), 'the auction runs down the turn order').to.deep.equal(
+            auction.playerOrder
+        );
+
+        const resources = stateIn(Phase.Resources);
+        expect(playerOrderForDisplay(resources, true), 'resources run back up it').to.deep.equal(
+            [...resources.playerOrder].reverse()
+        );
+
+        const building = stateIn(Phase.Building);
+        expect(playerOrderForDisplay(building, true), 'so does building').to.deep.equal(
+            [...building.playerOrder].reverse()
+        );
+    });
+
+    it('with the preference off, the boards keep table order', () => {
+        const G = stateIn(Phase.Resources);
+        expect(playerOrderForDisplay(G, false)).to.deep.equal([0, 1, 2, 3]);
+    });
+});


### PR DESCRIPTION
Closes the second half of #141 — the first half was a misreading of table order vs turn order, but the toggle really is broken.

## What happens

`adjustedPlayerOrder` ended in `this.G.playerOrder.reverse()`. `Array.reverse` works **in place**, so the getter whose only job was to read the turn order rewrote the game state on every evaluation, and handed back the state's own array rather than a value of its own.

Two symptoms come out of that one line:

**The toggle @coyotte508 screenshotted.** The getter re-runs when the preference changes, and each run flips the same array again. Turning the setting off returns seat order without unflipping anything, so turning it back on reverses an already-reversed order back to the original. The setting means something different on every second activation — correct, wrong, correct, wrong.

**The order track on the board.** `PlayerOrder.createPieces` lays out the goldenrod 1-6 track straight off `G.playerOrder`, in a `$nextTick` that runs *after* the render which evaluates this getter. So while the preference was on and the phase was not Auction, the track printed backwards on every state update. That one hadn't been reported yet.

The engine already spreads before it reverses, in both places it walks the order backwards (`engine.ts` in Building and Bureaucracy). Only the viewer mutated.

## The change

Copy before reversing.

The logic moves to `util/player-order.ts` so it can be tested against real engine states, the same way `util/resource-rows.ts` is. That is the actual reason this survived so long: sitting inside the component, it was unreachable from a test.

`player-order.spec.ts` covers the property rather than the arrow of the order — reading is repeatable, reading leaves the board alone, and the on/off/on sequence from the issue lands where it started — plus one test that the auction still runs down the order while resources and building run back up it. Four of the five fail against the old logic.

A note on that spec, since it is a nice trap: the "two reads agree" test was itself bent at first. A getter that returns the state's own array hands back the **same object** twice, so comparing the two references compares a value to itself and passes no matter how wrong the code is. It only became a real test once the first read was copied.

## Verification

- New spec: 4 of 5 red against the old logic, 5/5 green after.
- Full viewer suite: 26/26.
- `vue-cli-service build` clean.
- Ran the viewer with the preference forced on — renders correctly, no recursion from the getter and the imported helper sharing a name.

Viewer-only, no engine change.

## Left out on purpose

The getter reverses in *every* non-Auction phase, but ColorSelection and RegionSelection both advance **forward** through `playerOrder` in the engine. Cosmetic, pre-existing, and a behaviour change rather than a bug fix — happy to do it as its own issue rather than smuggle it in here.
