### PR TITLE
fix(engine): replay scrubber broken on Russia/China after Step-3 boundary

### DIFF
--- a/engine/src/engine.spec.ts
+++ b/engine/src/engine.spec.ts
@@ -15,7 +15,9 @@ import {
     reconstructState,
     setup,
 } from './engine';
+import ChinaStep3 from './fixtures/ChinaStep3.json';
 import GermanyRecharged from './fixtures/GermanyRecharged.json';
+import RussiaStep3 from './fixtures/RussiaStep3.json';
 import supply from './fixtures/supply.json';
 import USAOriginal from './fixtures/USAOriginal.json';
 import {
@@ -166,6 +168,67 @@ describe('Engine', () => {
         const G = reconstructState(game as any, game.log.length - 1);
 
         expect(ended(G)).to.be.false;
+    });
+
+    // Regression tests for the secret-seed replay prologue (scrubber path). The
+    // prologue re-seeds the deck from knownPowerPlantDeck; it used to assume a
+    // standard 4+4 market and to alias knownPowerPlantDeckStep3, which broke
+    // replays on Russia (3+3 market) / China (numPlayers+0) after the Step-3
+    // boundary ("Wrong argument for the command ChoosePowerPlant" — game
+    // 3-game). Fixtures are deterministic moveAI games that reach Step 3.
+    describe('replay from stripped state (secret seed)', () => {
+        const stripAndMoveIndices = (game: any) => {
+            const stripped = { ...game, seed: 'secret', powerPlantsDeck: [], hiddenLog: [] };
+            const moveIndices = game.log
+                .map((item: any, index: number) => ({ item, index }))
+                .filter(({ item }: any) => item.type === 'move')
+                .map(({ index }: any) => index);
+            return { stripped, moveIndices };
+        };
+
+        it('should replay every prefix of a Russia game (3+3 market, Step-3 deck swap)', () => {
+            const { stripped, moveIndices } = stripAndMoveIndices(RussiaStep3);
+
+            expect(RussiaStep3.step).to.equal(3);
+            expect(RussiaStep3.knownPowerPlantDeckStep3).to.not.be.empty;
+            // Sanity: this fixture only bites the old bug if the setup market is 3+3.
+            // The final market is empty (game end) — check via a fresh setup, which
+            // the replay prologue also derives its split sizes from.
+            const russiaSetup = setup(3, RussiaStep3.options as GameOptions, 'replay-prologue-check');
+            expect(russiaSetup.actualMarket).to.have.lengthOf(3);
+            expect(russiaSetup.futureMarket).to.have.lengthOf(3);
+
+            for (const index of moveIndices) {
+                // throws on the old 4+4 split or the consumed step-3 deck
+                reconstructState(stripped as any, index + 1);
+            }
+        });
+
+        it('should replay every prefix of a China game (numPlayers+0 market)', () => {
+            const { stripped, moveIndices } = stripAndMoveIndices(ChinaStep3);
+
+            const chinaSetup = setup(3, ChinaStep3.options as GameOptions, 'replay-prologue-check');
+            expect(chinaSetup.actualMarket).to.have.lengthOf(3);
+            expect(chinaSetup.futureMarket).to.have.lengthOf(0);
+
+            for (const index of moveIndices) {
+                reconstructState(stripped as any, index + 1);
+            }
+        });
+
+        it('should not consume knownPowerPlantDeckStep3 across successive replays', () => {
+            const { stripped } = stripAndMoveIndices(RussiaStep3);
+            const step3Before = RussiaStep3.knownPowerPlantDeckStep3.map((p: PowerPlant) => p.number);
+
+            // Replay past the Step-3 boundary twice (scrubber steps past it, then
+            // back and forward again). addPowerPlant() swaps powerPlantsDeck to
+            // powerPlantDeckAfterStep3 and shift()s draws off it — without the
+            // cloneDeep, the second replay would re-draw already-consumed plants.
+            reconstructState(stripped as any, RussiaStep3.log.length);
+            reconstructState(stripped as any, RussiaStep3.log.length);
+
+            expect(stripped.knownPowerPlantDeckStep3.map((p: PowerPlant) => p.number)).to.deep.equal(step3Before);
+        });
     });
 
     it('should setup Korea with dual-market populated and players ready to move', () => {

--- a/engine/src/engine.ts
+++ b/engine/src/engine.ts
@@ -1964,10 +1964,22 @@ export function reconstructState(gameState: GameState, to?: number): GameState {
         if (gameState.knownPowerPlantDeck) {
             G.map = gameState.map;
             G.powerPlantsDeck = cloneDeep(gameState.knownPowerPlantDeck);
-            G.actualMarket = G.powerPlantsDeck.splice(0, 4);
-            G.futureMarket = G.powerPlantsDeck.splice(0, 4);
+            // Split sizes must match the map's setup, not the standard 4+4: Russia
+            // deals a 3+3 market, China numPlayers+0, etc. The base state was built
+            // by the same setupDeck, so its market sizes are authoritative even
+            // though the (seeded) contents are not. knownPowerPlantDeck is
+            // actual-then-future at game start with the draws appended, so the
+            // first actualN+futureN entries seed the market and the rest the deck.
+            const actualN = initialState.actualMarket.length;
+            const futureN = initialState.futureMarket.length;
+            G.actualMarket = G.powerPlantsDeck.splice(0, actualN);
+            G.futureMarket = G.powerPlantsDeck.splice(0, futureN);
             G.players[G.currentPlayers[0]].availableMoves = availableMoves(G, G.players[G.currentPlayers[0]]);
-            G.powerPlantDeckAfterStep3 = gameState.knownPowerPlantDeckStep3;
+            // cloneDeep: addPowerPlant() replaces powerPlantsDeck with this array and
+            // shift()s draws off it — sharing the caller's array would consume
+            // knownPowerPlantDeckStep3 across successive replays (each replayTo
+            // must see the full deck).
+            G.powerPlantDeckAfterStep3 = cloneDeep(gameState.knownPowerPlantDeckStep3);
             G.knownPowerPlantDeck = G.actualMarket.concat(G.futureMarket);
         }
     }

--- a/engine/src/fixtures/ChinaStep3.json
+++ b/engine/src/fixtures/ChinaStep3.json
@@ -1,6964 +1,6395 @@
 {
-  "map": {
-    "name": "China",
-    "cities": [
-      {
-        "name": "Hegang",
-        "region": "pink",
-        "x": 1372,
-        "y": 101.5
-      },
-      {
-        "name": "Qiqha'er",
-        "region": "pink",
-        "x": 1197.6999999999998,
-        "y": 91.69999999999999
-      },
-      {
-        "name": "Haerbin",
-        "region": "pink",
-        "x": 1285.1999999999998,
-        "y": 151.89999999999998
-      },
-      {
-        "name": "Jilin",
-        "region": "pink",
-        "x": 1310.3999999999999,
-        "y": 214.89999999999998
-      },
-      {
-        "name": "Fushun",
-        "region": "pink",
-        "x": 1299.1999999999998,
-        "y": 274.4
-      },
-      {
-        "name": "Anshan",
-        "region": "pink",
-        "x": 1228.5,
-        "y": 315.7
-      },
-      {
-        "name": "Dalian",
-        "region": "pink",
-        "x": 1198.3999999999999,
-        "y": 368.2
-      },
-      {
-        "name": "Shanghai",
-        "region": "green",
-        "x": 1211.6999999999998,
-        "y": 585.1999999999999
-      },
-      {
-        "name": "Hangzhou",
-        "region": "green",
-        "x": 1148,
-        "y": 638.4
-      },
-      {
-        "name": "Nanjing",
-        "region": "green",
-        "x": 1095.5,
-        "y": 571.1999999999999
-      },
-      {
-        "name": "Qingdao",
-        "region": "green",
-        "x": 1162.6999999999998,
-        "y": 460.59999999999997
-      },
-      {
-        "name": "Jinan",
-        "region": "green",
-        "x": 1050.7,
-        "y": 452.2
-      },
-      {
-        "name": "Zhengzhou",
-        "region": "green",
-        "x": 972.3,
-        "y": 503.29999999999995
-      },
-      {
-        "name": "Shijiazhuang",
-        "region": "green",
-        "x": 1003.0999999999999,
-        "y": 403.2
-      },
-      {
-        "name": "Changchun",
-        "region": "red",
-        "x": 1226.3999999999999,
-        "y": 206.5
-      },
-      {
-        "name": "Shenyang",
-        "region": "red",
-        "x": 1210.3,
-        "y": 272.29999999999995
-      },
-      {
-        "name": "Tangshan",
-        "region": "red",
-        "x": 1105.3,
-        "y": 317.79999999999995
-      },
-      {
-        "name": "Tianjin",
-        "region": "red",
-        "x": 1096.8999999999999,
-        "y": 355.59999999999997
-      },
-      {
-        "name": "Beijing",
-        "region": "red",
-        "x": 1010.0999999999999,
-        "y": 318.5
-      },
-      {
-        "name": "Taiyuan",
-        "region": "red",
-        "x": 905.8,
-        "y": 395.5
-      },
-      {
-        "name": "Baotou",
-        "region": "red",
-        "x": 875,
-        "y": 301.7
-      }
-    ],
-    "connections": [
-      {
-        "nodes": [
-          "Hangzhou",
-          "Shanghai"
+    "map": {
+        "name": "China",
+        "cities": [
+            {
+                "name": "Hegang",
+                "region": "pink",
+                "x": 1372,
+                "y": 101.5
+            },
+            {
+                "name": "Qiqha'er",
+                "region": "pink",
+                "x": 1197.6999999999998,
+                "y": 91.69999999999999
+            },
+            {
+                "name": "Haerbin",
+                "region": "pink",
+                "x": 1285.1999999999998,
+                "y": 151.89999999999998
+            },
+            {
+                "name": "Jilin",
+                "region": "pink",
+                "x": 1310.3999999999999,
+                "y": 214.89999999999998
+            },
+            {
+                "name": "Fushun",
+                "region": "pink",
+                "x": 1299.1999999999998,
+                "y": 274.4
+            },
+            {
+                "name": "Anshan",
+                "region": "pink",
+                "x": 1228.5,
+                "y": 315.7
+            },
+            {
+                "name": "Dalian",
+                "region": "pink",
+                "x": 1198.3999999999999,
+                "y": 368.2
+            },
+            {
+                "name": "Shanghai",
+                "region": "green",
+                "x": 1211.6999999999998,
+                "y": 585.1999999999999
+            },
+            {
+                "name": "Hangzhou",
+                "region": "green",
+                "x": 1148,
+                "y": 638.4
+            },
+            {
+                "name": "Nanjing",
+                "region": "green",
+                "x": 1095.5,
+                "y": 571.1999999999999
+            },
+            {
+                "name": "Qingdao",
+                "region": "green",
+                "x": 1162.6999999999998,
+                "y": 460.59999999999997
+            },
+            {
+                "name": "Jinan",
+                "region": "green",
+                "x": 1050.7,
+                "y": 452.2
+            },
+            {
+                "name": "Zhengzhou",
+                "region": "green",
+                "x": 972.3,
+                "y": 503.29999999999995
+            },
+            {
+                "name": "Shijiazhuang",
+                "region": "green",
+                "x": 1003.0999999999999,
+                "y": 403.2
+            },
+            {
+                "name": "Changchun",
+                "region": "red",
+                "x": 1226.3999999999999,
+                "y": 206.5
+            },
+            {
+                "name": "Shenyang",
+                "region": "red",
+                "x": 1210.3,
+                "y": 272.29999999999995
+            },
+            {
+                "name": "Tangshan",
+                "region": "red",
+                "x": 1105.3,
+                "y": 317.79999999999995
+            },
+            {
+                "name": "Tianjin",
+                "region": "red",
+                "x": 1096.8999999999999,
+                "y": 355.59999999999997
+            },
+            {
+                "name": "Beijing",
+                "region": "red",
+                "x": 1010.0999999999999,
+                "y": 318.5
+            },
+            {
+                "name": "Taiyuan",
+                "region": "red",
+                "x": 905.8,
+                "y": 395.5
+            },
+            {
+                "name": "Baotou",
+                "region": "red",
+                "x": 875,
+                "y": 301.7
+            }
         ],
-        "cost": 4
-      },
-      {
-        "nodes": [
-          "Shanghai",
-          "Nanjing"
+        "connections": [
+            {
+                "nodes": ["Hangzhou", "Shanghai"],
+                "cost": 4
+            },
+            {
+                "nodes": ["Shanghai", "Nanjing"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Nanjing", "Hangzhou"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Taiyuan", "Zhengzhou"],
+                "cost": 11
+            },
+            {
+                "nodes": ["Taiyuan", "Shijiazhuang"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Shijiazhuang", "Tianjin"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Shijiazhuang", "Jinan"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Shijiazhuang", "Zhengzhou"],
+                "cost": 9
+            },
+            {
+                "nodes": ["Zhengzhou", "Jinan"],
+                "cost": 7
+            },
+            {
+                "nodes": ["Zhengzhou", "Nanjing"],
+                "cost": 12
+            },
+            {
+                "nodes": ["Jinan", "Nanjing"],
+                "cost": 11
+            },
+            {
+                "nodes": ["Nanjing", "Qingdao"],
+                "cost": 12
+            },
+            {
+                "nodes": ["Qingdao", "Jinan"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Jinan", "Tianjin"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Baotou", "Taiyuan"],
+                "cost": 9
+            },
+            {
+                "nodes": ["Taiyuan", "Beijing"],
+                "cost": 10
+            },
+            {
+                "nodes": ["Beijing", "Shijiazhuang"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Beijing", "Tangshan"],
+                "cost": 3
+            },
+            {
+                "nodes": ["Tangshan", "Tianjin"],
+                "cost": 0
+            },
+            {
+                "nodes": ["Beijing", "Baotou"],
+                "cost": 14
+            },
+            {
+                "nodes": ["Tangshan", "Shenyang"],
+                "cost": 11
+            },
+            {
+                "nodes": ["Dalian", "Anshan"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Qiqha'er", "Hegang"],
+                "cost": 11
+            },
+            {
+                "nodes": ["Hegang", "Haerbin"],
+                "cost": 7
+            },
+            {
+                "nodes": ["Haerbin", "Qiqha'er"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Changchun", "Jilin"],
+                "cost": 2
+            },
+            {
+                "nodes": ["Jilin", "Haerbin"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Haerbin", "Changchun"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Changchun", "Shenyang"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Shenyang", "Anshan"],
+                "cost": 2
+            },
+            {
+                "nodes": ["Jilin", "Fushun"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Fushun", "Shenyang"],
+                "cost": 0
+            },
+            {
+                "nodes": ["Changchun", "Qiqha'er"],
+                "cost": 9
+            }
         ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Nanjing",
-          "Hangzhou"
+        "layout": "Portrait",
+        "mapPosition": [-400, 70],
+        "adjustRatio": [0.35, 0.35],
+        "resupply": [
+            [
+                [4, 4, 3],
+                [5, 5, 3],
+                [6, 6, 4],
+                [7, 7, 5],
+                [9, 9, 6]
+            ],
+            [
+                [2, 2, 4],
+                [3, 3, 4],
+                [4, 4, 5],
+                [5, 5, 6],
+                [6, 6, 7]
+            ],
+            [
+                [2, 2, 1],
+                [2, 2, 1],
+                [3, 3, 2],
+                [3, 3, 3],
+                [5, 5, 3]
+            ],
+            [
+                [1, 1, 1],
+                [1, 1, 1],
+                [2, 2, 2],
+                [3, 3, 2],
+                [3, 3, 3]
+            ]
         ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Taiyuan",
-          "Zhengzhou"
-        ],
-        "cost": 11
-      },
-      {
-        "nodes": [
-          "Taiyuan",
-          "Shijiazhuang"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Shijiazhuang",
-          "Tianjin"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Shijiazhuang",
-          "Jinan"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Shijiazhuang",
-          "Zhengzhou"
-        ],
-        "cost": 9
-      },
-      {
-        "nodes": [
-          "Zhengzhou",
-          "Jinan"
-        ],
-        "cost": 7
-      },
-      {
-        "nodes": [
-          "Zhengzhou",
-          "Nanjing"
-        ],
-        "cost": 12
-      },
-      {
-        "nodes": [
-          "Jinan",
-          "Nanjing"
-        ],
-        "cost": 11
-      },
-      {
-        "nodes": [
-          "Nanjing",
-          "Qingdao"
-        ],
-        "cost": 12
-      },
-      {
-        "nodes": [
-          "Qingdao",
-          "Jinan"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Jinan",
-          "Tianjin"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Baotou",
-          "Taiyuan"
-        ],
-        "cost": 9
-      },
-      {
-        "nodes": [
-          "Taiyuan",
-          "Beijing"
-        ],
-        "cost": 10
-      },
-      {
-        "nodes": [
-          "Beijing",
-          "Shijiazhuang"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Beijing",
-          "Tangshan"
-        ],
-        "cost": 3
-      },
-      {
-        "nodes": [
-          "Tangshan",
-          "Tianjin"
-        ],
-        "cost": 0
-      },
-      {
-        "nodes": [
-          "Beijing",
-          "Baotou"
-        ],
-        "cost": 14
-      },
-      {
-        "nodes": [
-          "Tangshan",
-          "Shenyang"
-        ],
-        "cost": 11
-      },
-      {
-        "nodes": [
-          "Dalian",
-          "Anshan"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Qiqha'er",
-          "Hegang"
-        ],
-        "cost": 11
-      },
-      {
-        "nodes": [
-          "Hegang",
-          "Haerbin"
-        ],
-        "cost": 7
-      },
-      {
-        "nodes": [
-          "Haerbin",
-          "Qiqha'er"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Changchun",
-          "Jilin"
-        ],
-        "cost": 2
-      },
-      {
-        "nodes": [
-          "Jilin",
-          "Haerbin"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Haerbin",
-          "Changchun"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Changchun",
-          "Shenyang"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Shenyang",
-          "Anshan"
-        ],
-        "cost": 2
-      },
-      {
-        "nodes": [
-          "Jilin",
-          "Fushun"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Fushun",
-          "Shenyang"
-        ],
-        "cost": 0
-      },
-      {
-        "nodes": [
-          "Changchun",
-          "Qiqha'er"
-        ],
-        "cost": 9
-      }
-    ],
-    "layout": "Portrait",
-    "mapPosition": [
-      -400,
-      70
-    ],
-    "adjustRatio": [
-      0.35,
-      0.35
-    ],
-    "resupply": [
-      [
-        [
-          4,
-          4,
-          3
-        ],
-        [
-          5,
-          5,
-          3
-        ],
-        [
-          6,
-          6,
-          4
-        ],
-        [
-          7,
-          7,
-          5
-        ],
-        [
-          9,
-          9,
-          6
-        ]
-      ],
-      [
-        [
-          2,
-          2,
-          4
-        ],
-        [
-          3,
-          3,
-          4
-        ],
-        [
-          4,
-          4,
-          5
-        ],
-        [
-          5,
-          5,
-          6
-        ],
-        [
-          6,
-          6,
-          7
-        ]
-      ],
-      [
-        [
-          2,
-          2,
-          1
-        ],
-        [
-          2,
-          2,
-          1
-        ],
-        [
-          3,
-          3,
-          2
-        ],
-        [
-          3,
-          3,
-          3
-        ],
-        [
-          5,
-          5,
-          3
-        ]
-      ],
-      [
-        [
-          1,
-          1,
-          1
-        ],
-        [
-          1,
-          1,
-          1
-        ],
-        [
-          2,
-          2,
-          2
-        ],
-        [
-          3,
-          3,
-          2
-        ],
-        [
-          3,
-          3,
-          3
-        ]
-      ]
-    ],
-    "startingResources": [
-      12,
-      12,
-      6,
-      0
-    ],
-    "mapSpecificRules": "There are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.\n",
-    "deckBuild": "the same plants are removed every game: with 2-3 players 3, 4, 9, 11, 16, 18, 20, 24, 30, 33, 46; with 4 players 3, 4, 11, 18, 24, 33, 46; with 5-6 players 3, 4, 33. The deck is ordered, not shuffled: plants 5-30 in ascending order on top, then plants 31-35 shuffled together with the Step 3 card, then plants 36-50 shuffled on the bottom. The starting market has one plant per player and the future market starts empty.",
-    "viewBox": [
-      1480,
-      1060
-    ],
-    "playerOrderPosition": [
-      1160,
-      160
-    ],
-    "cityCountPosition": [
-      0,
-      0
-    ],
-    "powerPlantMarketPosition": [
-      745,
-      0
-    ],
-    "actualMarketWidth": 430,
-    "buttonsPosition": [
-      1305,
-      0
-    ],
-    "playerBoardsPosition": [
-      1105,
-      240
-    ],
-    "roundInfoPosition": [
-      20,
-      920
-    ],
-    "supplyPosition": [
-      675,
-      920
-    ]
-  },
-  "players": [
-    {
-      "id": 0,
-      "powerPlants": [
+        "startingResources": [12, 12, 6, 0],
+        "mapSpecificRules": "There are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.\n",
+        "deckBuild": "the same plants are removed every game: with 2-3 players 3, 4, 9, 11, 16, 18, 20, 24, 30, 33, 46; with 4 players 3, 4, 11, 18, 24, 33, 46; with 5-6 players 3, 4, 33. The deck is ordered, not shuffled: plants 5-30 in ascending order on top, then plants 31-35 shuffled together with the Step 3 card, then plants 36-50 shuffled on the bottom. The starting market has one plant per player and the future market starts empty.",
+        "viewBox": [1480, 1060],
+        "playerOrderPosition": [1160, 160],
+        "cityCountPosition": [0, 0],
+        "powerPlantMarketPosition": [745, 0],
+        "actualMarketWidth": 430,
+        "buttonsPosition": [1305, 0],
+        "playerBoardsPosition": [1105, 240],
+        "roundInfoPosition": [20, 920],
+        "supplyPosition": [675, 920]
+    },
+    "players": [
         {
-          "number": 23,
-          "type": 3,
-          "cost": 1,
-          "citiesPowered": 3
+            "id": 0,
+            "powerPlants": [
+                {
+                    "number": 23,
+                    "type": 3,
+                    "cost": 1,
+                    "citiesPowered": 3
+                },
+                {
+                    "number": 26,
+                    "type": 1,
+                    "cost": 2,
+                    "citiesPowered": 5
+                },
+                {
+                    "number": 27,
+                    "type": 5,
+                    "cost": 0,
+                    "citiesPowered": 3
+                }
+            ],
+            "coalCapacity": 0,
+            "coalLeft": 0,
+            "oilCapacity": 4,
+            "oilLeft": 2,
+            "garbageCapacity": 0,
+            "garbageLeft": 0,
+            "uraniumCapacity": 2,
+            "uraniumLeft": 1,
+            "hybridCapacity": 0,
+            "hybridLeft": 0,
+            "money": 1,
+            "housesLeft": 22,
+            "cities": [
+                {
+                    "name": "Qingdao",
+                    "position": 0
+                },
+                {
+                    "name": "Jinan",
+                    "position": 0
+                },
+                {
+                    "name": "Tangshan",
+                    "position": 0
+                },
+                {
+                    "name": "Tianjin",
+                    "position": 0
+                },
+                {
+                    "name": "Beijing",
+                    "position": 0
+                },
+                {
+                    "name": "Zhengzhou",
+                    "position": 0
+                },
+                {
+                    "name": "Shijiazhuang",
+                    "position": 1
+                },
+                {
+                    "name": "Taiyuan",
+                    "position": 1
+                },
+                {
+                    "name": "Nanjing",
+                    "position": 0
+                },
+                {
+                    "name": "Hangzhou",
+                    "position": 0
+                },
+                {
+                    "name": "Shanghai",
+                    "position": 0
+                },
+                {
+                    "name": "Hegang",
+                    "position": 1
+                }
+            ],
+            "powerPlantsNotUsed": [],
+            "availableMoves": null,
+            "lastMove": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "isDropped": false,
+            "isAI": false,
+            "bid": 0,
+            "passed": true,
+            "skipAuction": false,
+            "citiesPowered": 11,
+            "resourcesUsed": [],
+            "totalIncome": 469,
+            "totalSpentCities": 135,
+            "totalSpentConnections": 80,
+            "totalSpentPlants": 132,
+            "totalSpentResources": 171,
+            "usedFreeJump": false,
+            "totalTimeUsed": 2
         },
         {
-          "number": 26,
-          "type": 1,
-          "cost": 2,
-          "citiesPowered": 5
+            "id": 1,
+            "powerPlants": [
+                {
+                    "number": 19,
+                    "type": 2,
+                    "cost": 2,
+                    "citiesPowered": 3
+                },
+                {
+                    "number": 22,
+                    "type": 5,
+                    "cost": 0,
+                    "citiesPowered": 2
+                },
+                {
+                    "number": 25,
+                    "type": 0,
+                    "cost": 2,
+                    "citiesPowered": 5
+                }
+            ],
+            "coalCapacity": 4,
+            "coalLeft": 2,
+            "oilCapacity": 0,
+            "oilLeft": 0,
+            "garbageCapacity": 4,
+            "garbageLeft": 2,
+            "uraniumCapacity": 0,
+            "uraniumLeft": 0,
+            "hybridCapacity": 0,
+            "hybridLeft": 0,
+            "money": 25,
+            "housesLeft": 22,
+            "cities": [
+                {
+                    "name": "Qiqha'er",
+                    "position": 0
+                },
+                {
+                    "name": "Haerbin",
+                    "position": 0
+                },
+                {
+                    "name": "Hegang",
+                    "position": 0
+                },
+                {
+                    "name": "Jilin",
+                    "position": 1
+                },
+                {
+                    "name": "Changchun",
+                    "position": 1
+                },
+                {
+                    "name": "Shenyang",
+                    "position": 1
+                },
+                {
+                    "name": "Fushun",
+                    "position": 1
+                },
+                {
+                    "name": "Anshan",
+                    "position": 1
+                },
+                {
+                    "name": "Dalian",
+                    "position": 1
+                },
+                {
+                    "name": "Beijing",
+                    "position": 1
+                },
+                {
+                    "name": "Baotou",
+                    "position": 1
+                }
+            ],
+            "powerPlantsNotUsed": [],
+            "availableMoves": null,
+            "lastMove": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "isDropped": false,
+            "isAI": false,
+            "bid": 0,
+            "passed": true,
+            "skipAuction": false,
+            "citiesPowered": 10,
+            "resourcesUsed": [],
+            "totalIncome": 453,
+            "totalSpentCities": 150,
+            "totalSpentConnections": 61,
+            "totalSpentPlants": 119,
+            "totalSpentResources": 148,
+            "usedFreeJump": false,
+            "totalTimeUsed": 0
         },
         {
-          "number": 27,
-          "type": 5,
-          "cost": 0,
-          "citiesPowered": 3
+            "id": 2,
+            "powerPlants": [
+                {
+                    "number": 12,
+                    "type": 4,
+                    "cost": 2,
+                    "citiesPowered": 2
+                },
+                {
+                    "number": 10,
+                    "type": 0,
+                    "cost": 2,
+                    "citiesPowered": 2
+                },
+                {
+                    "number": 21,
+                    "type": 4,
+                    "cost": 2,
+                    "citiesPowered": 4
+                }
+            ],
+            "coalCapacity": 4,
+            "coalLeft": 3,
+            "oilCapacity": 0,
+            "oilLeft": 4,
+            "garbageCapacity": 0,
+            "garbageLeft": 0,
+            "uraniumCapacity": 0,
+            "uraniumLeft": 0,
+            "hybridCapacity": 8,
+            "hybridLeft": 0,
+            "money": 6,
+            "housesLeft": 22,
+            "cities": [
+                {
+                    "name": "Jilin",
+                    "position": 0
+                },
+                {
+                    "name": "Changchun",
+                    "position": 0
+                },
+                {
+                    "name": "Shenyang",
+                    "position": 0
+                },
+                {
+                    "name": "Fushun",
+                    "position": 0
+                },
+                {
+                    "name": "Anshan",
+                    "position": 0
+                },
+                {
+                    "name": "Dalian",
+                    "position": 0
+                },
+                {
+                    "name": "Shijiazhuang",
+                    "position": 0
+                },
+                {
+                    "name": "Taiyuan",
+                    "position": 0
+                },
+                {
+                    "name": "Baotou",
+                    "position": 0
+                },
+                {
+                    "name": "Tianjin",
+                    "position": 1
+                },
+                {
+                    "name": "Tangshan",
+                    "position": 1
+                },
+                {
+                    "name": "Haerbin",
+                    "position": 1
+                },
+                {
+                    "name": "Jinan",
+                    "position": 1
+                },
+                {
+                    "name": "Qiqha'er",
+                    "position": 1
+                },
+                {
+                    "name": "Qingdao",
+                    "position": 1
+                },
+                {
+                    "name": "Zhengzhou",
+                    "position": 1
+                },
+                {
+                    "name": "Nanjing",
+                    "position": 1
+                }
+            ],
+            "powerPlantsNotUsed": [],
+            "availableMoves": null,
+            "lastMove": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504472
+            },
+            "isDropped": false,
+            "isAI": false,
+            "bid": 0,
+            "passed": true,
+            "skipAuction": false,
+            "citiesPowered": 8,
+            "resourcesUsed": [],
+            "totalIncome": 644,
+            "totalSpentCities": 210,
+            "totalSpentConnections": 91,
+            "totalSpentPlants": 52,
+            "totalSpentResources": 335,
+            "usedFreeJump": false,
+            "totalTimeUsed": 6
         }
-      ],
-      "coalCapacity": 0,
-      "coalLeft": 0,
-      "oilCapacity": 4,
-      "oilLeft": 2,
-      "garbageCapacity": 0,
-      "garbageLeft": 0,
-      "uraniumCapacity": 2,
-      "uraniumLeft": 1,
-      "hybridCapacity": 0,
-      "hybridLeft": 0,
-      "money": 1,
-      "housesLeft": 22,
-      "cities": [
+    ],
+    "playerOrder": [2, 0, 1],
+    "currentPlayers": [],
+    "powerPlantsDeck": [
         {
-          "name": "Qingdao",
-          "position": 0
+            "number": 28,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 4
         },
         {
-          "name": "Jinan",
-          "position": 0
+            "number": 29,
+            "type": 4,
+            "cost": 1,
+            "citiesPowered": 4
         },
         {
-          "name": "Tangshan",
-          "position": 0
+            "number": 35,
+            "type": 1,
+            "cost": 1,
+            "citiesPowered": 5
         },
         {
-          "name": "Tianjin",
-          "position": 0
+            "number": 31,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 6
         },
         {
-          "name": "Beijing",
-          "position": 0
+            "number": 99,
+            "type": 7,
+            "cost": 0,
+            "citiesPowered": 6
         },
         {
-          "name": "Zhengzhou",
-          "position": 0
+            "number": 32,
+            "type": 1,
+            "cost": 3,
+            "citiesPowered": 6
         },
         {
-          "name": "Shijiazhuang",
-          "position": 1
+            "number": 34,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 5
         },
         {
-          "name": "Taiyuan",
-          "position": 1
+            "number": 38,
+            "type": 2,
+            "cost": 3,
+            "citiesPowered": 7
         },
         {
-          "name": "Nanjing",
-          "position": 0
+            "number": 50,
+            "type": 6,
+            "cost": 0,
+            "citiesPowered": 6
         },
         {
-          "name": "Hangzhou",
-          "position": 0
+            "number": 36,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 7
         },
         {
-          "name": "Shanghai",
-          "position": 0
+            "number": 40,
+            "type": 1,
+            "cost": 2,
+            "citiesPowered": 6
         },
         {
-          "name": "Hegang",
-          "position": 1
+            "number": 37,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 4
+        },
+        {
+            "number": 42,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 6
+        },
+        {
+            "number": 44,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 5
+        },
+        {
+            "number": 39,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 6
         }
-      ],
-      "powerPlantsNotUsed": [],
-      "availableMoves": null,
-      "lastMove": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "isDropped": false,
-      "isAI": false,
-      "bid": 0,
-      "passed": true,
-      "skipAuction": false,
-      "citiesPowered": 11,
-      "resourcesUsed": [],
-      "totalIncome": 469,
-      "totalSpentCities": 135,
-      "totalSpentConnections": 80,
-      "totalSpentPlants": 132,
-      "totalSpentResources": 171,
-      "usedFreeJump": false,
-      "totalTimeUsed": 2
+    ],
+    "coalSupply": 19,
+    "oilSupply": 4,
+    "garbageSupply": 18,
+    "uraniumSupply": 8,
+    "coalResupply": [
+        [4, 4, 3],
+        [5, 5, 3],
+        [6, 6, 4],
+        [7, 7, 5],
+        [9, 9, 6]
+    ],
+    "oilResupply": [
+        [2, 2, 4],
+        [3, 3, 4],
+        [4, 4, 5],
+        [5, 5, 6],
+        [6, 6, 7]
+    ],
+    "garbageResupply": [
+        [2, 2, 1],
+        [2, 2, 1],
+        [3, 3, 2],
+        [3, 3, 3],
+        [5, 5, 3]
+    ],
+    "uraniumResupply": [
+        [1, 1, 1],
+        [1, 1, 1],
+        [2, 2, 2],
+        [3, 3, 2],
+        [3, 3, 3]
+    ],
+    "coalMarket": 0,
+    "oilMarket": 14,
+    "garbageMarket": 4,
+    "uraniumMarket": 3,
+    "coalPrices": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    "oilPrices": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    "garbagePrices": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    "uraniumPrices": [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16],
+    "actualMarket": [],
+    "futureMarket": [],
+    "highestBidders": [],
+    "auctioningPlayer": 2,
+    "step": 2,
+    "phase": "Game End",
+    "options": {
+        "fastBid": false,
+        "map": "China",
+        "variant": "original",
+        "showMoney": false,
+        "useNewRechargedSetup": true,
+        "trackTotalSpent": true,
+        "chooseRegions": false,
+        "chooseColors": false
     },
-    {
-      "id": 1,
-      "powerPlants": [
+    "log": [
         {
-          "number": 19,
-          "type": 2,
-          "cost": 2,
-          "citiesPowered": 3
+            "type": "event",
+            "event": "Game Start!"
         },
         {
-          "number": 22,
-          "type": 5,
-          "cost": 0,
-          "citiesPowered": 2
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 6,
+                "time": 1788175504464
+            },
+            "simple": "undefined chooses Power Plant 6 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>6</b> to initiate an auction."
         },
         {
-          "number": 25,
-          "type": 0,
-          "cost": 2,
-          "citiesPowered": 5
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 6,
+                "time": 1788175504464
+            },
+            "simple": "undefined bids $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 7,
+                "time": 1788175504464
+            },
+            "simple": "undefined bids $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504464
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 8,
+                "time": 1788175504464
+            },
+            "simple": "undefined bids $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504464
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 5,
+                "time": 1788175504464
+            },
+            "simple": "undefined chooses Power Plant 5 to initiate an auction.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>5</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 5,
+                "time": 1788175504464
+            },
+            "simple": "undefined bids $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504464
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 7,
+                "time": 1788175504464
+            },
+            "simple": "undefined chooses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>7</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504464
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504464
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504464
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Qiqha'er",
+                    "price": 10
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined builds on Qiqha'er for $10.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qiqha'er</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Qingdao",
+                    "price": 10
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined builds on Qingdao for $10.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qingdao</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Jilin",
+                    "price": 10
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined builds on Jilin for $10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jilin</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Changchun",
+                    "price": 12
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined builds on Changchun for $12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Changchun</b> for <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 8 drawn from the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 10 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 7,
+                    "resourcesSpent": ["oil", "oil", "oil"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined uses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 8,
+                "time": 1788175504465
+            },
+            "simple": "undefined chooses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>8</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Haerbin",
+                    "price": 16
+                },
+                "time": 1788175504465
+            },
+            "simple": "undefined builds on Haerbin for $16.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Haerbin</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504465
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Jinan",
+                    "price": 16
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined builds on Jinan for $16.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jinan</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 12 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 7,
+                    "resourcesSpent": ["oil", "oil", "oil"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 12,
+                "time": 1788175504466
+            },
+            "simple": "undefined chooses Power Plant 12 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>12</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 12,
+                "time": 1788175504466
+            },
+            "simple": "undefined bids $12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tangshan",
+                    "price": 16
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined builds on Tangshan for $16.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tangshan</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Shenyang",
+                    "price": 15
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined builds on Shenyang for $15.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shenyang</b> for <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Hegang",
+                    "price": 17
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined builds on Hegang for $17.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hegang</b> for <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 13 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 7,
+                    "resourcesSpent": ["oil", "oil", "oil"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 10,
+                "time": 1788175504466
+            },
+            "simple": "undefined chooses Power Plant 10 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>10</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 10,
+                "time": 1788175504466
+            },
+            "simple": "undefined bids $10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $2.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504466
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tianjin",
+                    "price": 10
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined builds on Tianjin for $10.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tianjin</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Beijing",
+                    "price": 13
+                },
+                "time": 1788175504466
+            },
+            "simple": "undefined builds on Beijing for $13.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Beijing</b> for <span style=\"color: green\">$13</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Fushun",
+                    "price": 10
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined builds on Fushun for $10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Fushun</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 14 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 14,
+                "time": 1788175504467
+            },
+            "simple": "undefined chooses Power Plant 14 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>14</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 14,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$14</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 15,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 16,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $16.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 17,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $17.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 18,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $18.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 18.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 13,
+                "time": 1788175504467
+            },
+            "simple": "undefined chooses Power Plant 13 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>13</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 13,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$13</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 14,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $14.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$14</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 15,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $15.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 16,
+                "time": 1788175504467
+            },
+            "simple": "undefined bids $16.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 16.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504467
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504467
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Anshan",
+                    "price": 12
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined builds on Anshan for $12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Anshan</b> for <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 15 drawn from the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 17 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 7,
+                    "resourcesSpent": ["oil", "oil", "oil"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 15,
+                "time": 1788175504468
+            },
+            "simple": "undefined chooses Power Plant 15 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>15</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 15,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $15.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 16,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $16.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 16.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 5,
+                "time": 1788175504468
+            },
+            "simple": "undefined discards Power Plant 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Dalian",
+                    "price": 16
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined builds on Dalian for $16.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Dalian</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 19 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 14,
+                    "resourcesSpent": ["garbage", "garbage"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 7,
+                    "resourcesSpent": ["oil", "oil", "oil"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 8,
+                    "resourcesSpent": ["coal", "coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined uses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 19,
+                "time": 1788175504468
+            },
+            "simple": "undefined chooses Power Plant 19 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>19</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 19,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $19.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$19</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 20,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $20.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 21,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $21.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 22,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $22.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 23,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $23.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 24,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $24.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$24</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 25,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $25.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 25.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 8,
+                "time": 1788175504468
+            },
+            "simple": "undefined discards Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 17,
+                "time": 1788175504468
+            },
+            "simple": "undefined chooses Power Plant 17 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>17</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 17,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $17.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 18,
+                "time": 1788175504468
+            },
+            "simple": "undefined bids $18.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 18.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys uranium for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined buys oil for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504468
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Shijiazhuang",
+                    "price": 26
+                },
+                "time": 1788175504468
+            },
+            "simple": "undefined builds on Shijiazhuang for $26.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shijiazhuang</b> for <span style=\"color: green\">$26</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Taiyuan",
+                    "price": 15
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Taiyuan for $15.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Taiyuan</b> for <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Starting Step 2, Power Plant undefined discarded."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 21 drawn from the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 22 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 7,
+                    "resourcesSpent": ["oil", "oil", "oil"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 14,
+                    "resourcesSpent": ["garbage", "garbage"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 17,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 17.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 15,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 21,
+                "time": 1788175504469
+            },
+            "simple": "undefined chooses Power Plant 21 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>21</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 21,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 22,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $22.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 23,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $23.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 23.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$23</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 7,
+                "time": 1788175504469
+            },
+            "simple": "undefined discards Power Plant 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>7</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 22,
+                "time": 1788175504469
+            },
+            "simple": "undefined chooses Power Plant 22 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>22</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 22,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $22.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 23,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $23.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 23.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$23</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 13,
+                "time": 1788175504469
+            },
+            "simple": "undefined discards Power Plant 13.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys garbage for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys uranium for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys oil for $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Jilin",
+                    "price": 20
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Jilin for $20.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jilin</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Changchun",
+                    "price": 17
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Changchun for $17.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Changchun</b> for <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Zhengzhou",
+                    "price": 17
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Zhengzhou for $17.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Zhengzhou</b> for <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Shijiazhuang",
+                    "price": 20
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Shijiazhuang for $20.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shijiazhuang</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 23 drawn from the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 25 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 21,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 6,
+                    "resourcesSpent": ["garbage"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 14,
+                    "resourcesSpent": ["garbage", "garbage"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 17,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 17.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 22,
+                    "resourcesSpent": [],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 22.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 15,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined uses Power Plant 15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 23,
+                "time": 1788175504469
+            },
+            "simple": "undefined chooses Power Plant 23 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>23</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 23,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $23.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 24,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $24.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$24</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 25,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $25.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 26,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $26.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$26</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 27,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $27.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$27</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 28,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $28.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$28</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 29,
+                "time": 1788175504469
+            },
+            "simple": "undefined bids $29.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$29</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 29.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$29</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 6,
+                "time": 1788175504469
+            },
+            "simple": "undefined discards Power Plant 6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>6</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys uranium for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys uranium for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Shenyang",
+                    "price": 20
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Shenyang for $20.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shenyang</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Fushun",
+                    "price": 15
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Fushun for $15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Fushun</b> for <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Anshan",
+                    "price": 17
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Anshan for $17.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Anshan</b> for <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504469
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Baotou",
+                    "price": 19
+                },
+                "time": 1788175504469
+            },
+            "simple": "undefined builds on Baotou for $19.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Baotou</b> for <span style=\"color: green\">$19</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tianjin",
+                    "price": 20
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Tianjin for $20.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tianjin</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tangshan",
+                    "price": 15
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Tangshan for $15.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tangshan</b> for <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 26 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 21,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 14,
+                    "resourcesSpent": ["garbage", "garbage"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 17,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 17.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 23,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 23.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>23</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 22,
+                    "resourcesSpent": [],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 22.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 15,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 19,
+                    "resourcesSpent": ["garbage", "garbage"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 19.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>19</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 26,
+                "time": 1788175504470
+            },
+            "simple": "undefined chooses Power Plant 26.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>26</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 26.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$26</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 14,
+                "time": 1788175504470
+            },
+            "simple": "undefined discards Power Plant 14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>14</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys oil for $4.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys oil for $4.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys uranium for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys uranium for $10.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Taiyuan",
+                    "price": 20
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Taiyuan for $20.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Taiyuan</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Nanjing",
+                    "price": 21
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Nanjing for $21.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Nanjing</b> for <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Hangzhou",
+                    "price": 15
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Hangzhou for $15.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hangzhou</b> for <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Dalian",
+                    "price": 21
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Dalian for $21.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Dalian</b> for <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Beijing",
+                    "price": 29
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Beijing for $29.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Beijing</b> for <span style=\"color: green\">$29</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Haerbin",
+                    "price": 20
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Haerbin for $20.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Haerbin</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Jinan",
+                    "price": 21
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Jinan for $21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jinan</b> for <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Qiqha'er",
+                    "price": 21
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined builds on Qiqha'er for $21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qiqha'er</b> for <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 27 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 12,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 12.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 10,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 21,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 22,
+                    "resourcesSpent": [],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 22.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 15,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 19,
+                    "resourcesSpent": ["garbage", "garbage"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 19.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>19</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 17,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 17.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 23,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 3
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 23.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>23</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 26,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 5
+                },
+                "time": 1788175504470
+            },
+            "simple": "undefined uses Power Plant 26.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>26</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504470
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [5, 3, 2, 1]."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 27,
+                "time": 1788175504471
+            },
+            "simple": "undefined chooses Power Plant 27 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>27</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 27,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $27.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$27</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 28,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $28.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$28</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 29,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $29.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$29</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 30,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $30.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$30</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 31,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $31.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$31</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 32,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $32.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$32</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 33,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $33.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$33</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 33.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$33</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 17,
+                "time": 1788175504471
+            },
+            "simple": "undefined discards Power Plant 17.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>17</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 25,
+                "time": 1788175504471
+            },
+            "simple": "undefined chooses Power Plant 25 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>25</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 25,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $25.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 26,
+                "time": 1788175504471
+            },
+            "simple": "undefined bids $26.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$26</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 26.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$26</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 15,
+                "time": 1788175504471
+            },
+            "simple": "undefined discards Power Plant 15.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>15</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "garbage"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys garbage for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys oil for $3.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys oil for $4.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys uranium for $10.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Baotou",
+                    "price": 29
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined builds on Baotou for $29.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Baotou</b> for <span style=\"color: green\">$29</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Shanghai",
+                    "price": 14
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined builds on Shanghai for $14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shanghai</b> for <span style=\"color: green\">$14</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Hegang",
+                    "price": 43
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined builds on Hegang for $43.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hegang</b> for <span style=\"color: green\">$43</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504471
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Qingdao",
+                    "price": 21
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined builds on Qingdao for $21.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qingdao</b> for <span style=\"color: green\">$21</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Zhengzhou",
+                    "price": 22
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined builds on Zhengzhou for $22.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Zhengzhou</b> for <span style=\"color: green\">$22</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Nanjing",
+                    "price": 26
+                },
+                "time": 1788175504471
+            },
+            "simple": "undefined builds on Nanjing for $26.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Nanjing</b> for <span style=\"color: green\">$26</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504472
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Game Ended!"
         }
-      ],
-      "coalCapacity": 4,
-      "coalLeft": 2,
-      "oilCapacity": 0,
-      "oilLeft": 0,
-      "garbageCapacity": 4,
-      "garbageLeft": 2,
-      "uraniumCapacity": 0,
-      "uraniumLeft": 0,
-      "hybridCapacity": 0,
-      "hybridLeft": 0,
-      "money": 25,
-      "housesLeft": 22,
-      "cities": [
-        {
-          "name": "Qiqha'er",
-          "position": 0
-        },
-        {
-          "name": "Haerbin",
-          "position": 0
-        },
-        {
-          "name": "Hegang",
-          "position": 0
-        },
-        {
-          "name": "Jilin",
-          "position": 1
-        },
-        {
-          "name": "Changchun",
-          "position": 1
-        },
-        {
-          "name": "Shenyang",
-          "position": 1
-        },
-        {
-          "name": "Fushun",
-          "position": 1
-        },
-        {
-          "name": "Anshan",
-          "position": 1
-        },
-        {
-          "name": "Dalian",
-          "position": 1
-        },
-        {
-          "name": "Beijing",
-          "position": 1
-        },
-        {
-          "name": "Baotou",
-          "position": 1
-        }
-      ],
-      "powerPlantsNotUsed": [],
-      "availableMoves": null,
-      "lastMove": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "isDropped": false,
-      "isAI": false,
-      "bid": 0,
-      "passed": true,
-      "skipAuction": false,
-      "citiesPowered": 10,
-      "resourcesUsed": [],
-      "totalIncome": 453,
-      "totalSpentCities": 150,
-      "totalSpentConnections": 61,
-      "totalSpentPlants": 119,
-      "totalSpentResources": 148,
-      "usedFreeJump": false,
-      "totalTimeUsed": 0
-    },
-    {
-      "id": 2,
-      "powerPlants": [
-        {
-          "number": 12,
-          "type": 4,
-          "cost": 2,
-          "citiesPowered": 2
-        },
-        {
-          "number": 10,
-          "type": 0,
-          "cost": 2,
-          "citiesPowered": 2
-        },
-        {
-          "number": 21,
-          "type": 4,
-          "cost": 2,
-          "citiesPowered": 4
-        }
-      ],
-      "coalCapacity": 4,
-      "coalLeft": 3,
-      "oilCapacity": 0,
-      "oilLeft": 4,
-      "garbageCapacity": 0,
-      "garbageLeft": 0,
-      "uraniumCapacity": 0,
-      "uraniumLeft": 0,
-      "hybridCapacity": 8,
-      "hybridLeft": 0,
-      "money": 6,
-      "housesLeft": 22,
-      "cities": [
-        {
-          "name": "Jilin",
-          "position": 0
-        },
-        {
-          "name": "Changchun",
-          "position": 0
-        },
-        {
-          "name": "Shenyang",
-          "position": 0
-        },
-        {
-          "name": "Fushun",
-          "position": 0
-        },
-        {
-          "name": "Anshan",
-          "position": 0
-        },
-        {
-          "name": "Dalian",
-          "position": 0
-        },
-        {
-          "name": "Shijiazhuang",
-          "position": 0
-        },
-        {
-          "name": "Taiyuan",
-          "position": 0
-        },
-        {
-          "name": "Baotou",
-          "position": 0
-        },
-        {
-          "name": "Tianjin",
-          "position": 1
-        },
-        {
-          "name": "Tangshan",
-          "position": 1
-        },
-        {
-          "name": "Haerbin",
-          "position": 1
-        },
-        {
-          "name": "Jinan",
-          "position": 1
-        },
-        {
-          "name": "Qiqha'er",
-          "position": 1
-        },
-        {
-          "name": "Qingdao",
-          "position": 1
-        },
-        {
-          "name": "Zhengzhou",
-          "position": 1
-        },
-        {
-          "name": "Nanjing",
-          "position": 1
-        }
-      ],
-      "powerPlantsNotUsed": [],
-      "availableMoves": null,
-      "lastMove": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504472
-      },
-      "isDropped": false,
-      "isAI": false,
-      "bid": 0,
-      "passed": true,
-      "skipAuction": false,
-      "citiesPowered": 8,
-      "resourcesUsed": [],
-      "totalIncome": 644,
-      "totalSpentCities": 210,
-      "totalSpentConnections": 91,
-      "totalSpentPlants": 52,
-      "totalSpentResources": 335,
-      "usedFreeJump": false,
-      "totalTimeUsed": 6
-    }
-  ],
-  "playerOrder": [
-    2,
-    0,
-    1
-  ],
-  "currentPlayers": [],
-  "powerPlantsDeck": [
-    {
-      "number": 28,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 4
-    },
-    {
-      "number": 29,
-      "type": 4,
-      "cost": 1,
-      "citiesPowered": 4
-    },
-    {
-      "number": 35,
-      "type": 1,
-      "cost": 1,
-      "citiesPowered": 5
-    },
-    {
-      "number": 31,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 6
-    },
-    {
-      "number": 99,
-      "type": 7,
-      "cost": 0,
-      "citiesPowered": 6
-    },
-    {
-      "number": 32,
-      "type": 1,
-      "cost": 3,
-      "citiesPowered": 6
-    },
-    {
-      "number": 34,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 5
-    },
-    {
-      "number": 38,
-      "type": 2,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 50,
-      "type": 6,
-      "cost": 0,
-      "citiesPowered": 6
-    },
-    {
-      "number": 36,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 40,
-      "type": 1,
-      "cost": 2,
-      "citiesPowered": 6
-    },
-    {
-      "number": 37,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 4
-    },
-    {
-      "number": 42,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 6
-    },
-    {
-      "number": 44,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 5
-    },
-    {
-      "number": 39,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 6
-    }
-  ],
-  "coalSupply": 19,
-  "oilSupply": 4,
-  "garbageSupply": 18,
-  "uraniumSupply": 8,
-  "coalResupply": [
-    [
-      4,
-      4,
-      3
     ],
-    [
-      5,
-      5,
-      3
+    "hiddenLog": [],
+    "seed": "replay-china-fixture",
+    "round": 11,
+    "newTurn": true,
+    "auctionSkips": 1,
+    "citiesToStep2": 7,
+    "citiesToEndGame": 17,
+    "resourceResupply": ["[5, 3, 2, 1]", "[5, 3, 2, 1]", "[3, 4, 1, 1]"],
+    "paymentTable": [
+        10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150
     ],
-    [
-      6,
-      6,
-      4
-    ],
-    [
-      7,
-      7,
-      5
-    ],
-    [
-      9,
-      9,
-      6
-    ]
-  ],
-  "oilResupply": [
-    [
-      2,
-      2,
-      4
-    ],
-    [
-      3,
-      3,
-      4
-    ],
-    [
-      4,
-      4,
-      5
-    ],
-    [
-      5,
-      5,
-      6
-    ],
-    [
-      6,
-      6,
-      7
-    ]
-  ],
-  "garbageResupply": [
-    [
-      2,
-      2,
-      1
-    ],
-    [
-      2,
-      2,
-      1
-    ],
-    [
-      3,
-      3,
-      2
-    ],
-    [
-      3,
-      3,
-      3
-    ],
-    [
-      5,
-      5,
-      3
-    ]
-  ],
-  "uraniumResupply": [
-    [
-      1,
-      1,
-      1
-    ],
-    [
-      1,
-      1,
-      1
-    ],
-    [
-      2,
-      2,
-      2
-    ],
-    [
-      3,
-      3,
-      2
-    ],
-    [
-      3,
-      3,
-      3
-    ]
-  ],
-  "coalMarket": 0,
-  "oilMarket": 14,
-  "garbageMarket": 4,
-  "uraniumMarket": 3,
-  "coalPrices": [
-    1,
-    1,
-    1,
-    2,
-    2,
-    2,
-    3,
-    3,
-    3,
-    4,
-    4,
-    4,
-    5,
-    5,
-    5,
-    6,
-    6,
-    6,
-    7,
-    7,
-    7,
-    8,
-    8,
-    8
-  ],
-  "oilPrices": [
-    1,
-    1,
-    1,
-    2,
-    2,
-    2,
-    3,
-    3,
-    3,
-    4,
-    4,
-    4,
-    5,
-    5,
-    5,
-    6,
-    6,
-    6,
-    7,
-    7,
-    7,
-    8,
-    8,
-    8
-  ],
-  "garbagePrices": [
-    1,
-    1,
-    1,
-    2,
-    2,
-    2,
-    3,
-    3,
-    3,
-    4,
-    4,
-    4,
-    5,
-    5,
-    5,
-    6,
-    6,
-    6,
-    7,
-    7,
-    7,
-    8,
-    8,
-    8
-  ],
-  "uraniumPrices": [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    10,
-    12,
-    14,
-    16
-  ],
-  "actualMarket": [],
-  "futureMarket": [],
-  "highestBidders": [],
-  "auctioningPlayer": 2,
-  "step": 2,
-  "phase": "Game End",
-  "options": {
-    "fastBid": false,
-    "map": "China",
     "variant": "original",
-    "showMoney": false,
-    "useNewRechargedSetup": true,
-    "trackTotalSpent": true,
-    "chooseRegions": false,
-    "chooseColors": false
-  },
-  "log": [
-    {
-      "type": "event",
-      "event": "Game Start!"
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 6,
-        "time": 1788175504464
-      },
-      "simple": "undefined chooses Power Plant 6 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>6</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 6,
-        "time": 1788175504464
-      },
-      "simple": "undefined bids $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 7,
-        "time": 1788175504464
-      },
-      "simple": "undefined bids $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504464
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 8,
-        "time": 1788175504464
-      },
-      "simple": "undefined bids $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504464
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 5,
-        "time": 1788175504464
-      },
-      "simple": "undefined chooses Power Plant 5 to initiate an auction.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>5</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 5,
-        "time": 1788175504464
-      },
-      "simple": "undefined bids $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504464
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 7,
-        "time": 1788175504464
-      },
-      "simple": "undefined chooses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>7</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504464
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504464
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504464
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Qiqha'er",
-          "price": 10
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined builds on Qiqha'er for $10.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qiqha'er</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Qingdao",
-          "price": 10
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined builds on Qingdao for $10.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qingdao</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Jilin",
-          "price": 10
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined builds on Jilin for $10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jilin</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Changchun",
-          "price": 12
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined builds on Changchun for $12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Changchun</b> for <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 8 drawn from the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 10 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 7,
-          "resourcesSpent": [
-            "oil",
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined uses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 8,
-        "time": 1788175504465
-      },
-      "simple": "undefined chooses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>8</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Haerbin",
-          "price": 16
-        },
-        "time": 1788175504465
-      },
-      "simple": "undefined builds on Haerbin for $16.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Haerbin</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504465
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Jinan",
-          "price": 16
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined builds on Jinan for $16.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jinan</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 12 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 7,
-          "resourcesSpent": [
-            "oil",
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 12,
-        "time": 1788175504466
-      },
-      "simple": "undefined chooses Power Plant 12 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>12</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 12,
-        "time": 1788175504466
-      },
-      "simple": "undefined bids $12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tangshan",
-          "price": 16
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined builds on Tangshan for $16.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tangshan</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Shenyang",
-          "price": 15
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined builds on Shenyang for $15.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shenyang</b> for <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Hegang",
-          "price": 17
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined builds on Hegang for $17.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hegang</b> for <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 13 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 7,
-          "resourcesSpent": [
-            "oil",
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 10,
-        "time": 1788175504466
-      },
-      "simple": "undefined chooses Power Plant 10 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>10</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 10,
-        "time": 1788175504466
-      },
-      "simple": "undefined bids $10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $2.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504466
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tianjin",
-          "price": 10
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined builds on Tianjin for $10.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tianjin</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Beijing",
-          "price": 13
-        },
-        "time": 1788175504466
-      },
-      "simple": "undefined builds on Beijing for $13.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Beijing</b> for <span style=\"color: green\">$13</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Fushun",
-          "price": 10
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined builds on Fushun for $10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Fushun</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 14 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 14,
-        "time": 1788175504467
-      },
-      "simple": "undefined chooses Power Plant 14 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>14</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 14,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$14</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 15,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 16,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $16.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 17,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $17.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 18,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $18.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 18.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 13,
-        "time": 1788175504467
-      },
-      "simple": "undefined chooses Power Plant 13 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>13</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 13,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$13</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 14,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $14.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$14</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 15,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $15.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 16,
-        "time": 1788175504467
-      },
-      "simple": "undefined bids $16.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 16.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504467
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504467
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Anshan",
-          "price": 12
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined builds on Anshan for $12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Anshan</b> for <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 15 drawn from the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 17 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 7,
-          "resourcesSpent": [
-            "oil",
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 15,
-        "time": 1788175504468
-      },
-      "simple": "undefined chooses Power Plant 15 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>15</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 15,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $15.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 16,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $16.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 16.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 5,
-        "time": 1788175504468
-      },
-      "simple": "undefined discards Power Plant 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Dalian",
-          "price": 16
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined builds on Dalian for $16.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Dalian</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 19 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 14,
-          "resourcesSpent": [
-            "garbage",
-            "garbage"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 7,
-          "resourcesSpent": [
-            "oil",
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 8,
-          "resourcesSpent": [
-            "coal",
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined uses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 19,
-        "time": 1788175504468
-      },
-      "simple": "undefined chooses Power Plant 19 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>19</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 19,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $19.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$19</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 20,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $20.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 21,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $21.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 22,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $22.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 23,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $23.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 24,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $24.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$24</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 25,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $25.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 25.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 8,
-        "time": 1788175504468
-      },
-      "simple": "undefined discards Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 17,
-        "time": 1788175504468
-      },
-      "simple": "undefined chooses Power Plant 17 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>17</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 17,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $17.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 18,
-        "time": 1788175504468
-      },
-      "simple": "undefined bids $18.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 18.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys uranium for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined buys oil for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504468
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Shijiazhuang",
-          "price": 26
-        },
-        "time": 1788175504468
-      },
-      "simple": "undefined builds on Shijiazhuang for $26.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shijiazhuang</b> for <span style=\"color: green\">$26</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Taiyuan",
-          "price": 15
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Taiyuan for $15.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Taiyuan</b> for <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Starting Step 2, Power Plant undefined discarded."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 21 drawn from the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 22 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 7,
-          "resourcesSpent": [
-            "oil",
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 14,
-          "resourcesSpent": [
-            "garbage",
-            "garbage"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 17,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 17.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 15,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 21,
-        "time": 1788175504469
-      },
-      "simple": "undefined chooses Power Plant 21 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>21</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 21,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 22,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $22.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 23,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $23.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 23.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$23</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 7,
-        "time": 1788175504469
-      },
-      "simple": "undefined discards Power Plant 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>7</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 22,
-        "time": 1788175504469
-      },
-      "simple": "undefined chooses Power Plant 22 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>22</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 22,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $22.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 23,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $23.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 23.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$23</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 13,
-        "time": 1788175504469
-      },
-      "simple": "undefined discards Power Plant 13.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys garbage for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys uranium for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys oil for $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Jilin",
-          "price": 20
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Jilin for $20.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jilin</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Changchun",
-          "price": 17
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Changchun for $17.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Changchun</b> for <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Zhengzhou",
-          "price": 17
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Zhengzhou for $17.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Zhengzhou</b> for <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Shijiazhuang",
-          "price": 20
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Shijiazhuang for $20.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shijiazhuang</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 23 drawn from the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 25 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 21,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 4
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 6,
-          "resourcesSpent": [
-            "garbage"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 14,
-          "resourcesSpent": [
-            "garbage",
-            "garbage"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 17,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 17.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 22,
-          "resourcesSpent": [],
-          "citiesPowered": 2
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 22.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 15,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined uses Power Plant 15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 23,
-        "time": 1788175504469
-      },
-      "simple": "undefined chooses Power Plant 23 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>23</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 23,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $23.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 24,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $24.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$24</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 25,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $25.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 26,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $26.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$26</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 27,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $27.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$27</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 28,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $28.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$28</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 29,
-        "time": 1788175504469
-      },
-      "simple": "undefined bids $29.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$29</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 29.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$29</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 6,
-        "time": 1788175504469
-      },
-      "simple": "undefined discards Power Plant 6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>6</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys uranium for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys uranium for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Shenyang",
-          "price": 20
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Shenyang for $20.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shenyang</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Fushun",
-          "price": 15
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Fushun for $15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Fushun</b> for <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Anshan",
-          "price": 17
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Anshan for $17.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Anshan</b> for <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504469
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Baotou",
-          "price": 19
-        },
-        "time": 1788175504469
-      },
-      "simple": "undefined builds on Baotou for $19.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Baotou</b> for <span style=\"color: green\">$19</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tianjin",
-          "price": 20
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Tianjin for $20.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tianjin</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tangshan",
-          "price": 15
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Tangshan for $15.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tangshan</b> for <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 26 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 21,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 4
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 14,
-          "resourcesSpent": [
-            "garbage",
-            "garbage"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 17,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 17.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 23,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 23.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>23</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 22,
-          "resourcesSpent": [],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 22.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 15,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 19,
-          "resourcesSpent": [
-            "garbage",
-            "garbage"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 19.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>19</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 26,
-        "time": 1788175504470
-      },
-      "simple": "undefined chooses Power Plant 26.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>26</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 26.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$26</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 14,
-        "time": 1788175504470
-      },
-      "simple": "undefined discards Power Plant 14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>14</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys oil for $4.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys oil for $4.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys uranium for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys uranium for $10.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Taiyuan",
-          "price": 20
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Taiyuan for $20.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Taiyuan</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Nanjing",
-          "price": 21
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Nanjing for $21.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Nanjing</b> for <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Hangzhou",
-          "price": 15
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Hangzhou for $15.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hangzhou</b> for <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Dalian",
-          "price": 21
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Dalian for $21.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Dalian</b> for <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Beijing",
-          "price": 29
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Beijing for $29.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Beijing</b> for <span style=\"color: green\">$29</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Haerbin",
-          "price": 20
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Haerbin for $20.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Haerbin</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Jinan",
-          "price": 21
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Jinan for $21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jinan</b> for <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Qiqha'er",
-          "price": 21
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined builds on Qiqha'er for $21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qiqha'er</b> for <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 27 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 12,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 12.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 10,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 21,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 4
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 22,
-          "resourcesSpent": [],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 22.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 15,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 19,
-          "resourcesSpent": [
-            "garbage",
-            "garbage"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 19.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>19</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 17,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 17.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 23,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 3
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 23.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>23</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 26,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 5
-        },
-        "time": 1788175504470
-      },
-      "simple": "undefined uses Power Plant 26.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>26</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504470
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [5, 3, 2, 1]."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 27,
-        "time": 1788175504471
-      },
-      "simple": "undefined chooses Power Plant 27 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>27</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 27,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $27.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$27</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 28,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $28.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$28</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 29,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $29.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$29</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 30,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $30.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$30</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 31,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $31.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$31</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 32,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $32.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$32</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 33,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $33.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$33</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 33.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$33</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 17,
-        "time": 1788175504471
-      },
-      "simple": "undefined discards Power Plant 17.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>17</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 25,
-        "time": 1788175504471
-      },
-      "simple": "undefined chooses Power Plant 25 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>25</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 25,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $25.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 26,
-        "time": 1788175504471
-      },
-      "simple": "undefined bids $26.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$26</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 26.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$26</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 15,
-        "time": 1788175504471
-      },
-      "simple": "undefined discards Power Plant 15.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>15</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "garbage"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys garbage for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys oil for $3.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys oil for $4.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys uranium for $10.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Baotou",
-          "price": 29
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined builds on Baotou for $29.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Baotou</b> for <span style=\"color: green\">$29</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Shanghai",
-          "price": 14
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined builds on Shanghai for $14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shanghai</b> for <span style=\"color: green\">$14</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Hegang",
-          "price": 43
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined builds on Hegang for $43.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hegang</b> for <span style=\"color: green\">$43</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504471
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Qingdao",
-          "price": 21
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined builds on Qingdao for $21.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qingdao</b> for <span style=\"color: green\">$21</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Zhengzhou",
-          "price": 22
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined builds on Zhengzhou for $22.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Zhengzhou</b> for <span style=\"color: green\">$22</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Nanjing",
-          "price": 26
-        },
-        "time": 1788175504471
-      },
-      "simple": "undefined builds on Nanjing for $26.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Nanjing</b> for <span style=\"color: green\">$26</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504472
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Game Ended!"
-    }
-  ],
-  "hiddenLog": [],
-  "seed": "replay-china-fixture",
-  "round": 11,
-  "newTurn": true,
-  "auctionSkips": 1,
-  "citiesToStep2": 7,
-  "citiesToEndGame": 17,
-  "resourceResupply": [
-    "[5, 3, 2, 1]",
-    "[5, 3, 2, 1]",
-    "[3, 4, 1, 1]"
-  ],
-  "paymentTable": [
-    10,
-    22,
-    33,
-    44,
-    54,
-    64,
-    73,
-    82,
-    90,
-    98,
-    105,
-    112,
-    118,
-    124,
-    129,
-    134,
-    138,
-    142,
-    145,
-    148,
-    150,
-    150
-  ],
-  "variant": "original",
-  "minimunBid": 25,
-  "plantDiscountActive": false,
-  "discardSmallestPlant": false,
-  "cardsLeft": 15,
-  "nextCardWeak": false,
-  "card39Bought": false,
-  "knownPowerPlantDeck": [
-    {
-      "number": 5,
-      "type": 4,
-      "cost": 2,
-      "citiesPowered": 1
-    },
-    {
-      "number": 6,
-      "type": 2,
-      "cost": 1,
-      "citiesPowered": 1
-    },
-    {
-      "number": 7,
-      "type": 1,
-      "cost": 3,
-      "citiesPowered": 2
-    },
-    {
-      "number": 8,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 2
-    },
-    {
-      "number": 10,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 2
-    },
-    {
-      "number": 12,
-      "type": 4,
-      "cost": 2,
-      "citiesPowered": 2
-    },
-    {
-      "number": 13,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 1
-    },
-    {
-      "number": 14,
-      "type": 2,
-      "cost": 2,
-      "citiesPowered": 2
-    },
-    {
-      "number": 15,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 3
-    },
-    {
-      "number": 17,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 2
-    },
-    {
-      "number": 19,
-      "type": 2,
-      "cost": 2,
-      "citiesPowered": 3
-    },
-    {
-      "number": 21,
-      "type": 4,
-      "cost": 2,
-      "citiesPowered": 4
-    },
-    {
-      "number": 22,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 2
-    },
-    {
-      "number": 23,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 3
-    },
-    {
-      "number": 25,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 5
-    },
-    {
-      "number": 26,
-      "type": 1,
-      "cost": 2,
-      "citiesPowered": 5
-    },
-    {
-      "number": 27,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 3
-    }
-  ],
-  "knownPowerPlantDeckStep3": [],
-  "pendingMarketRefill": false,
-  "chosenResource": "coal"
+    "minimunBid": 25,
+    "plantDiscountActive": false,
+    "discardSmallestPlant": false,
+    "cardsLeft": 15,
+    "nextCardWeak": false,
+    "card39Bought": false,
+    "knownPowerPlantDeck": [
+        {
+            "number": 5,
+            "type": 4,
+            "cost": 2,
+            "citiesPowered": 1
+        },
+        {
+            "number": 6,
+            "type": 2,
+            "cost": 1,
+            "citiesPowered": 1
+        },
+        {
+            "number": 7,
+            "type": 1,
+            "cost": 3,
+            "citiesPowered": 2
+        },
+        {
+            "number": 8,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 2
+        },
+        {
+            "number": 10,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 2
+        },
+        {
+            "number": 12,
+            "type": 4,
+            "cost": 2,
+            "citiesPowered": 2
+        },
+        {
+            "number": 13,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 1
+        },
+        {
+            "number": 14,
+            "type": 2,
+            "cost": 2,
+            "citiesPowered": 2
+        },
+        {
+            "number": 15,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 3
+        },
+        {
+            "number": 17,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 2
+        },
+        {
+            "number": 19,
+            "type": 2,
+            "cost": 2,
+            "citiesPowered": 3
+        },
+        {
+            "number": 21,
+            "type": 4,
+            "cost": 2,
+            "citiesPowered": 4
+        },
+        {
+            "number": 22,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 2
+        },
+        {
+            "number": 23,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 3
+        },
+        {
+            "number": 25,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 5
+        },
+        {
+            "number": 26,
+            "type": 1,
+            "cost": 2,
+            "citiesPowered": 5
+        },
+        {
+            "number": 27,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 3
+        }
+    ],
+    "knownPowerPlantDeckStep3": [],
+    "pendingMarketRefill": false,
+    "chosenResource": "coal"
 }

--- a/engine/src/fixtures/ChinaStep3.json
+++ b/engine/src/fixtures/ChinaStep3.json
@@ -1,0 +1,6964 @@
+{
+  "map": {
+    "name": "China",
+    "cities": [
+      {
+        "name": "Hegang",
+        "region": "pink",
+        "x": 1372,
+        "y": 101.5
+      },
+      {
+        "name": "Qiqha'er",
+        "region": "pink",
+        "x": 1197.6999999999998,
+        "y": 91.69999999999999
+      },
+      {
+        "name": "Haerbin",
+        "region": "pink",
+        "x": 1285.1999999999998,
+        "y": 151.89999999999998
+      },
+      {
+        "name": "Jilin",
+        "region": "pink",
+        "x": 1310.3999999999999,
+        "y": 214.89999999999998
+      },
+      {
+        "name": "Fushun",
+        "region": "pink",
+        "x": 1299.1999999999998,
+        "y": 274.4
+      },
+      {
+        "name": "Anshan",
+        "region": "pink",
+        "x": 1228.5,
+        "y": 315.7
+      },
+      {
+        "name": "Dalian",
+        "region": "pink",
+        "x": 1198.3999999999999,
+        "y": 368.2
+      },
+      {
+        "name": "Shanghai",
+        "region": "green",
+        "x": 1211.6999999999998,
+        "y": 585.1999999999999
+      },
+      {
+        "name": "Hangzhou",
+        "region": "green",
+        "x": 1148,
+        "y": 638.4
+      },
+      {
+        "name": "Nanjing",
+        "region": "green",
+        "x": 1095.5,
+        "y": 571.1999999999999
+      },
+      {
+        "name": "Qingdao",
+        "region": "green",
+        "x": 1162.6999999999998,
+        "y": 460.59999999999997
+      },
+      {
+        "name": "Jinan",
+        "region": "green",
+        "x": 1050.7,
+        "y": 452.2
+      },
+      {
+        "name": "Zhengzhou",
+        "region": "green",
+        "x": 972.3,
+        "y": 503.29999999999995
+      },
+      {
+        "name": "Shijiazhuang",
+        "region": "green",
+        "x": 1003.0999999999999,
+        "y": 403.2
+      },
+      {
+        "name": "Changchun",
+        "region": "red",
+        "x": 1226.3999999999999,
+        "y": 206.5
+      },
+      {
+        "name": "Shenyang",
+        "region": "red",
+        "x": 1210.3,
+        "y": 272.29999999999995
+      },
+      {
+        "name": "Tangshan",
+        "region": "red",
+        "x": 1105.3,
+        "y": 317.79999999999995
+      },
+      {
+        "name": "Tianjin",
+        "region": "red",
+        "x": 1096.8999999999999,
+        "y": 355.59999999999997
+      },
+      {
+        "name": "Beijing",
+        "region": "red",
+        "x": 1010.0999999999999,
+        "y": 318.5
+      },
+      {
+        "name": "Taiyuan",
+        "region": "red",
+        "x": 905.8,
+        "y": 395.5
+      },
+      {
+        "name": "Baotou",
+        "region": "red",
+        "x": 875,
+        "y": 301.7
+      }
+    ],
+    "connections": [
+      {
+        "nodes": [
+          "Hangzhou",
+          "Shanghai"
+        ],
+        "cost": 4
+      },
+      {
+        "nodes": [
+          "Shanghai",
+          "Nanjing"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Nanjing",
+          "Hangzhou"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Taiyuan",
+          "Zhengzhou"
+        ],
+        "cost": 11
+      },
+      {
+        "nodes": [
+          "Taiyuan",
+          "Shijiazhuang"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Shijiazhuang",
+          "Tianjin"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Shijiazhuang",
+          "Jinan"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Shijiazhuang",
+          "Zhengzhou"
+        ],
+        "cost": 9
+      },
+      {
+        "nodes": [
+          "Zhengzhou",
+          "Jinan"
+        ],
+        "cost": 7
+      },
+      {
+        "nodes": [
+          "Zhengzhou",
+          "Nanjing"
+        ],
+        "cost": 12
+      },
+      {
+        "nodes": [
+          "Jinan",
+          "Nanjing"
+        ],
+        "cost": 11
+      },
+      {
+        "nodes": [
+          "Nanjing",
+          "Qingdao"
+        ],
+        "cost": 12
+      },
+      {
+        "nodes": [
+          "Qingdao",
+          "Jinan"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Jinan",
+          "Tianjin"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Baotou",
+          "Taiyuan"
+        ],
+        "cost": 9
+      },
+      {
+        "nodes": [
+          "Taiyuan",
+          "Beijing"
+        ],
+        "cost": 10
+      },
+      {
+        "nodes": [
+          "Beijing",
+          "Shijiazhuang"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Beijing",
+          "Tangshan"
+        ],
+        "cost": 3
+      },
+      {
+        "nodes": [
+          "Tangshan",
+          "Tianjin"
+        ],
+        "cost": 0
+      },
+      {
+        "nodes": [
+          "Beijing",
+          "Baotou"
+        ],
+        "cost": 14
+      },
+      {
+        "nodes": [
+          "Tangshan",
+          "Shenyang"
+        ],
+        "cost": 11
+      },
+      {
+        "nodes": [
+          "Dalian",
+          "Anshan"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Qiqha'er",
+          "Hegang"
+        ],
+        "cost": 11
+      },
+      {
+        "nodes": [
+          "Hegang",
+          "Haerbin"
+        ],
+        "cost": 7
+      },
+      {
+        "nodes": [
+          "Haerbin",
+          "Qiqha'er"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Changchun",
+          "Jilin"
+        ],
+        "cost": 2
+      },
+      {
+        "nodes": [
+          "Jilin",
+          "Haerbin"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Haerbin",
+          "Changchun"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Changchun",
+          "Shenyang"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Shenyang",
+          "Anshan"
+        ],
+        "cost": 2
+      },
+      {
+        "nodes": [
+          "Jilin",
+          "Fushun"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Fushun",
+          "Shenyang"
+        ],
+        "cost": 0
+      },
+      {
+        "nodes": [
+          "Changchun",
+          "Qiqha'er"
+        ],
+        "cost": 9
+      }
+    ],
+    "layout": "Portrait",
+    "mapPosition": [
+      -400,
+      70
+    ],
+    "adjustRatio": [
+      0.35,
+      0.35
+    ],
+    "resupply": [
+      [
+        [
+          4,
+          4,
+          3
+        ],
+        [
+          5,
+          5,
+          3
+        ],
+        [
+          6,
+          6,
+          4
+        ],
+        [
+          7,
+          7,
+          5
+        ],
+        [
+          9,
+          9,
+          6
+        ]
+      ],
+      [
+        [
+          2,
+          2,
+          4
+        ],
+        [
+          3,
+          3,
+          4
+        ],
+        [
+          4,
+          4,
+          5
+        ],
+        [
+          5,
+          5,
+          6
+        ],
+        [
+          6,
+          6,
+          7
+        ]
+      ],
+      [
+        [
+          2,
+          2,
+          1
+        ],
+        [
+          2,
+          2,
+          1
+        ],
+        [
+          3,
+          3,
+          2
+        ],
+        [
+          3,
+          3,
+          3
+        ],
+        [
+          5,
+          5,
+          3
+        ]
+      ],
+      [
+        [
+          1,
+          1,
+          1
+        ],
+        [
+          1,
+          1,
+          1
+        ],
+        [
+          2,
+          2,
+          2
+        ],
+        [
+          3,
+          3,
+          2
+        ],
+        [
+          3,
+          3,
+          3
+        ]
+      ]
+    ],
+    "startingResources": [
+      12,
+      12,
+      6,
+      0
+    ],
+    "mapSpecificRules": "There are several changes to when new plants are drawn. In particular, during steps 1 and 2, plants are only drawn from the deck during the bureaucracy phase.\n",
+    "deckBuild": "the same plants are removed every game: with 2-3 players 3, 4, 9, 11, 16, 18, 20, 24, 30, 33, 46; with 4 players 3, 4, 11, 18, 24, 33, 46; with 5-6 players 3, 4, 33. The deck is ordered, not shuffled: plants 5-30 in ascending order on top, then plants 31-35 shuffled together with the Step 3 card, then plants 36-50 shuffled on the bottom. The starting market has one plant per player and the future market starts empty.",
+    "viewBox": [
+      1480,
+      1060
+    ],
+    "playerOrderPosition": [
+      1160,
+      160
+    ],
+    "cityCountPosition": [
+      0,
+      0
+    ],
+    "powerPlantMarketPosition": [
+      745,
+      0
+    ],
+    "actualMarketWidth": 430,
+    "buttonsPosition": [
+      1305,
+      0
+    ],
+    "playerBoardsPosition": [
+      1105,
+      240
+    ],
+    "roundInfoPosition": [
+      20,
+      920
+    ],
+    "supplyPosition": [
+      675,
+      920
+    ]
+  },
+  "players": [
+    {
+      "id": 0,
+      "powerPlants": [
+        {
+          "number": 23,
+          "type": 3,
+          "cost": 1,
+          "citiesPowered": 3
+        },
+        {
+          "number": 26,
+          "type": 1,
+          "cost": 2,
+          "citiesPowered": 5
+        },
+        {
+          "number": 27,
+          "type": 5,
+          "cost": 0,
+          "citiesPowered": 3
+        }
+      ],
+      "coalCapacity": 0,
+      "coalLeft": 0,
+      "oilCapacity": 4,
+      "oilLeft": 2,
+      "garbageCapacity": 0,
+      "garbageLeft": 0,
+      "uraniumCapacity": 2,
+      "uraniumLeft": 1,
+      "hybridCapacity": 0,
+      "hybridLeft": 0,
+      "money": 1,
+      "housesLeft": 22,
+      "cities": [
+        {
+          "name": "Qingdao",
+          "position": 0
+        },
+        {
+          "name": "Jinan",
+          "position": 0
+        },
+        {
+          "name": "Tangshan",
+          "position": 0
+        },
+        {
+          "name": "Tianjin",
+          "position": 0
+        },
+        {
+          "name": "Beijing",
+          "position": 0
+        },
+        {
+          "name": "Zhengzhou",
+          "position": 0
+        },
+        {
+          "name": "Shijiazhuang",
+          "position": 1
+        },
+        {
+          "name": "Taiyuan",
+          "position": 1
+        },
+        {
+          "name": "Nanjing",
+          "position": 0
+        },
+        {
+          "name": "Hangzhou",
+          "position": 0
+        },
+        {
+          "name": "Shanghai",
+          "position": 0
+        },
+        {
+          "name": "Hegang",
+          "position": 1
+        }
+      ],
+      "powerPlantsNotUsed": [],
+      "availableMoves": null,
+      "lastMove": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "isDropped": false,
+      "isAI": false,
+      "bid": 0,
+      "passed": true,
+      "skipAuction": false,
+      "citiesPowered": 11,
+      "resourcesUsed": [],
+      "totalIncome": 469,
+      "totalSpentCities": 135,
+      "totalSpentConnections": 80,
+      "totalSpentPlants": 132,
+      "totalSpentResources": 171,
+      "usedFreeJump": false,
+      "totalTimeUsed": 2
+    },
+    {
+      "id": 1,
+      "powerPlants": [
+        {
+          "number": 19,
+          "type": 2,
+          "cost": 2,
+          "citiesPowered": 3
+        },
+        {
+          "number": 22,
+          "type": 5,
+          "cost": 0,
+          "citiesPowered": 2
+        },
+        {
+          "number": 25,
+          "type": 0,
+          "cost": 2,
+          "citiesPowered": 5
+        }
+      ],
+      "coalCapacity": 4,
+      "coalLeft": 2,
+      "oilCapacity": 0,
+      "oilLeft": 0,
+      "garbageCapacity": 4,
+      "garbageLeft": 2,
+      "uraniumCapacity": 0,
+      "uraniumLeft": 0,
+      "hybridCapacity": 0,
+      "hybridLeft": 0,
+      "money": 25,
+      "housesLeft": 22,
+      "cities": [
+        {
+          "name": "Qiqha'er",
+          "position": 0
+        },
+        {
+          "name": "Haerbin",
+          "position": 0
+        },
+        {
+          "name": "Hegang",
+          "position": 0
+        },
+        {
+          "name": "Jilin",
+          "position": 1
+        },
+        {
+          "name": "Changchun",
+          "position": 1
+        },
+        {
+          "name": "Shenyang",
+          "position": 1
+        },
+        {
+          "name": "Fushun",
+          "position": 1
+        },
+        {
+          "name": "Anshan",
+          "position": 1
+        },
+        {
+          "name": "Dalian",
+          "position": 1
+        },
+        {
+          "name": "Beijing",
+          "position": 1
+        },
+        {
+          "name": "Baotou",
+          "position": 1
+        }
+      ],
+      "powerPlantsNotUsed": [],
+      "availableMoves": null,
+      "lastMove": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "isDropped": false,
+      "isAI": false,
+      "bid": 0,
+      "passed": true,
+      "skipAuction": false,
+      "citiesPowered": 10,
+      "resourcesUsed": [],
+      "totalIncome": 453,
+      "totalSpentCities": 150,
+      "totalSpentConnections": 61,
+      "totalSpentPlants": 119,
+      "totalSpentResources": 148,
+      "usedFreeJump": false,
+      "totalTimeUsed": 0
+    },
+    {
+      "id": 2,
+      "powerPlants": [
+        {
+          "number": 12,
+          "type": 4,
+          "cost": 2,
+          "citiesPowered": 2
+        },
+        {
+          "number": 10,
+          "type": 0,
+          "cost": 2,
+          "citiesPowered": 2
+        },
+        {
+          "number": 21,
+          "type": 4,
+          "cost": 2,
+          "citiesPowered": 4
+        }
+      ],
+      "coalCapacity": 4,
+      "coalLeft": 3,
+      "oilCapacity": 0,
+      "oilLeft": 4,
+      "garbageCapacity": 0,
+      "garbageLeft": 0,
+      "uraniumCapacity": 0,
+      "uraniumLeft": 0,
+      "hybridCapacity": 8,
+      "hybridLeft": 0,
+      "money": 6,
+      "housesLeft": 22,
+      "cities": [
+        {
+          "name": "Jilin",
+          "position": 0
+        },
+        {
+          "name": "Changchun",
+          "position": 0
+        },
+        {
+          "name": "Shenyang",
+          "position": 0
+        },
+        {
+          "name": "Fushun",
+          "position": 0
+        },
+        {
+          "name": "Anshan",
+          "position": 0
+        },
+        {
+          "name": "Dalian",
+          "position": 0
+        },
+        {
+          "name": "Shijiazhuang",
+          "position": 0
+        },
+        {
+          "name": "Taiyuan",
+          "position": 0
+        },
+        {
+          "name": "Baotou",
+          "position": 0
+        },
+        {
+          "name": "Tianjin",
+          "position": 1
+        },
+        {
+          "name": "Tangshan",
+          "position": 1
+        },
+        {
+          "name": "Haerbin",
+          "position": 1
+        },
+        {
+          "name": "Jinan",
+          "position": 1
+        },
+        {
+          "name": "Qiqha'er",
+          "position": 1
+        },
+        {
+          "name": "Qingdao",
+          "position": 1
+        },
+        {
+          "name": "Zhengzhou",
+          "position": 1
+        },
+        {
+          "name": "Nanjing",
+          "position": 1
+        }
+      ],
+      "powerPlantsNotUsed": [],
+      "availableMoves": null,
+      "lastMove": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504472
+      },
+      "isDropped": false,
+      "isAI": false,
+      "bid": 0,
+      "passed": true,
+      "skipAuction": false,
+      "citiesPowered": 8,
+      "resourcesUsed": [],
+      "totalIncome": 644,
+      "totalSpentCities": 210,
+      "totalSpentConnections": 91,
+      "totalSpentPlants": 52,
+      "totalSpentResources": 335,
+      "usedFreeJump": false,
+      "totalTimeUsed": 6
+    }
+  ],
+  "playerOrder": [
+    2,
+    0,
+    1
+  ],
+  "currentPlayers": [],
+  "powerPlantsDeck": [
+    {
+      "number": 28,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 4
+    },
+    {
+      "number": 29,
+      "type": 4,
+      "cost": 1,
+      "citiesPowered": 4
+    },
+    {
+      "number": 35,
+      "type": 1,
+      "cost": 1,
+      "citiesPowered": 5
+    },
+    {
+      "number": 31,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 6
+    },
+    {
+      "number": 99,
+      "type": 7,
+      "cost": 0,
+      "citiesPowered": 6
+    },
+    {
+      "number": 32,
+      "type": 1,
+      "cost": 3,
+      "citiesPowered": 6
+    },
+    {
+      "number": 34,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 5
+    },
+    {
+      "number": 38,
+      "type": 2,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 50,
+      "type": 6,
+      "cost": 0,
+      "citiesPowered": 6
+    },
+    {
+      "number": 36,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 40,
+      "type": 1,
+      "cost": 2,
+      "citiesPowered": 6
+    },
+    {
+      "number": 37,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 4
+    },
+    {
+      "number": 42,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 6
+    },
+    {
+      "number": 44,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 5
+    },
+    {
+      "number": 39,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 6
+    }
+  ],
+  "coalSupply": 19,
+  "oilSupply": 4,
+  "garbageSupply": 18,
+  "uraniumSupply": 8,
+  "coalResupply": [
+    [
+      4,
+      4,
+      3
+    ],
+    [
+      5,
+      5,
+      3
+    ],
+    [
+      6,
+      6,
+      4
+    ],
+    [
+      7,
+      7,
+      5
+    ],
+    [
+      9,
+      9,
+      6
+    ]
+  ],
+  "oilResupply": [
+    [
+      2,
+      2,
+      4
+    ],
+    [
+      3,
+      3,
+      4
+    ],
+    [
+      4,
+      4,
+      5
+    ],
+    [
+      5,
+      5,
+      6
+    ],
+    [
+      6,
+      6,
+      7
+    ]
+  ],
+  "garbageResupply": [
+    [
+      2,
+      2,
+      1
+    ],
+    [
+      2,
+      2,
+      1
+    ],
+    [
+      3,
+      3,
+      2
+    ],
+    [
+      3,
+      3,
+      3
+    ],
+    [
+      5,
+      5,
+      3
+    ]
+  ],
+  "uraniumResupply": [
+    [
+      1,
+      1,
+      1
+    ],
+    [
+      1,
+      1,
+      1
+    ],
+    [
+      2,
+      2,
+      2
+    ],
+    [
+      3,
+      3,
+      2
+    ],
+    [
+      3,
+      3,
+      3
+    ]
+  ],
+  "coalMarket": 0,
+  "oilMarket": 14,
+  "garbageMarket": 4,
+  "uraniumMarket": 3,
+  "coalPrices": [
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    3,
+    3,
+    3,
+    4,
+    4,
+    4,
+    5,
+    5,
+    5,
+    6,
+    6,
+    6,
+    7,
+    7,
+    7,
+    8,
+    8,
+    8
+  ],
+  "oilPrices": [
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    3,
+    3,
+    3,
+    4,
+    4,
+    4,
+    5,
+    5,
+    5,
+    6,
+    6,
+    6,
+    7,
+    7,
+    7,
+    8,
+    8,
+    8
+  ],
+  "garbagePrices": [
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    3,
+    3,
+    3,
+    4,
+    4,
+    4,
+    5,
+    5,
+    5,
+    6,
+    6,
+    6,
+    7,
+    7,
+    7,
+    8,
+    8,
+    8
+  ],
+  "uraniumPrices": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    10,
+    12,
+    14,
+    16
+  ],
+  "actualMarket": [],
+  "futureMarket": [],
+  "highestBidders": [],
+  "auctioningPlayer": 2,
+  "step": 2,
+  "phase": "Game End",
+  "options": {
+    "fastBid": false,
+    "map": "China",
+    "variant": "original",
+    "showMoney": false,
+    "useNewRechargedSetup": true,
+    "trackTotalSpent": true,
+    "chooseRegions": false,
+    "chooseColors": false
+  },
+  "log": [
+    {
+      "type": "event",
+      "event": "Game Start!"
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 6,
+        "time": 1788175504464
+      },
+      "simple": "undefined chooses Power Plant 6 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>6</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 6,
+        "time": 1788175504464
+      },
+      "simple": "undefined bids $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 7,
+        "time": 1788175504464
+      },
+      "simple": "undefined bids $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504464
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 8,
+        "time": 1788175504464
+      },
+      "simple": "undefined bids $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504464
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 5,
+        "time": 1788175504464
+      },
+      "simple": "undefined chooses Power Plant 5 to initiate an auction.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>5</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 5,
+        "time": 1788175504464
+      },
+      "simple": "undefined bids $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504464
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 7,
+        "time": 1788175504464
+      },
+      "simple": "undefined chooses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>7</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504464
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504464
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504464
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Qiqha'er",
+          "price": 10
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined builds on Qiqha'er for $10.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qiqha'er</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Qingdao",
+          "price": 10
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined builds on Qingdao for $10.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qingdao</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Jilin",
+          "price": 10
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined builds on Jilin for $10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jilin</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Changchun",
+          "price": 12
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined builds on Changchun for $12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Changchun</b> for <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 8 drawn from the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 10 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 7,
+          "resourcesSpent": [
+            "oil",
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined uses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 8,
+        "time": 1788175504465
+      },
+      "simple": "undefined chooses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>8</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Haerbin",
+          "price": 16
+        },
+        "time": 1788175504465
+      },
+      "simple": "undefined builds on Haerbin for $16.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Haerbin</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504465
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Jinan",
+          "price": 16
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined builds on Jinan for $16.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jinan</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 12 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 7,
+          "resourcesSpent": [
+            "oil",
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 12,
+        "time": 1788175504466
+      },
+      "simple": "undefined chooses Power Plant 12 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>12</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 12,
+        "time": 1788175504466
+      },
+      "simple": "undefined bids $12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tangshan",
+          "price": 16
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined builds on Tangshan for $16.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tangshan</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Shenyang",
+          "price": 15
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined builds on Shenyang for $15.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shenyang</b> for <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Hegang",
+          "price": 17
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined builds on Hegang for $17.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hegang</b> for <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 13 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 7,
+          "resourcesSpent": [
+            "oil",
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 10,
+        "time": 1788175504466
+      },
+      "simple": "undefined chooses Power Plant 10 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>10</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 10,
+        "time": 1788175504466
+      },
+      "simple": "undefined bids $10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $2.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504466
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tianjin",
+          "price": 10
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined builds on Tianjin for $10.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tianjin</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Beijing",
+          "price": 13
+        },
+        "time": 1788175504466
+      },
+      "simple": "undefined builds on Beijing for $13.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Beijing</b> for <span style=\"color: green\">$13</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Fushun",
+          "price": 10
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined builds on Fushun for $10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Fushun</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 14 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 14,
+        "time": 1788175504467
+      },
+      "simple": "undefined chooses Power Plant 14 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>14</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 14,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$14</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 15,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 16,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $16.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 17,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $17.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 18,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $18.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 18.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 13,
+        "time": 1788175504467
+      },
+      "simple": "undefined chooses Power Plant 13 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>13</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 13,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$13</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 14,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $14.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$14</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 15,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $15.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 16,
+        "time": 1788175504467
+      },
+      "simple": "undefined bids $16.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 16.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504467
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504467
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Anshan",
+          "price": 12
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined builds on Anshan for $12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Anshan</b> for <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 15 drawn from the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 17 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 7,
+          "resourcesSpent": [
+            "oil",
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 15,
+        "time": 1788175504468
+      },
+      "simple": "undefined chooses Power Plant 15 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>15</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 15,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $15.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 16,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $16.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 16.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 5,
+        "time": 1788175504468
+      },
+      "simple": "undefined discards Power Plant 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Dalian",
+          "price": 16
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined builds on Dalian for $16.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Dalian</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 19 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 14,
+          "resourcesSpent": [
+            "garbage",
+            "garbage"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 7,
+          "resourcesSpent": [
+            "oil",
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 8,
+          "resourcesSpent": [
+            "coal",
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined uses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 19,
+        "time": 1788175504468
+      },
+      "simple": "undefined chooses Power Plant 19 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>19</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 19,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $19.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$19</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 20,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $20.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 21,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $21.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 22,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $22.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 23,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $23.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 24,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $24.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$24</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 25,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $25.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 25.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 8,
+        "time": 1788175504468
+      },
+      "simple": "undefined discards Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 17,
+        "time": 1788175504468
+      },
+      "simple": "undefined chooses Power Plant 17 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>17</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 17,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $17.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 18,
+        "time": 1788175504468
+      },
+      "simple": "undefined bids $18.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 18.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys uranium for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined buys oil for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504468
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Shijiazhuang",
+          "price": 26
+        },
+        "time": 1788175504468
+      },
+      "simple": "undefined builds on Shijiazhuang for $26.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shijiazhuang</b> for <span style=\"color: green\">$26</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Taiyuan",
+          "price": 15
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Taiyuan for $15.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Taiyuan</b> for <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Starting Step 2, Power Plant undefined discarded."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 21 drawn from the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 22 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 7,
+          "resourcesSpent": [
+            "oil",
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 14,
+          "resourcesSpent": [
+            "garbage",
+            "garbage"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 17,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 17.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 15,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 21,
+        "time": 1788175504469
+      },
+      "simple": "undefined chooses Power Plant 21 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>21</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 21,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 22,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $22.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 23,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $23.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 23.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$23</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 7,
+        "time": 1788175504469
+      },
+      "simple": "undefined discards Power Plant 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>7</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 22,
+        "time": 1788175504469
+      },
+      "simple": "undefined chooses Power Plant 22 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>22</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 22,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $22.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$22</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 23,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $23.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 23.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$23</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 13,
+        "time": 1788175504469
+      },
+      "simple": "undefined discards Power Plant 13.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys garbage for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys uranium for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys oil for $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Jilin",
+          "price": 20
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Jilin for $20.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jilin</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Changchun",
+          "price": 17
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Changchun for $17.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Changchun</b> for <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Zhengzhou",
+          "price": 17
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Zhengzhou for $17.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Zhengzhou</b> for <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Shijiazhuang",
+          "price": 20
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Shijiazhuang for $20.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shijiazhuang</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 23 drawn from the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 25 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 21,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 4
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 6,
+          "resourcesSpent": [
+            "garbage"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 14,
+          "resourcesSpent": [
+            "garbage",
+            "garbage"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 17,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 17.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 22,
+          "resourcesSpent": [],
+          "citiesPowered": 2
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 22.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 15,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined uses Power Plant 15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 23,
+        "time": 1788175504469
+      },
+      "simple": "undefined chooses Power Plant 23 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>23</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 23,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $23.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$23</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 24,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $24.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$24</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 25,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $25.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 26,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $26.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$26</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 27,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $27.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$27</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 28,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $28.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$28</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 29,
+        "time": 1788175504469
+      },
+      "simple": "undefined bids $29.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$29</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 29.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$29</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 6,
+        "time": 1788175504469
+      },
+      "simple": "undefined discards Power Plant 6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>6</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys uranium for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys uranium for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Shenyang",
+          "price": 20
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Shenyang for $20.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shenyang</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Fushun",
+          "price": 15
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Fushun for $15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Fushun</b> for <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Anshan",
+          "price": 17
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Anshan for $17.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Anshan</b> for <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504469
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Baotou",
+          "price": 19
+        },
+        "time": 1788175504469
+      },
+      "simple": "undefined builds on Baotou for $19.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Baotou</b> for <span style=\"color: green\">$19</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tianjin",
+          "price": 20
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Tianjin for $20.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tianjin</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tangshan",
+          "price": 15
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Tangshan for $15.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tangshan</b> for <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 26 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 21,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 4
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 14,
+          "resourcesSpent": [
+            "garbage",
+            "garbage"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>14</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 17,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 17.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 23,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 23.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>23</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 22,
+          "resourcesSpent": [],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 22.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 15,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 19,
+          "resourcesSpent": [
+            "garbage",
+            "garbage"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 19.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>19</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 26,
+        "time": 1788175504470
+      },
+      "simple": "undefined chooses Power Plant 26.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>26</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 26.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$26</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 14,
+        "time": 1788175504470
+      },
+      "simple": "undefined discards Power Plant 14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>14</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys oil for $4.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys oil for $4.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys uranium for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys uranium for $10.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Taiyuan",
+          "price": 20
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Taiyuan for $20.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Taiyuan</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Nanjing",
+          "price": 21
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Nanjing for $21.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Nanjing</b> for <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Hangzhou",
+          "price": 15
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Hangzhou for $15.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hangzhou</b> for <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Dalian",
+          "price": 21
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Dalian for $21.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Dalian</b> for <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Beijing",
+          "price": 29
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Beijing for $29.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Beijing</b> for <span style=\"color: green\">$29</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Haerbin",
+          "price": 20
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Haerbin for $20.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Haerbin</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Jinan",
+          "price": 21
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Jinan for $21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Jinan</b> for <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Qiqha'er",
+          "price": 21
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined builds on Qiqha'er for $21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qiqha'er</b> for <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 27 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 12,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 12.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>12</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 10,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>10</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 21,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 4
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>21</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 22,
+          "resourcesSpent": [],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 22.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>22</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 15,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>15</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 19,
+          "resourcesSpent": [
+            "garbage",
+            "garbage"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 19.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>19</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 17,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 17.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>17</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 23,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 3
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 23.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>23</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 26,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 5
+        },
+        "time": 1788175504470
+      },
+      "simple": "undefined uses Power Plant 26.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>26</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504470
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [5, 3, 2, 1]."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 27,
+        "time": 1788175504471
+      },
+      "simple": "undefined chooses Power Plant 27 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>27</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 27,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $27.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$27</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 28,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $28.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$28</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 29,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $29.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$29</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 30,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $30.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$30</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 31,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $31.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$31</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 32,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $32.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$32</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 33,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $33.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$33</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 33.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$33</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 17,
+        "time": 1788175504471
+      },
+      "simple": "undefined discards Power Plant 17.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>17</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 25,
+        "time": 1788175504471
+      },
+      "simple": "undefined chooses Power Plant 25 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>25</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 25,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $25.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 26,
+        "time": 1788175504471
+      },
+      "simple": "undefined bids $26.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$26</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 26.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$26</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 15,
+        "time": 1788175504471
+      },
+      "simple": "undefined discards Power Plant 15.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>15</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "garbage"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys garbage for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>garbage</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys oil for $3.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys oil for $4.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys uranium for $10.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Baotou",
+          "price": 29
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined builds on Baotou for $29.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Baotou</b> for <span style=\"color: green\">$29</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Shanghai",
+          "price": 14
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined builds on Shanghai for $14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Shanghai</b> for <span style=\"color: green\">$14</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Hegang",
+          "price": 43
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined builds on Hegang for $43.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Hegang</b> for <span style=\"color: green\">$43</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504471
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Qingdao",
+          "price": 21
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined builds on Qingdao for $21.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Qingdao</b> for <span style=\"color: green\">$21</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Zhengzhou",
+          "price": 22
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined builds on Zhengzhou for $22.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Zhengzhou</b> for <span style=\"color: green\">$22</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Nanjing",
+          "price": 26
+        },
+        "time": 1788175504471
+      },
+      "simple": "undefined builds on Nanjing for $26.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Nanjing</b> for <span style=\"color: green\">$26</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504472
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Game Ended!"
+    }
+  ],
+  "hiddenLog": [],
+  "seed": "replay-china-fixture",
+  "round": 11,
+  "newTurn": true,
+  "auctionSkips": 1,
+  "citiesToStep2": 7,
+  "citiesToEndGame": 17,
+  "resourceResupply": [
+    "[5, 3, 2, 1]",
+    "[5, 3, 2, 1]",
+    "[3, 4, 1, 1]"
+  ],
+  "paymentTable": [
+    10,
+    22,
+    33,
+    44,
+    54,
+    64,
+    73,
+    82,
+    90,
+    98,
+    105,
+    112,
+    118,
+    124,
+    129,
+    134,
+    138,
+    142,
+    145,
+    148,
+    150,
+    150
+  ],
+  "variant": "original",
+  "minimunBid": 25,
+  "plantDiscountActive": false,
+  "discardSmallestPlant": false,
+  "cardsLeft": 15,
+  "nextCardWeak": false,
+  "card39Bought": false,
+  "knownPowerPlantDeck": [
+    {
+      "number": 5,
+      "type": 4,
+      "cost": 2,
+      "citiesPowered": 1
+    },
+    {
+      "number": 6,
+      "type": 2,
+      "cost": 1,
+      "citiesPowered": 1
+    },
+    {
+      "number": 7,
+      "type": 1,
+      "cost": 3,
+      "citiesPowered": 2
+    },
+    {
+      "number": 8,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 2
+    },
+    {
+      "number": 10,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 2
+    },
+    {
+      "number": 12,
+      "type": 4,
+      "cost": 2,
+      "citiesPowered": 2
+    },
+    {
+      "number": 13,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 1
+    },
+    {
+      "number": 14,
+      "type": 2,
+      "cost": 2,
+      "citiesPowered": 2
+    },
+    {
+      "number": 15,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 3
+    },
+    {
+      "number": 17,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 2
+    },
+    {
+      "number": 19,
+      "type": 2,
+      "cost": 2,
+      "citiesPowered": 3
+    },
+    {
+      "number": 21,
+      "type": 4,
+      "cost": 2,
+      "citiesPowered": 4
+    },
+    {
+      "number": 22,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 2
+    },
+    {
+      "number": 23,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 3
+    },
+    {
+      "number": 25,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 5
+    },
+    {
+      "number": 26,
+      "type": 1,
+      "cost": 2,
+      "citiesPowered": 5
+    },
+    {
+      "number": 27,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 3
+    }
+  ],
+  "knownPowerPlantDeckStep3": [],
+  "pendingMarketRefill": false,
+  "chosenResource": "coal"
+}

--- a/engine/src/fixtures/RussiaStep3.json
+++ b/engine/src/fixtures/RussiaStep3.json
@@ -1,6331 +1,5776 @@
 {
-  "map": {
-    "name": "Russia",
-    "cities": [
-      {
-        "name": "Murmansk",
-        "region": "green",
-        "x": 393.5,
-        "y": 87.75
-      },
-      {
-        "name": "Arkhangelsk",
-        "region": "green",
-        "x": 364,
-        "y": 173.75
-      },
-      {
-        "name": "Syktyvkar",
-        "region": "green",
-        "x": 417.25,
-        "y": 251.25
-      },
-      {
-        "name": "Kirov",
-        "region": "green",
-        "x": 364.25,
-        "y": 293
-      },
-      {
-        "name": "Kazan",
-        "region": "green",
-        "x": 344.5,
-        "y": 369.5
-      },
-      {
-        "name": "Cheboksary",
-        "region": "green",
-        "x": 300,
-        "y": 332
-      },
-      {
-        "name": "Ulyanovsk",
-        "region": "green",
-        "x": 221,
-        "y": 362
-      },
-      {
-        "name": "Norilsk",
-        "region": "yellow",
-        "x": 750.25,
-        "y": 214
-      },
-      {
-        "name": "Surgut",
-        "region": "yellow",
-        "x": 587,
-        "y": 352.75
-      },
-      {
-        "name": "Tyumen",
-        "region": "yellow",
-        "x": 515,
-        "y": 406.75
-      },
-      {
-        "name": "Tomsk",
-        "region": "yellow",
-        "x": 693.25,
-        "y": 458.75
-      },
-      {
-        "name": "Novosibirsk",
-        "region": "yellow",
-        "x": 661.75,
-        "y": 501.25
-      },
-      {
-        "name": "Barnaul",
-        "region": "yellow",
-        "x": 665.5,
-        "y": 547.75
-      },
-      {
-        "name": "Omsk",
-        "region": "yellow",
-        "x": 548.75,
-        "y": 489.25
-      },
-      {
-        "name": "Chelyabinsk",
-        "region": "purple",
-        "x": 442,
-        "y": 466.25
-      },
-      {
-        "name": "Ufa",
-        "region": "purple",
-        "x": 368,
-        "y": 476.75
-      },
-      {
-        "name": "Perm",
-        "region": "purple",
-        "x": 422,
-        "y": 347
-      },
-      {
-        "name": "Yekaterinburg",
-        "region": "purple",
-        "x": 439.25,
-        "y": 405
-      },
-      {
-        "name": "Orenburg",
-        "region": "purple",
-        "x": 312.5,
-        "y": 499.25
-      },
-      {
-        "name": "Naberezhnye Chelny",
-        "region": "purple",
-        "x": 356.75,
-        "y": 427.25
-      },
-      {
-        "name": "Samara",
-        "region": "purple",
-        "x": 283,
-        "y": 425.25
-      }
-    ],
-    "connections": [
-      {
-        "nodes": [
-          "Murmansk",
-          "Arkhangelsk"
+    "map": {
+        "name": "Russia",
+        "cities": [
+            {
+                "name": "Murmansk",
+                "region": "green",
+                "x": 393.5,
+                "y": 87.75
+            },
+            {
+                "name": "Arkhangelsk",
+                "region": "green",
+                "x": 364,
+                "y": 173.75
+            },
+            {
+                "name": "Syktyvkar",
+                "region": "green",
+                "x": 417.25,
+                "y": 251.25
+            },
+            {
+                "name": "Kirov",
+                "region": "green",
+                "x": 364.25,
+                "y": 293
+            },
+            {
+                "name": "Kazan",
+                "region": "green",
+                "x": 344.5,
+                "y": 369.5
+            },
+            {
+                "name": "Cheboksary",
+                "region": "green",
+                "x": 300,
+                "y": 332
+            },
+            {
+                "name": "Ulyanovsk",
+                "region": "green",
+                "x": 221,
+                "y": 362
+            },
+            {
+                "name": "Norilsk",
+                "region": "yellow",
+                "x": 750.25,
+                "y": 214
+            },
+            {
+                "name": "Surgut",
+                "region": "yellow",
+                "x": 587,
+                "y": 352.75
+            },
+            {
+                "name": "Tyumen",
+                "region": "yellow",
+                "x": 515,
+                "y": 406.75
+            },
+            {
+                "name": "Tomsk",
+                "region": "yellow",
+                "x": 693.25,
+                "y": 458.75
+            },
+            {
+                "name": "Novosibirsk",
+                "region": "yellow",
+                "x": 661.75,
+                "y": 501.25
+            },
+            {
+                "name": "Barnaul",
+                "region": "yellow",
+                "x": 665.5,
+                "y": 547.75
+            },
+            {
+                "name": "Omsk",
+                "region": "yellow",
+                "x": 548.75,
+                "y": 489.25
+            },
+            {
+                "name": "Chelyabinsk",
+                "region": "purple",
+                "x": 442,
+                "y": 466.25
+            },
+            {
+                "name": "Ufa",
+                "region": "purple",
+                "x": 368,
+                "y": 476.75
+            },
+            {
+                "name": "Perm",
+                "region": "purple",
+                "x": 422,
+                "y": 347
+            },
+            {
+                "name": "Yekaterinburg",
+                "region": "purple",
+                "x": 439.25,
+                "y": 405
+            },
+            {
+                "name": "Orenburg",
+                "region": "purple",
+                "x": 312.5,
+                "y": 499.25
+            },
+            {
+                "name": "Naberezhnye Chelny",
+                "region": "purple",
+                "x": 356.75,
+                "y": 427.25
+            },
+            {
+                "name": "Samara",
+                "region": "purple",
+                "x": 283,
+                "y": 425.25
+            }
         ],
-        "cost": 15
-      },
-      {
-        "nodes": [
-          "Arkhangelsk",
-          "Syktyvkar"
+        "connections": [
+            {
+                "nodes": ["Murmansk", "Arkhangelsk"],
+                "cost": 15
+            },
+            {
+                "nodes": ["Arkhangelsk", "Syktyvkar"],
+                "cost": 10
+            },
+            {
+                "nodes": ["Syktyvkar", "Surgut"],
+                "cost": 21
+            },
+            {
+                "nodes": ["Perm", "Syktyvkar"],
+                "cost": 8
+            },
+            {
+                "nodes": ["Syktyvkar", "Kirov"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Cheboksary", "Ulyanovsk"],
+                "cost": 4
+            },
+            {
+                "nodes": ["Samara", "Ulyanovsk"],
+                "cost": 3
+            },
+            {
+                "nodes": ["Ulyanovsk", "Kazan"],
+                "cost": 3
+            },
+            {
+                "nodes": ["Kazan", "Samara"],
+                "cost": 4
+            },
+            {
+                "nodes": ["Samara", "Naberezhnye Chelny"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Cheboksary", "Kazan"],
+                "cost": 2
+            },
+            {
+                "nodes": ["Cheboksary", "Kirov"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Kirov", "Kazan"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Kazan", "Perm"],
+                "cost": 8
+            },
+            {
+                "nodes": ["Kazan", "Naberezhnye Chelny"],
+                "cost": 3
+            },
+            {
+                "nodes": ["Naberezhnye Chelny", "Ufa"],
+                "cost": 4
+            },
+            {
+                "nodes": ["Ufa", "Orenburg"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Orenburg", "Samara"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Orenburg", "Naberezhnye Chelny"],
+                "cost": 7
+            },
+            {
+                "nodes": ["Ufa", "Chelyabinsk"],
+                "cost": 8
+            },
+            {
+                "nodes": ["Chelyabinsk", "Yekaterinburg"],
+                "cost": 3
+            },
+            {
+                "nodes": ["Yekaterinburg", "Perm"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Perm", "Kirov"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Chelyabinsk", "Tyumen"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Tyumen", "Surgut"],
+                "cost": 10
+            },
+            {
+                "nodes": ["Syktyvkar", "Tyumen"],
+                "cost": 17
+            },
+            {
+                "nodes": ["Tyumen", "Yekaterinburg"],
+                "cost": 5
+            },
+            {
+                "nodes": ["Chelyabinsk", "Omsk"],
+                "cost": 13
+            },
+            {
+                "nodes": ["Omsk", "Tyumen"],
+                "cost": 9
+            },
+            {
+                "nodes": ["Tyumen", "Tomsk"],
+                "cost": 19
+            },
+            {
+                "nodes": ["Tomsk", "Surgut"],
+                "cost": 15
+            },
+            {
+                "nodes": ["Tomsk", "Novosibirsk"],
+                "cost": 4
+            },
+            {
+                "nodes": ["Novosibirsk", "Barnaul"],
+                "cost": 4
+            },
+            {
+                "nodes": ["Barnaul", "Omsk"],
+                "cost": 11
+            },
+            {
+                "nodes": ["Omsk", "Novosibirsk"],
+                "cost": 10
+            },
+            {
+                "nodes": ["Omsk", "Tomsk"],
+                "cost": 12
+            },
+            {
+                "nodes": ["Naberezhnye Chelny", "Perm"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Naberezhnye Chelny", "Yekaterinburg"],
+                "cost": 8
+            },
+            {
+                "nodes": ["Ufa", "Yekaterinburg"],
+                "cost": 6
+            },
+            {
+                "nodes": ["Tomsk", "Norilsk"],
+                "cost": 24
+            },
+            {
+                "nodes": ["Norilsk", "Surgut"],
+                "cost": 19
+            }
         ],
-        "cost": 10
-      },
-      {
-        "nodes": [
-          "Syktyvkar",
-          "Surgut"
+        "adjustRatio": [0.25, 0.25],
+        "resupply": [
+            [
+                [2, 2, 4],
+                [2, 3, 4],
+                [3, 4, 5],
+                [4, 5, 6],
+                [5, 6, 7]
+            ],
+            [
+                [3, 4, 3],
+                [3, 4, 3],
+                [5, 6, 4],
+                [5, 7, 5],
+                [7, 9, 6]
+            ],
+            [
+                [2, 2, 3],
+                [2, 2, 3],
+                [3, 3, 4],
+                [4, 3, 5],
+                [4, 5, 6]
+            ],
+            [
+                [1, 1, 1],
+                [1, 1, 1],
+                [1, 2, 2],
+                [2, 3, 2],
+                [2, 3, 3]
+            ]
         ],
-        "cost": 21
-      },
-      {
-        "nodes": [
-          "Perm",
-          "Syktyvkar"
-        ],
-        "cost": 8
-      },
-      {
-        "nodes": [
-          "Syktyvkar",
-          "Kirov"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Cheboksary",
-          "Ulyanovsk"
-        ],
-        "cost": 4
-      },
-      {
-        "nodes": [
-          "Samara",
-          "Ulyanovsk"
-        ],
-        "cost": 3
-      },
-      {
-        "nodes": [
-          "Ulyanovsk",
-          "Kazan"
-        ],
-        "cost": 3
-      },
-      {
-        "nodes": [
-          "Kazan",
-          "Samara"
-        ],
-        "cost": 4
-      },
-      {
-        "nodes": [
-          "Samara",
-          "Naberezhnye Chelny"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Cheboksary",
-          "Kazan"
-        ],
-        "cost": 2
-      },
-      {
-        "nodes": [
-          "Cheboksary",
-          "Kirov"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Kirov",
-          "Kazan"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Kazan",
-          "Perm"
-        ],
-        "cost": 8
-      },
-      {
-        "nodes": [
-          "Kazan",
-          "Naberezhnye Chelny"
-        ],
-        "cost": 3
-      },
-      {
-        "nodes": [
-          "Naberezhnye Chelny",
-          "Ufa"
-        ],
-        "cost": 4
-      },
-      {
-        "nodes": [
-          "Ufa",
-          "Orenburg"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Orenburg",
-          "Samara"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Orenburg",
-          "Naberezhnye Chelny"
-        ],
-        "cost": 7
-      },
-      {
-        "nodes": [
-          "Ufa",
-          "Chelyabinsk"
-        ],
-        "cost": 8
-      },
-      {
-        "nodes": [
-          "Chelyabinsk",
-          "Yekaterinburg"
-        ],
-        "cost": 3
-      },
-      {
-        "nodes": [
-          "Yekaterinburg",
-          "Perm"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Perm",
-          "Kirov"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Chelyabinsk",
-          "Tyumen"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Tyumen",
-          "Surgut"
-        ],
-        "cost": 10
-      },
-      {
-        "nodes": [
-          "Syktyvkar",
-          "Tyumen"
-        ],
-        "cost": 17
-      },
-      {
-        "nodes": [
-          "Tyumen",
-          "Yekaterinburg"
-        ],
-        "cost": 5
-      },
-      {
-        "nodes": [
-          "Chelyabinsk",
-          "Omsk"
-        ],
-        "cost": 13
-      },
-      {
-        "nodes": [
-          "Omsk",
-          "Tyumen"
-        ],
-        "cost": 9
-      },
-      {
-        "nodes": [
-          "Tyumen",
-          "Tomsk"
-        ],
-        "cost": 19
-      },
-      {
-        "nodes": [
-          "Tomsk",
-          "Surgut"
-        ],
-        "cost": 15
-      },
-      {
-        "nodes": [
-          "Tomsk",
-          "Novosibirsk"
-        ],
-        "cost": 4
-      },
-      {
-        "nodes": [
-          "Novosibirsk",
-          "Barnaul"
-        ],
-        "cost": 4
-      },
-      {
-        "nodes": [
-          "Barnaul",
-          "Omsk"
-        ],
-        "cost": 11
-      },
-      {
-        "nodes": [
-          "Omsk",
-          "Novosibirsk"
-        ],
-        "cost": 10
-      },
-      {
-        "nodes": [
-          "Omsk",
-          "Tomsk"
-        ],
-        "cost": 12
-      },
-      {
-        "nodes": [
-          "Naberezhnye Chelny",
-          "Perm"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Naberezhnye Chelny",
-          "Yekaterinburg"
-        ],
-        "cost": 8
-      },
-      {
-        "nodes": [
-          "Ufa",
-          "Yekaterinburg"
-        ],
-        "cost": 6
-      },
-      {
-        "nodes": [
-          "Tomsk",
-          "Norilsk"
-        ],
-        "cost": 24
-      },
-      {
-        "nodes": [
-          "Norilsk",
-          "Surgut"
-        ],
-        "cost": 19
-      }
-    ],
-    "adjustRatio": [
-      0.25,
-      0.25
-    ],
-    "resupply": [
-      [
-        [
-          2,
-          2,
-          4
-        ],
-        [
-          2,
-          3,
-          4
-        ],
-        [
-          3,
-          4,
-          5
-        ],
-        [
-          4,
-          5,
-          6
-        ],
-        [
-          5,
-          6,
-          7
-        ]
-      ],
-      [
-        [
-          3,
-          4,
-          3
-        ],
-        [
-          3,
-          4,
-          3
-        ],
-        [
-          5,
-          6,
-          4
-        ],
-        [
-          5,
-          7,
-          5
-        ],
-        [
-          7,
-          9,
-          6
-        ]
-      ],
-      [
-        [
-          2,
-          2,
-          3
-        ],
-        [
-          2,
-          2,
-          3
-        ],
-        [
-          3,
-          3,
-          4
-        ],
-        [
-          4,
-          3,
-          5
-        ],
-        [
-          4,
-          5,
-          6
-        ]
-      ],
-      [
-        [
-          1,
-          1,
-          1
-        ],
-        [
-          1,
-          1,
-          1
-        ],
-        [
-          1,
-          2,
-          2
-        ],
-        [
-          2,
-          3,
-          2
-        ],
-        [
-          2,
-          3,
-          3
-        ]
-      ]
-    ],
-    "startingResources": [
-      18,
-      24,
-      0,
-      7
-    ],
-    "mapSpecificRules": "The power plant market is restricted, and the rules for removing old plants are changed.\n",
-    "deckBuild": {
-      "recharged": "plants 6 and 14 are removed from the game. The market has 6 plants (3 current, 3 future) drawn at random from the low plants; the six undrawn low plants sit shuffled on top of the deck. Removal by player count (higher plants only): 2 players remove 6, 3 players remove 8, 4 players remove 4.",
-      "original": "plants 6 and 14 are removed from the game; the market is 3, 4, 5 / 7, 8, 9. Plant 13 goes on top of the deck, then five shuffled cards (plants 10, 11 and the top three of the deck), then the rest, with the Step 3 card on the bottom."
+        "startingResources": [18, 24, 0, 7],
+        "mapSpecificRules": "The power plant market is restricted, and the rules for removing old plants are changed.\n",
+        "deckBuild": {
+            "recharged": "plants 6 and 14 are removed from the game. The market has 6 plants (3 current, 3 future) drawn at random from the low plants; the six undrawn low plants sit shuffled on top of the deck. Removal by player count (higher plants only): 2 players remove 6, 3 players remove 8, 4 players remove 4.",
+            "original": "plants 6 and 14 are removed from the game; the market is 3, 4, 5 / 7, 8, 9. Plant 13 goes on top of the deck, then five shuffled cards (plants 10, 11 and the top three of the deck), then the rest, with the Step 3 card on the bottom."
+        },
+        "viewBox": [1465, 860],
+        "playerOrderPosition": [1160, 140],
+        "cityCountPosition": [0, 0],
+        "powerPlantMarketPosition": [745, 0],
+        "actualMarketWidth": 430,
+        "mapPosition": [-10, 0],
+        "buttonsPosition": [1305, 0],
+        "playerBoardsPosition": [1105, 200],
+        "roundInfoPosition": [20, 590],
+        "supplyPosition": [0, 720]
     },
-    "viewBox": [
-      1465,
-      860
-    ],
-    "playerOrderPosition": [
-      1160,
-      140
-    ],
-    "cityCountPosition": [
-      0,
-      0
-    ],
-    "powerPlantMarketPosition": [
-      745,
-      0
-    ],
-    "actualMarketWidth": 430,
-    "mapPosition": [
-      -10,
-      0
-    ],
-    "buttonsPosition": [
-      1305,
-      0
-    ],
-    "playerBoardsPosition": [
-      1105,
-      200
-    ],
-    "roundInfoPosition": [
-      20,
-      590
-    ],
-    "supplyPosition": [
-      0,
-      720
-    ]
-  },
-  "players": [
-    {
-      "id": 0,
-      "powerPlants": [
+    "players": [
         {
-          "number": 5,
-          "type": 4,
-          "cost": 2,
-          "citiesPowered": 1
+            "id": 0,
+            "powerPlants": [
+                {
+                    "number": 5,
+                    "type": 4,
+                    "cost": 2,
+                    "citiesPowered": 1
+                },
+                {
+                    "number": 31,
+                    "type": 0,
+                    "cost": 3,
+                    "citiesPowered": 6
+                },
+                {
+                    "number": 25,
+                    "type": 0,
+                    "cost": 2,
+                    "citiesPowered": 5
+                }
+            ],
+            "coalCapacity": 10,
+            "coalLeft": 1,
+            "oilCapacity": 0,
+            "oilLeft": 2,
+            "garbageCapacity": 0,
+            "garbageLeft": 0,
+            "uraniumCapacity": 0,
+            "uraniumLeft": 0,
+            "hybridCapacity": 4,
+            "hybridLeft": 0,
+            "money": 0,
+            "housesLeft": 22,
+            "cities": [
+                {
+                    "name": "Chelyabinsk",
+                    "position": 0
+                },
+                {
+                    "name": "Yekaterinburg",
+                    "position": 0
+                },
+                {
+                    "name": "Tyumen",
+                    "position": 0
+                },
+                {
+                    "name": "Ufa",
+                    "position": 0
+                },
+                {
+                    "name": "Omsk",
+                    "position": 0
+                },
+                {
+                    "name": "Perm",
+                    "position": 1
+                },
+                {
+                    "name": "Novosibirsk",
+                    "position": 0
+                },
+                {
+                    "name": "Tomsk",
+                    "position": 0
+                }
+            ],
+            "powerPlantsNotUsed": [31, 25],
+            "availableMoves": null,
+            "lastMove": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504460
+            },
+            "isDropped": false,
+            "isAI": false,
+            "bid": 0,
+            "passed": true,
+            "skipAuction": false,
+            "citiesPowered": 1,
+            "resourcesUsed": [],
+            "totalIncome": 304,
+            "totalSpentCities": 85,
+            "totalSpentConnections": 42,
+            "totalSpentPlants": 61,
+            "totalSpentResources": 166,
+            "usedFreeJump": false,
+            "totalTimeUsed": 7
         },
         {
-          "number": 31,
-          "type": 0,
-          "cost": 3,
-          "citiesPowered": 6
+            "id": 1,
+            "powerPlants": [
+                {
+                    "number": 11,
+                    "type": 3,
+                    "cost": 1,
+                    "citiesPowered": 2
+                },
+                {
+                    "number": 28,
+                    "type": 3,
+                    "cost": 1,
+                    "citiesPowered": 4
+                },
+                {
+                    "number": 46,
+                    "type": 4,
+                    "cost": 3,
+                    "citiesPowered": 7
+                }
+            ],
+            "coalCapacity": 0,
+            "coalLeft": 3,
+            "oilCapacity": 0,
+            "oilLeft": 1,
+            "garbageCapacity": 0,
+            "garbageLeft": 0,
+            "uraniumCapacity": 4,
+            "uraniumLeft": 0,
+            "hybridCapacity": 6,
+            "hybridLeft": 0,
+            "money": 0,
+            "housesLeft": 22,
+            "cities": [
+                {
+                    "name": "Cheboksary",
+                    "position": 0
+                },
+                {
+                    "name": "Kazan",
+                    "position": 0
+                },
+                {
+                    "name": "Naberezhnye Chelny",
+                    "position": 0
+                },
+                {
+                    "name": "Samara",
+                    "position": 0
+                },
+                {
+                    "name": "Ulyanovsk",
+                    "position": 1
+                },
+                {
+                    "name": "Ufa",
+                    "position": 1
+                },
+                {
+                    "name": "Kirov",
+                    "position": 1
+                }
+            ],
+            "powerPlantsNotUsed": [11, 28, 46],
+            "availableMoves": null,
+            "lastMove": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "isDropped": false,
+            "isAI": false,
+            "bid": 0,
+            "passed": true,
+            "skipAuction": false,
+            "citiesPowered": 7,
+            "resourcesUsed": [],
+            "totalIncome": 333,
+            "totalSpentCities": 85,
+            "totalSpentConnections": 21,
+            "totalSpentPlants": 99,
+            "totalSpentResources": 178,
+            "usedFreeJump": false,
+            "totalTimeUsed": 3
         },
         {
-          "number": 25,
-          "type": 0,
-          "cost": 2,
-          "citiesPowered": 5
+            "id": 2,
+            "powerPlants": [
+                {
+                    "number": 37,
+                    "type": 5,
+                    "cost": 0,
+                    "citiesPowered": 4
+                },
+                {
+                    "number": 42,
+                    "type": 0,
+                    "cost": 2,
+                    "citiesPowered": 6
+                },
+                {
+                    "number": 44,
+                    "type": 5,
+                    "cost": 0,
+                    "citiesPowered": 5
+                }
+            ],
+            "coalCapacity": 4,
+            "coalLeft": 2,
+            "oilCapacity": 0,
+            "oilLeft": 0,
+            "garbageCapacity": 0,
+            "garbageLeft": 0,
+            "uraniumCapacity": 0,
+            "uraniumLeft": 0,
+            "hybridCapacity": 0,
+            "hybridLeft": 0,
+            "money": 9,
+            "housesLeft": 22,
+            "cities": [
+                {
+                    "name": "Syktyvkar",
+                    "position": 0
+                },
+                {
+                    "name": "Kirov",
+                    "position": 0
+                },
+                {
+                    "name": "Perm",
+                    "position": 0
+                },
+                {
+                    "name": "Ulyanovsk",
+                    "position": 0
+                },
+                {
+                    "name": "Orenburg",
+                    "position": 0
+                },
+                {
+                    "name": "Arkhangelsk",
+                    "position": 0
+                },
+                {
+                    "name": "Murmansk",
+                    "position": 0
+                },
+                {
+                    "name": "Surgut",
+                    "position": 0
+                },
+                {
+                    "name": "Samara",
+                    "position": 1
+                },
+                {
+                    "name": "Kazan",
+                    "position": 1
+                },
+                {
+                    "name": "Cheboksary",
+                    "position": 1
+                },
+                {
+                    "name": "Naberezhnye Chelny",
+                    "position": 1
+                },
+                {
+                    "name": "Yekaterinburg",
+                    "position": 1
+                },
+                {
+                    "name": "Chelyabinsk",
+                    "position": 1
+                },
+                {
+                    "name": "Tyumen",
+                    "position": 1
+                },
+                {
+                    "name": "Ufa",
+                    "position": 2
+                },
+                {
+                    "name": "Omsk",
+                    "position": 1
+                }
+            ],
+            "powerPlantsNotUsed": [42],
+            "availableMoves": null,
+            "lastMove": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504460
+            },
+            "isDropped": false,
+            "isAI": false,
+            "bid": 0,
+            "passed": true,
+            "skipAuction": false,
+            "citiesPowered": 15,
+            "resourcesUsed": [],
+            "totalIncome": 476,
+            "totalSpentCities": 220,
+            "totalSpentConnections": 111,
+            "totalSpentPlants": 143,
+            "totalSpentResources": 43,
+            "usedFreeJump": false,
+            "totalTimeUsed": 12
         }
-      ],
-      "coalCapacity": 10,
-      "coalLeft": 1,
-      "oilCapacity": 0,
-      "oilLeft": 2,
-      "garbageCapacity": 0,
-      "garbageLeft": 0,
-      "uraniumCapacity": 0,
-      "uraniumLeft": 0,
-      "hybridCapacity": 4,
-      "hybridLeft": 0,
-      "money": 0,
-      "housesLeft": 22,
-      "cities": [
-        {
-          "name": "Chelyabinsk",
-          "position": 0
-        },
-        {
-          "name": "Yekaterinburg",
-          "position": 0
-        },
-        {
-          "name": "Tyumen",
-          "position": 0
-        },
-        {
-          "name": "Ufa",
-          "position": 0
-        },
-        {
-          "name": "Omsk",
-          "position": 0
-        },
-        {
-          "name": "Perm",
-          "position": 1
-        },
-        {
-          "name": "Novosibirsk",
-          "position": 0
-        },
-        {
-          "name": "Tomsk",
-          "position": 0
-        }
-      ],
-      "powerPlantsNotUsed": [
-        31,
-        25
-      ],
-      "availableMoves": null,
-      "lastMove": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504460
-      },
-      "isDropped": false,
-      "isAI": false,
-      "bid": 0,
-      "passed": true,
-      "skipAuction": false,
-      "citiesPowered": 1,
-      "resourcesUsed": [],
-      "totalIncome": 304,
-      "totalSpentCities": 85,
-      "totalSpentConnections": 42,
-      "totalSpentPlants": 61,
-      "totalSpentResources": 166,
-      "usedFreeJump": false,
-      "totalTimeUsed": 7
+    ],
+    "playerOrder": [2, 0, 1],
+    "currentPlayers": [],
+    "powerPlantsDeck": [],
+    "coalSupply": 18,
+    "oilSupply": 0,
+    "garbageSupply": 0,
+    "uraniumSupply": 0,
+    "coalResupply": [
+        [2, 2, 4],
+        [2, 3, 4],
+        [3, 4, 5],
+        [4, 5, 6],
+        [5, 6, 7]
+    ],
+    "oilResupply": [
+        [3, 4, 3],
+        [3, 4, 3],
+        [5, 6, 4],
+        [5, 7, 5],
+        [7, 9, 6]
+    ],
+    "garbageResupply": [
+        [2, 2, 3],
+        [2, 2, 3],
+        [3, 3, 4],
+        [4, 3, 5],
+        [4, 5, 6]
+    ],
+    "uraniumResupply": [
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 2, 2],
+        [2, 3, 2],
+        [2, 3, 3]
+    ],
+    "coalMarket": 0,
+    "oilMarket": 21,
+    "garbageMarket": 24,
+    "uraniumMarket": 12,
+    "coalPrices": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    "oilPrices": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    "garbagePrices": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8],
+    "uraniumPrices": [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16],
+    "actualMarket": [],
+    "futureMarket": [],
+    "highestBidders": [],
+    "auctioningPlayer": 2,
+    "step": 3,
+    "phase": "Game End",
+    "options": {
+        "fastBid": false,
+        "map": "Russia",
+        "variant": "original",
+        "showMoney": false,
+        "useNewRechargedSetup": true,
+        "trackTotalSpent": true,
+        "chooseRegions": false,
+        "chooseColors": false
     },
-    {
-      "id": 1,
-      "powerPlants": [
+    "log": [
         {
-          "number": 11,
-          "type": 3,
-          "cost": 1,
-          "citiesPowered": 2
+            "type": "event",
+            "event": "Game Start!"
         },
         {
-          "number": 28,
-          "type": 3,
-          "cost": 1,
-          "citiesPowered": 4
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 3,
+                "time": 1788175504439
+            },
+            "simple": "undefined chooses Power Plant 3 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>3</b> to initiate an auction."
         },
         {
-          "number": 46,
-          "type": 4,
-          "cost": 3,
-          "citiesPowered": 7
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 3,
+                "time": 1788175504440
+            },
+            "simple": "undefined bids $3.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 4,
+                "time": 1788175504440
+            },
+            "simple": "undefined bids $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 5,
+                "time": 1788175504440
+            },
+            "simple": "undefined bids $5.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504440
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 6,
+                "time": 1788175504440
+            },
+            "simple": "undefined bids $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 7,
+                "time": 1788175504440
+            },
+            "simple": "undefined bids $7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504440
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 7.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 13 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 4,
+                "time": 1788175504441
+            },
+            "simple": "undefined chooses Power Plant 4 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>4</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 4,
+                "time": 1788175504441
+            },
+            "simple": "undefined bids $4.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 5,
+                "time": 1788175504441
+            },
+            "simple": "undefined bids $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504441
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 50 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 5,
+                "time": 1788175504441
+            },
+            "simple": "undefined chooses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>5</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 39 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504441
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504442
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504442
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined buys oil for $2.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504442
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Syktyvkar",
+                    "price": 10
+                },
+                "time": 1788175504442
+            },
+            "simple": "undefined builds on Syktyvkar for $10.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Syktyvkar</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Kirov",
+                    "price": 16
+                },
+                "time": 1788175504446
+            },
+            "simple": "undefined builds on Kirov for $16.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kirov</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504446
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Cheboksary",
+                    "price": 10
+                },
+                "time": 1788175504446
+            },
+            "simple": "undefined builds on Cheboksary for $10.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Cheboksary</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504446
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Chelyabinsk",
+                    "price": 10
+                },
+                "time": 1788175504447
+            },
+            "simple": "undefined builds on Chelyabinsk for $10.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Chelyabinsk</b> for <span style=\"color: green\">$10</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504447
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504447
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504447
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504447
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504447
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504447
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504447
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [2, 2, 2, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 50 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 10 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504447
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (7)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 12 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504447
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 8,
+                "time": 1788175504448
+            },
+            "simple": "undefined chooses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>8</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 11 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $3.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504448
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504448
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined buys oil for $2.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504448
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Kazan",
+                    "price": 12
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined builds on Kazan for $12.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kazan</b> for <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504448
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Yekaterinburg",
+                    "price": 13
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined builds on Yekaterinburg for $13.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Yekaterinburg</b> for <span style=\"color: green\">$13</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504448
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Perm",
+                    "price": 16
+                },
+                "time": 1788175504448
+            },
+            "simple": "undefined builds on Perm for $16.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Perm</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 8,
+                    "resourcesSpent": ["coal", "coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined uses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [2, 2, 2, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 39 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 25 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (9)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 18 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys coal for $5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined buys oil for $2.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tyumen",
+                    "price": 15
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined builds on Tyumen for $15.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tyumen</b> for <span style=\"color: green\">$15</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Naberezhnye Chelny",
+                    "price": 13
+                },
+                "time": 1788175504449
+            },
+            "simple": "undefined builds on Naberezhnye Chelny for $13.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Naberezhnye Chelny</b> for <span style=\"color: green\">$13</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504449
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Ulyanovsk",
+                    "price": 18
+                },
+                "time": 1788175504450
+            },
+            "simple": "undefined builds on Ulyanovsk for $18.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ulyanovsk</b> for <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504450
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504450
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504450
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504450
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504450
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504450
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504450
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [2, 2, 2, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 25 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 38 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 11,
+                "time": 1788175504451
+            },
+            "simple": "undefined chooses Power Plant 11 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>11</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 11,
+                "time": 1788175504451
+            },
+            "simple": "undefined bids $11.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$11</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Bid",
+                "data": 12,
+                "time": 1788175504451
+            },
+            "simple": "undefined bids $12.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 12.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$12</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 42 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (10)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 35 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504451
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504451
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504451
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504451
+            },
+            "simple": "undefined buys oil for $2.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504451
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Ufa",
+                    "price": 16
+                },
+                "time": 1788175504451
+            },
+            "simple": "undefined builds on Ufa for $16.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$16</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Samara",
+                    "price": 14
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined builds on Samara for $14.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Samara</b> for <span style=\"color: green\">$14</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Orenburg",
+                    "price": 19
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined builds on Orenburg for $19.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Orenburg</b> for <span style=\"color: green\">$19</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [2, 2, 2, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 42 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 32 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (12)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 31 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 31,
+                "time": 1788175504452
+            },
+            "simple": "undefined chooses Power Plant 31.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>31</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 31.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$31</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 16 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined buys oil for $2.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Arkhangelsk",
+                    "price": 20
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined builds on Arkhangelsk for $20.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Arkhangelsk</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504452
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504452
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [2, 3, 2, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 38 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 19 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 13,
+                "time": 1788175504453
+            },
+            "simple": "undefined chooses Power Plant 13 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>13</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 13,
+                "time": 1788175504453
+            },
+            "simple": "undefined bids $13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$13</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$13</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 27 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (16)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 33 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Omsk",
+                    "price": 19
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined builds on Omsk for $19.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Omsk</b> for <span style=\"color: green\">$19</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [2, 3, 2, 0]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 35 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 28 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (18)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 26 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504453
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504453
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Murmansk",
+                    "price": 25
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined builds on Murmansk for $25.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Murmansk</b> for <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Surgut",
+                    "price": 30
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined builds on Surgut for $30.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Surgut</b> for <span style=\"color: green\">$30</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Starting Step 2, Power Plant 19 discarded."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 36 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [3, 2, 2, 0]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 36 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 15 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (15)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 34 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined buys coal for $6.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Ulyanovsk",
+                    "price": 18
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined builds on Ulyanovsk for $18.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ulyanovsk</b> for <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Samara",
+                    "price": 18
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined builds on Samara for $18.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Samara</b> for <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504454
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504454
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 4,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined uses Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 8,
+                    "resourcesSpent": ["coal", "coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined uses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [3, 2, 2, 0]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 34 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 46 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (26)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 24 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 28,
+                "time": 1788175504455
+            },
+            "simple": "undefined chooses Power Plant 28.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>28</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 28.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$28</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 4,
+                "time": 1788175504455
+            },
+            "simple": "undefined discards Power Plant 4.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>4</b>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 44 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Kazan",
+                    "price": 18
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined builds on Kazan for $18.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kazan</b> for <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504455
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [3, 2, 2, 0]."
+        },
+        {
+            "type": "event",
+            "event": "Putting Power Plant 46 on the bottom of the deck."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 37 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (24)."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504455
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Starting Step 3, Power Plant 27 discarded."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504456
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504456
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504456
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504456
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504456
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Cheboksary",
+                    "price": 17
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined builds on Cheboksary for $17.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Cheboksary</b> for <span style=\"color: green\">$17</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Naberezhnye Chelny",
+                    "price": 18
+                },
+                "time": 1788175504456
+            },
+            "simple": "undefined builds on Naberezhnye Chelny for $18.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Naberezhnye Chelny</b> for <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [4, 2, 3, 0]."
+        },
+        {
+            "type": "event",
+            "event": "Discarding Power Plant 32."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 34 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 37,
+                "time": 1788175504457
+            },
+            "simple": "undefined chooses Power Plant 37 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>37</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 37,
+                "time": 1788175504457
+            },
+            "simple": "undefined bids $37.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$37</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 37.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$37</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 46 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (33)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 38 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504457
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504457
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 37,
+                    "resourcesSpent": [],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined uses Power Plant 37.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 31,
+                    "resourcesSpent": ["coal", "coal", "coal"],
+                    "citiesPowered": 6
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined uses Power Plant 31.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>31</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 8,
+                    "resourcesSpent": ["coal", "coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined uses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [4, 0, 3, 0]."
+        },
+        {
+            "type": "event",
+            "event": "Discarding Power Plant 34."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 39 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (38)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 25 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 25,
+                "time": 1788175504458
+            },
+            "simple": "undefined chooses Power Plant 25 to initiate an auction.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>25</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Bid",
+                "data": 25,
+                "time": 1788175504458
+            },
+            "simple": "undefined bids $25.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 25.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$25</span>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 42 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys uranium for $1.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "uranium"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys uranium for $2.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined buys oil for $2.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Ufa",
+                    "price": 19
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined builds on Ufa for $19.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$19</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Perm",
+                    "price": 20
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined builds on Perm for $20.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Perm</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504458
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Yekaterinburg",
+                    "price": 20
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined builds on Yekaterinburg for $20.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Yekaterinburg</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Chelyabinsk",
+                    "price": 18
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined builds on Chelyabinsk for $18.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Chelyabinsk</b> for <span style=\"color: green\">$18</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tyumen",
+                    "price": 20
+                },
+                "time": 1788175504458
+            },
+            "simple": "undefined builds on Tyumen for $20.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tyumen</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 3,
+                    "resourcesSpent": ["oil", "oil"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 37,
+                    "resourcesSpent": [],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 37.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 8,
+                    "resourcesSpent": ["coal", "coal", "coal"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 11,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 2
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 11.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>11</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 28,
+                    "resourcesSpent": ["uranium"],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 28.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>28</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [4, 2, 0, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Discarding Power Plant 39."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 50 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 42,
+                "time": 1788175504459
+            },
+            "simple": "undefined chooses Power Plant 42 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>42</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 42,
+                "time": 1788175504459
+            },
+            "simple": "undefined bids $42.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$42</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 42.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$42</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 3,
+                "time": 1788175504459
+            },
+            "simple": "undefined discards Power Plant 3.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>3</b>."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 36 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (36)."
+        },
+        {
+            "type": "event",
+            "event": "Power Plant 35 drawn from the deck."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 46,
+                "time": 1788175504459
+            },
+            "simple": "undefined chooses Power Plant 46.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>46</b>."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 46.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$46</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 8,
+                "time": 1788175504459
+            },
+            "simple": "undefined discards Power Plant 8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>8</b>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Novosibirsk",
+                    "price": 20
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined builds on Novosibirsk for $20.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Novosibirsk</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Ufa",
+                    "price": 24
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined builds on Ufa for $24.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$24</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 13,
+                    "resourcesSpent": [],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 37,
+                    "resourcesSpent": [],
+                    "citiesPowered": 4
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 37.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "UsePowerPlant",
+                "data": {
+                    "powerPlant": 5,
+                    "resourcesSpent": ["coal", "coal"],
+                    "citiesPowered": 1
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined uses Power Plant 5.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Resupplying resources: [4, 0, 0, 1]."
+        },
+        {
+            "type": "event",
+            "event": "Discarding Power Plant 35."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "ChoosePowerPlant",
+                "data": 44,
+                "time": 1788175504459
+            },
+            "simple": "undefined chooses Power Plant 44 to initiate an auction.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>44</b> to initiate an auction."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Bid",
+                "data": 44,
+                "time": 1788175504459
+            },
+            "simple": "undefined bids $44.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$44</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "undefined wins the bid and pays 44.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$44</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "DiscardPowerPlant",
+                "data": 13,
+                "time": 1788175504459
+            },
+            "simple": "undefined discards Power Plant 13.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>13</b>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "First pass, removing lowest numbered Power Plant (50)."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $7.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "oil"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys oil for $1.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "BuyResource",
+                "data": {
+                    "resource": "coal"
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined buys coal for $8.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Kirov",
+                    "price": 20
+                },
+                "time": 1788175504459
+            },
+            "simple": "undefined builds on Kirov for $20.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kirov</b> for <span style=\"color: green\">$20</span>."
+        },
+        {
+            "type": "move",
+            "player": 1,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504459
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Tomsk",
+                    "price": 14
+                },
+                "time": 1788175504460
+            },
+            "simple": "undefined builds on Tomsk for $14.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tomsk</b> for <span style=\"color: green\">$14</span>."
+        },
+        {
+            "type": "move",
+            "player": 0,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504460
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Build",
+                "data": {
+                    "name": "Omsk",
+                    "price": 24
+                },
+                "time": 1788175504460
+            },
+            "simple": "undefined builds on Omsk for $24.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Omsk</b> for <span style=\"color: green\">$24</span>."
+        },
+        {
+            "type": "move",
+            "player": 2,
+            "move": {
+                "name": "Pass",
+                "data": true,
+                "time": 1788175504460
+            },
+            "simple": "undefined passes.",
+            "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+        },
+        {
+            "type": "event",
+            "event": "Game Ended!"
         }
-      ],
-      "coalCapacity": 0,
-      "coalLeft": 3,
-      "oilCapacity": 0,
-      "oilLeft": 1,
-      "garbageCapacity": 0,
-      "garbageLeft": 0,
-      "uraniumCapacity": 4,
-      "uraniumLeft": 0,
-      "hybridCapacity": 6,
-      "hybridLeft": 0,
-      "money": 0,
-      "housesLeft": 22,
-      "cities": [
-        {
-          "name": "Cheboksary",
-          "position": 0
-        },
-        {
-          "name": "Kazan",
-          "position": 0
-        },
-        {
-          "name": "Naberezhnye Chelny",
-          "position": 0
-        },
-        {
-          "name": "Samara",
-          "position": 0
-        },
-        {
-          "name": "Ulyanovsk",
-          "position": 1
-        },
-        {
-          "name": "Ufa",
-          "position": 1
-        },
-        {
-          "name": "Kirov",
-          "position": 1
-        }
-      ],
-      "powerPlantsNotUsed": [
-        11,
-        28,
-        46
-      ],
-      "availableMoves": null,
-      "lastMove": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "isDropped": false,
-      "isAI": false,
-      "bid": 0,
-      "passed": true,
-      "skipAuction": false,
-      "citiesPowered": 7,
-      "resourcesUsed": [],
-      "totalIncome": 333,
-      "totalSpentCities": 85,
-      "totalSpentConnections": 21,
-      "totalSpentPlants": 99,
-      "totalSpentResources": 178,
-      "usedFreeJump": false,
-      "totalTimeUsed": 3
-    },
-    {
-      "id": 2,
-      "powerPlants": [
-        {
-          "number": 37,
-          "type": 5,
-          "cost": 0,
-          "citiesPowered": 4
-        },
-        {
-          "number": 42,
-          "type": 0,
-          "cost": 2,
-          "citiesPowered": 6
-        },
-        {
-          "number": 44,
-          "type": 5,
-          "cost": 0,
-          "citiesPowered": 5
-        }
-      ],
-      "coalCapacity": 4,
-      "coalLeft": 2,
-      "oilCapacity": 0,
-      "oilLeft": 0,
-      "garbageCapacity": 0,
-      "garbageLeft": 0,
-      "uraniumCapacity": 0,
-      "uraniumLeft": 0,
-      "hybridCapacity": 0,
-      "hybridLeft": 0,
-      "money": 9,
-      "housesLeft": 22,
-      "cities": [
-        {
-          "name": "Syktyvkar",
-          "position": 0
-        },
-        {
-          "name": "Kirov",
-          "position": 0
-        },
-        {
-          "name": "Perm",
-          "position": 0
-        },
-        {
-          "name": "Ulyanovsk",
-          "position": 0
-        },
-        {
-          "name": "Orenburg",
-          "position": 0
-        },
-        {
-          "name": "Arkhangelsk",
-          "position": 0
-        },
-        {
-          "name": "Murmansk",
-          "position": 0
-        },
-        {
-          "name": "Surgut",
-          "position": 0
-        },
-        {
-          "name": "Samara",
-          "position": 1
-        },
-        {
-          "name": "Kazan",
-          "position": 1
-        },
-        {
-          "name": "Cheboksary",
-          "position": 1
-        },
-        {
-          "name": "Naberezhnye Chelny",
-          "position": 1
-        },
-        {
-          "name": "Yekaterinburg",
-          "position": 1
-        },
-        {
-          "name": "Chelyabinsk",
-          "position": 1
-        },
-        {
-          "name": "Tyumen",
-          "position": 1
-        },
-        {
-          "name": "Ufa",
-          "position": 2
-        },
-        {
-          "name": "Omsk",
-          "position": 1
-        }
-      ],
-      "powerPlantsNotUsed": [
-        42
-      ],
-      "availableMoves": null,
-      "lastMove": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504460
-      },
-      "isDropped": false,
-      "isAI": false,
-      "bid": 0,
-      "passed": true,
-      "skipAuction": false,
-      "citiesPowered": 15,
-      "resourcesUsed": [],
-      "totalIncome": 476,
-      "totalSpentCities": 220,
-      "totalSpentConnections": 111,
-      "totalSpentPlants": 143,
-      "totalSpentResources": 43,
-      "usedFreeJump": false,
-      "totalTimeUsed": 12
-    }
-  ],
-  "playerOrder": [
-    2,
-    0,
-    1
-  ],
-  "currentPlayers": [],
-  "powerPlantsDeck": [],
-  "coalSupply": 18,
-  "oilSupply": 0,
-  "garbageSupply": 0,
-  "uraniumSupply": 0,
-  "coalResupply": [
-    [
-      2,
-      2,
-      4
     ],
-    [
-      2,
-      3,
-      4
+    "hiddenLog": [],
+    "seed": "replay-russia-fixture",
+    "round": 14,
+    "newTurn": true,
+    "auctionSkips": 2,
+    "citiesToStep2": 7,
+    "citiesToEndGame": 17,
+    "resourceResupply": ["[2, 3, 2, 1]", "[3, 4, 2, 1]", "[4, 3, 3, 1]"],
+    "paymentTable": [
+        10, 22, 33, 44, 54, 64, 73, 82, 90, 98, 105, 112, 118, 124, 129, 134, 138, 142, 145, 148, 150, 150
     ],
-    [
-      3,
-      4,
-      5
-    ],
-    [
-      4,
-      5,
-      6
-    ],
-    [
-      5,
-      6,
-      7
-    ]
-  ],
-  "oilResupply": [
-    [
-      3,
-      4,
-      3
-    ],
-    [
-      3,
-      4,
-      3
-    ],
-    [
-      5,
-      6,
-      4
-    ],
-    [
-      5,
-      7,
-      5
-    ],
-    [
-      7,
-      9,
-      6
-    ]
-  ],
-  "garbageResupply": [
-    [
-      2,
-      2,
-      3
-    ],
-    [
-      2,
-      2,
-      3
-    ],
-    [
-      3,
-      3,
-      4
-    ],
-    [
-      4,
-      3,
-      5
-    ],
-    [
-      4,
-      5,
-      6
-    ]
-  ],
-  "uraniumResupply": [
-    [
-      1,
-      1,
-      1
-    ],
-    [
-      1,
-      1,
-      1
-    ],
-    [
-      1,
-      2,
-      2
-    ],
-    [
-      2,
-      3,
-      2
-    ],
-    [
-      2,
-      3,
-      3
-    ]
-  ],
-  "coalMarket": 0,
-  "oilMarket": 21,
-  "garbageMarket": 24,
-  "uraniumMarket": 12,
-  "coalPrices": [
-    1,
-    1,
-    1,
-    2,
-    2,
-    2,
-    3,
-    3,
-    3,
-    4,
-    4,
-    4,
-    5,
-    5,
-    5,
-    6,
-    6,
-    6,
-    7,
-    7,
-    7,
-    8,
-    8,
-    8
-  ],
-  "oilPrices": [
-    1,
-    1,
-    1,
-    2,
-    2,
-    2,
-    3,
-    3,
-    3,
-    4,
-    4,
-    4,
-    5,
-    5,
-    5,
-    6,
-    6,
-    6,
-    7,
-    7,
-    7,
-    8,
-    8,
-    8
-  ],
-  "garbagePrices": [
-    1,
-    1,
-    1,
-    2,
-    2,
-    2,
-    3,
-    3,
-    3,
-    4,
-    4,
-    4,
-    5,
-    5,
-    5,
-    6,
-    6,
-    6,
-    7,
-    7,
-    7,
-    8,
-    8,
-    8
-  ],
-  "uraniumPrices": [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    10,
-    12,
-    14,
-    16
-  ],
-  "actualMarket": [],
-  "futureMarket": [],
-  "highestBidders": [],
-  "auctioningPlayer": 2,
-  "step": 3,
-  "phase": "Game End",
-  "options": {
-    "fastBid": false,
-    "map": "Russia",
     "variant": "original",
-    "showMoney": false,
-    "useNewRechargedSetup": true,
-    "trackTotalSpent": true,
-    "chooseRegions": false,
-    "chooseColors": false
-  },
-  "log": [
-    {
-      "type": "event",
-      "event": "Game Start!"
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 3,
-        "time": 1788175504439
-      },
-      "simple": "undefined chooses Power Plant 3 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>3</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 3,
-        "time": 1788175504440
-      },
-      "simple": "undefined bids $3.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 4,
-        "time": 1788175504440
-      },
-      "simple": "undefined bids $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 5,
-        "time": 1788175504440
-      },
-      "simple": "undefined bids $5.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504440
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 6,
-        "time": 1788175504440
-      },
-      "simple": "undefined bids $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 7,
-        "time": 1788175504440
-      },
-      "simple": "undefined bids $7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504440
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 7.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 13 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 4,
-        "time": 1788175504441
-      },
-      "simple": "undefined chooses Power Plant 4 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>4</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 4,
-        "time": 1788175504441
-      },
-      "simple": "undefined bids $4.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 5,
-        "time": 1788175504441
-      },
-      "simple": "undefined bids $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504441
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 50 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 5,
-        "time": 1788175504441
-      },
-      "simple": "undefined chooses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>5</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 39 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504441
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504442
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504442
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined buys oil for $2.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504442
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Syktyvkar",
-          "price": 10
-        },
-        "time": 1788175504442
-      },
-      "simple": "undefined builds on Syktyvkar for $10.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Syktyvkar</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Kirov",
-          "price": 16
-        },
-        "time": 1788175504446
-      },
-      "simple": "undefined builds on Kirov for $16.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kirov</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504446
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Cheboksary",
-          "price": 10
-        },
-        "time": 1788175504446
-      },
-      "simple": "undefined builds on Cheboksary for $10.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Cheboksary</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504446
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Chelyabinsk",
-          "price": 10
-        },
-        "time": 1788175504447
-      },
-      "simple": "undefined builds on Chelyabinsk for $10.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Chelyabinsk</b> for <span style=\"color: green\">$10</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504447
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504447
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504447
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504447
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504447
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504447
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504447
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [2, 2, 2, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 50 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 10 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504447
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (7)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 12 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504447
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 8,
-        "time": 1788175504448
-      },
-      "simple": "undefined chooses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>8</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 11 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $3.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504448
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504448
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined buys oil for $2.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504448
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Kazan",
-          "price": 12
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined builds on Kazan for $12.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kazan</b> for <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504448
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Yekaterinburg",
-          "price": 13
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined builds on Yekaterinburg for $13.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Yekaterinburg</b> for <span style=\"color: green\">$13</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504448
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Perm",
-          "price": 16
-        },
-        "time": 1788175504448
-      },
-      "simple": "undefined builds on Perm for $16.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Perm</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 8,
-          "resourcesSpent": [
-            "coal",
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined uses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [2, 2, 2, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 39 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 25 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (9)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 18 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys coal for $5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined buys oil for $2.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tyumen",
-          "price": 15
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined builds on Tyumen for $15.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tyumen</b> for <span style=\"color: green\">$15</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Naberezhnye Chelny",
-          "price": 13
-        },
-        "time": 1788175504449
-      },
-      "simple": "undefined builds on Naberezhnye Chelny for $13.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Naberezhnye Chelny</b> for <span style=\"color: green\">$13</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504449
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Ulyanovsk",
-          "price": 18
-        },
-        "time": 1788175504450
-      },
-      "simple": "undefined builds on Ulyanovsk for $18.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ulyanovsk</b> for <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504450
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504450
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504450
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504450
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504450
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504450
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504450
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [2, 2, 2, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 25 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 38 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 11,
-        "time": 1788175504451
-      },
-      "simple": "undefined chooses Power Plant 11 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>11</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 11,
-        "time": 1788175504451
-      },
-      "simple": "undefined bids $11.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$11</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Bid",
-        "data": 12,
-        "time": 1788175504451
-      },
-      "simple": "undefined bids $12.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 12.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$12</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 42 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (10)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 35 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504451
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504451
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504451
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504451
-      },
-      "simple": "undefined buys oil for $2.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504451
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Ufa",
-          "price": 16
-        },
-        "time": 1788175504451
-      },
-      "simple": "undefined builds on Ufa for $16.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$16</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Samara",
-          "price": 14
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined builds on Samara for $14.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Samara</b> for <span style=\"color: green\">$14</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Orenburg",
-          "price": 19
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined builds on Orenburg for $19.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Orenburg</b> for <span style=\"color: green\">$19</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [2, 2, 2, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 42 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 32 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (12)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 31 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 31,
-        "time": 1788175504452
-      },
-      "simple": "undefined chooses Power Plant 31.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>31</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 31.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$31</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 16 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined buys oil for $2.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Arkhangelsk",
-          "price": 20
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined builds on Arkhangelsk for $20.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Arkhangelsk</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504452
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504452
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [2, 3, 2, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 38 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 19 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 13,
-        "time": 1788175504453
-      },
-      "simple": "undefined chooses Power Plant 13 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>13</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 13,
-        "time": 1788175504453
-      },
-      "simple": "undefined bids $13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$13</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$13</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 27 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (16)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 33 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Omsk",
-          "price": 19
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined builds on Omsk for $19.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Omsk</b> for <span style=\"color: green\">$19</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [2, 3, 2, 0]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 35 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 28 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (18)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 26 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504453
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504453
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Murmansk",
-          "price": 25
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined builds on Murmansk for $25.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Murmansk</b> for <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Surgut",
-          "price": 30
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined builds on Surgut for $30.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Surgut</b> for <span style=\"color: green\">$30</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Starting Step 2, Power Plant 19 discarded."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 36 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [3, 2, 2, 0]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 36 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 15 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (15)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 34 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined buys coal for $6.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Ulyanovsk",
-          "price": 18
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined builds on Ulyanovsk for $18.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ulyanovsk</b> for <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Samara",
-          "price": 18
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined builds on Samara for $18.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Samara</b> for <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504454
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504454
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 4,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined uses Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 8,
-          "resourcesSpent": [
-            "coal",
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined uses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [3, 2, 2, 0]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 34 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 46 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (26)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 24 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 28,
-        "time": 1788175504455
-      },
-      "simple": "undefined chooses Power Plant 28.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>28</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 28.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$28</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 4,
-        "time": 1788175504455
-      },
-      "simple": "undefined discards Power Plant 4.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>4</b>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 44 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Kazan",
-          "price": 18
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined builds on Kazan for $18.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kazan</b> for <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504455
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [3, 2, 2, 0]."
-    },
-    {
-      "type": "event",
-      "event": "Putting Power Plant 46 on the bottom of the deck."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 37 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (24)."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504455
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Starting Step 3, Power Plant 27 discarded."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504456
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504456
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504456
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504456
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504456
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Cheboksary",
-          "price": 17
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined builds on Cheboksary for $17.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Cheboksary</b> for <span style=\"color: green\">$17</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Naberezhnye Chelny",
-          "price": 18
-        },
-        "time": 1788175504456
-      },
-      "simple": "undefined builds on Naberezhnye Chelny for $18.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Naberezhnye Chelny</b> for <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [4, 2, 3, 0]."
-    },
-    {
-      "type": "event",
-      "event": "Discarding Power Plant 32."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 34 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 37,
-        "time": 1788175504457
-      },
-      "simple": "undefined chooses Power Plant 37 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>37</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 37,
-        "time": 1788175504457
-      },
-      "simple": "undefined bids $37.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$37</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 37.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$37</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 46 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (33)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 38 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504457
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504457
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 37,
-          "resourcesSpent": [],
-          "citiesPowered": 4
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined uses Power Plant 37.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 31,
-          "resourcesSpent": [
-            "coal",
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 6
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined uses Power Plant 31.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>31</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 8,
-          "resourcesSpent": [
-            "coal",
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined uses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [4, 0, 3, 0]."
-    },
-    {
-      "type": "event",
-      "event": "Discarding Power Plant 34."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 39 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (38)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 25 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 25,
-        "time": 1788175504458
-      },
-      "simple": "undefined chooses Power Plant 25 to initiate an auction.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>25</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Bid",
-        "data": 25,
-        "time": 1788175504458
-      },
-      "simple": "undefined bids $25.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 25.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$25</span>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 42 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys uranium for $1.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "uranium"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys uranium for $2.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined buys oil for $2.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Ufa",
-          "price": 19
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined builds on Ufa for $19.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$19</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Perm",
-          "price": 20
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined builds on Perm for $20.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Perm</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504458
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Yekaterinburg",
-          "price": 20
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined builds on Yekaterinburg for $20.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Yekaterinburg</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Chelyabinsk",
-          "price": 18
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined builds on Chelyabinsk for $18.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Chelyabinsk</b> for <span style=\"color: green\">$18</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tyumen",
-          "price": 20
-        },
-        "time": 1788175504458
-      },
-      "simple": "undefined builds on Tyumen for $20.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tyumen</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 3,
-          "resourcesSpent": [
-            "oil",
-            "oil"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 37,
-          "resourcesSpent": [],
-          "citiesPowered": 4
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 37.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 8,
-          "resourcesSpent": [
-            "coal",
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 11,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 2
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 11.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>11</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 28,
-          "resourcesSpent": [
-            "uranium"
-          ],
-          "citiesPowered": 4
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 28.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>28</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [4, 2, 0, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Discarding Power Plant 39."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 50 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 42,
-        "time": 1788175504459
-      },
-      "simple": "undefined chooses Power Plant 42 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>42</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 42,
-        "time": 1788175504459
-      },
-      "simple": "undefined bids $42.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$42</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 42.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$42</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 3,
-        "time": 1788175504459
-      },
-      "simple": "undefined discards Power Plant 3.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>3</b>."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 36 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (36)."
-    },
-    {
-      "type": "event",
-      "event": "Power Plant 35 drawn from the deck."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 46,
-        "time": 1788175504459
-      },
-      "simple": "undefined chooses Power Plant 46.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>46</b>."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 46.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$46</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 8,
-        "time": 1788175504459
-      },
-      "simple": "undefined discards Power Plant 8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>8</b>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Novosibirsk",
-          "price": 20
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined builds on Novosibirsk for $20.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Novosibirsk</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Ufa",
-          "price": 24
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined builds on Ufa for $24.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$24</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 13,
-          "resourcesSpent": [],
-          "citiesPowered": 1
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 37,
-          "resourcesSpent": [],
-          "citiesPowered": 4
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 37.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "UsePowerPlant",
-        "data": {
-          "powerPlant": 5,
-          "resourcesSpent": [
-            "coal",
-            "coal"
-          ],
-          "citiesPowered": 1
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined uses Power Plant 5.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Resupplying resources: [4, 0, 0, 1]."
-    },
-    {
-      "type": "event",
-      "event": "Discarding Power Plant 35."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "ChoosePowerPlant",
-        "data": 44,
-        "time": 1788175504459
-      },
-      "simple": "undefined chooses Power Plant 44 to initiate an auction.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>44</b> to initiate an auction."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Bid",
-        "data": 44,
-        "time": 1788175504459
-      },
-      "simple": "undefined bids $44.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$44</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "undefined wins the bid and pays 44.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$44</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "DiscardPowerPlant",
-        "data": 13,
-        "time": 1788175504459
-      },
-      "simple": "undefined discards Power Plant 13.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>13</b>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "First pass, removing lowest numbered Power Plant (50)."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $7.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "oil"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys oil for $1.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "BuyResource",
-        "data": {
-          "resource": "coal"
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined buys coal for $8.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Kirov",
-          "price": 20
-        },
-        "time": 1788175504459
-      },
-      "simple": "undefined builds on Kirov for $20.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kirov</b> for <span style=\"color: green\">$20</span>."
-    },
-    {
-      "type": "move",
-      "player": 1,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504459
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Tomsk",
-          "price": 14
-        },
-        "time": 1788175504460
-      },
-      "simple": "undefined builds on Tomsk for $14.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tomsk</b> for <span style=\"color: green\">$14</span>."
-    },
-    {
-      "type": "move",
-      "player": 0,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504460
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Build",
-        "data": {
-          "name": "Omsk",
-          "price": 24
-        },
-        "time": 1788175504460
-      },
-      "simple": "undefined builds on Omsk for $24.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Omsk</b> for <span style=\"color: green\">$24</span>."
-    },
-    {
-      "type": "move",
-      "player": 2,
-      "move": {
-        "name": "Pass",
-        "data": true,
-        "time": 1788175504460
-      },
-      "simple": "undefined passes.",
-      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
-    },
-    {
-      "type": "event",
-      "event": "Game Ended!"
-    }
-  ],
-  "hiddenLog": [],
-  "seed": "replay-russia-fixture",
-  "round": 14,
-  "newTurn": true,
-  "auctionSkips": 2,
-  "citiesToStep2": 7,
-  "citiesToEndGame": 17,
-  "resourceResupply": [
-    "[2, 3, 2, 1]",
-    "[3, 4, 2, 1]",
-    "[4, 3, 3, 1]"
-  ],
-  "paymentTable": [
-    10,
-    22,
-    33,
-    44,
-    54,
-    64,
-    73,
-    82,
-    90,
-    98,
-    105,
-    112,
-    118,
-    124,
-    129,
-    134,
-    138,
-    142,
-    145,
-    148,
-    150,
-    150
-  ],
-  "variant": "original",
-  "minimunBid": 44,
-  "plantDiscountActive": false,
-  "discardSmallestPlant": false,
-  "cardsLeft": 0,
-  "nextCardWeak": false,
-  "card39Bought": false,
-  "knownPowerPlantDeck": [
-    {
-      "number": 3,
-      "type": 1,
-      "cost": 2,
-      "citiesPowered": 1
-    },
-    {
-      "number": 4,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 1
-    },
-    {
-      "number": 5,
-      "type": 4,
-      "cost": 2,
-      "citiesPowered": 1
-    },
-    {
-      "number": 7,
-      "type": 1,
-      "cost": 3,
-      "citiesPowered": 2
-    },
-    {
-      "number": 8,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 2
-    },
-    {
-      "number": 9,
-      "type": 1,
-      "cost": 1,
-      "citiesPowered": 1
-    },
-    {
-      "number": 13,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 1
-    },
-    {
-      "number": 50,
-      "type": 6,
-      "cost": 0,
-      "citiesPowered": 6
-    },
-    {
-      "number": 39,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 6
-    },
-    {
-      "number": 10,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 2
-    },
-    {
-      "number": 12,
-      "type": 4,
-      "cost": 2,
-      "citiesPowered": 2
-    },
-    {
-      "number": 11,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 2
-    },
-    {
-      "number": 25,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 5
-    },
-    {
-      "number": 18,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 2
-    },
-    {
-      "number": 38,
-      "type": 2,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 42,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 6
-    },
-    {
-      "number": 35,
-      "type": 1,
-      "cost": 1,
-      "citiesPowered": 5
-    },
-    {
-      "number": 32,
-      "type": 1,
-      "cost": 3,
-      "citiesPowered": 6
-    },
-    {
-      "number": 31,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 6
-    },
-    {
-      "number": 16,
-      "type": 1,
-      "cost": 2,
-      "citiesPowered": 3
-    },
-    {
-      "number": 19,
-      "type": 2,
-      "cost": 2,
-      "citiesPowered": 3
-    },
-    {
-      "number": 27,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 3
-    },
-    {
-      "number": 33,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 4
-    },
-    {
-      "number": 28,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 4
-    },
-    {
-      "number": 26,
-      "type": 1,
-      "cost": 2,
-      "citiesPowered": 5
-    },
-    {
-      "number": 36,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 15,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 3
-    },
-    {
-      "number": 34,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 5
-    },
-    {
-      "number": 46,
-      "type": 4,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 24,
-      "type": 2,
-      "cost": 2,
-      "citiesPowered": 4
-    },
-    {
-      "number": 44,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 5
-    },
-    {
-      "number": 37,
-      "type": 5,
-      "cost": 0,
-      "citiesPowered": 4
-    },
-    {
-      "number": 99,
-      "type": 7,
-      "cost": 0,
-      "citiesPowered": 6
-    }
-  ],
-  "knownPowerPlantDeckStep3": [
-    {
-      "number": 34,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 5
-    },
-    {
-      "number": 46,
-      "type": 4,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 38,
-      "type": 2,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 39,
-      "type": 3,
-      "cost": 1,
-      "citiesPowered": 6
-    },
-    {
-      "number": 25,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 5
-    },
-    {
-      "number": 42,
-      "type": 0,
-      "cost": 2,
-      "citiesPowered": 6
-    },
-    {
-      "number": 50,
-      "type": 6,
-      "cost": 0,
-      "citiesPowered": 6
-    },
-    {
-      "number": 36,
-      "type": 0,
-      "cost": 3,
-      "citiesPowered": 7
-    },
-    {
-      "number": 35,
-      "type": 1,
-      "cost": 1,
-      "citiesPowered": 5
-    }
-  ],
-  "pendingMarketRefill": false,
-  "chosenResource": "coal"
+    "minimunBid": 44,
+    "plantDiscountActive": false,
+    "discardSmallestPlant": false,
+    "cardsLeft": 0,
+    "nextCardWeak": false,
+    "card39Bought": false,
+    "knownPowerPlantDeck": [
+        {
+            "number": 3,
+            "type": 1,
+            "cost": 2,
+            "citiesPowered": 1
+        },
+        {
+            "number": 4,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 1
+        },
+        {
+            "number": 5,
+            "type": 4,
+            "cost": 2,
+            "citiesPowered": 1
+        },
+        {
+            "number": 7,
+            "type": 1,
+            "cost": 3,
+            "citiesPowered": 2
+        },
+        {
+            "number": 8,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 2
+        },
+        {
+            "number": 9,
+            "type": 1,
+            "cost": 1,
+            "citiesPowered": 1
+        },
+        {
+            "number": 13,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 1
+        },
+        {
+            "number": 50,
+            "type": 6,
+            "cost": 0,
+            "citiesPowered": 6
+        },
+        {
+            "number": 39,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 6
+        },
+        {
+            "number": 10,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 2
+        },
+        {
+            "number": 12,
+            "type": 4,
+            "cost": 2,
+            "citiesPowered": 2
+        },
+        {
+            "number": 11,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 2
+        },
+        {
+            "number": 25,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 5
+        },
+        {
+            "number": 18,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 2
+        },
+        {
+            "number": 38,
+            "type": 2,
+            "cost": 3,
+            "citiesPowered": 7
+        },
+        {
+            "number": 42,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 6
+        },
+        {
+            "number": 35,
+            "type": 1,
+            "cost": 1,
+            "citiesPowered": 5
+        },
+        {
+            "number": 32,
+            "type": 1,
+            "cost": 3,
+            "citiesPowered": 6
+        },
+        {
+            "number": 31,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 6
+        },
+        {
+            "number": 16,
+            "type": 1,
+            "cost": 2,
+            "citiesPowered": 3
+        },
+        {
+            "number": 19,
+            "type": 2,
+            "cost": 2,
+            "citiesPowered": 3
+        },
+        {
+            "number": 27,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 3
+        },
+        {
+            "number": 33,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 4
+        },
+        {
+            "number": 28,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 4
+        },
+        {
+            "number": 26,
+            "type": 1,
+            "cost": 2,
+            "citiesPowered": 5
+        },
+        {
+            "number": 36,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 7
+        },
+        {
+            "number": 15,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 3
+        },
+        {
+            "number": 34,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 5
+        },
+        {
+            "number": 46,
+            "type": 4,
+            "cost": 3,
+            "citiesPowered": 7
+        },
+        {
+            "number": 24,
+            "type": 2,
+            "cost": 2,
+            "citiesPowered": 4
+        },
+        {
+            "number": 44,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 5
+        },
+        {
+            "number": 37,
+            "type": 5,
+            "cost": 0,
+            "citiesPowered": 4
+        },
+        {
+            "number": 99,
+            "type": 7,
+            "cost": 0,
+            "citiesPowered": 6
+        }
+    ],
+    "knownPowerPlantDeckStep3": [
+        {
+            "number": 34,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 5
+        },
+        {
+            "number": 46,
+            "type": 4,
+            "cost": 3,
+            "citiesPowered": 7
+        },
+        {
+            "number": 38,
+            "type": 2,
+            "cost": 3,
+            "citiesPowered": 7
+        },
+        {
+            "number": 39,
+            "type": 3,
+            "cost": 1,
+            "citiesPowered": 6
+        },
+        {
+            "number": 25,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 5
+        },
+        {
+            "number": 42,
+            "type": 0,
+            "cost": 2,
+            "citiesPowered": 6
+        },
+        {
+            "number": 50,
+            "type": 6,
+            "cost": 0,
+            "citiesPowered": 6
+        },
+        {
+            "number": 36,
+            "type": 0,
+            "cost": 3,
+            "citiesPowered": 7
+        },
+        {
+            "number": 35,
+            "type": 1,
+            "cost": 1,
+            "citiesPowered": 5
+        }
+    ],
+    "pendingMarketRefill": false,
+    "chosenResource": "coal"
 }

--- a/engine/src/fixtures/RussiaStep3.json
+++ b/engine/src/fixtures/RussiaStep3.json
@@ -1,0 +1,6331 @@
+{
+  "map": {
+    "name": "Russia",
+    "cities": [
+      {
+        "name": "Murmansk",
+        "region": "green",
+        "x": 393.5,
+        "y": 87.75
+      },
+      {
+        "name": "Arkhangelsk",
+        "region": "green",
+        "x": 364,
+        "y": 173.75
+      },
+      {
+        "name": "Syktyvkar",
+        "region": "green",
+        "x": 417.25,
+        "y": 251.25
+      },
+      {
+        "name": "Kirov",
+        "region": "green",
+        "x": 364.25,
+        "y": 293
+      },
+      {
+        "name": "Kazan",
+        "region": "green",
+        "x": 344.5,
+        "y": 369.5
+      },
+      {
+        "name": "Cheboksary",
+        "region": "green",
+        "x": 300,
+        "y": 332
+      },
+      {
+        "name": "Ulyanovsk",
+        "region": "green",
+        "x": 221,
+        "y": 362
+      },
+      {
+        "name": "Norilsk",
+        "region": "yellow",
+        "x": 750.25,
+        "y": 214
+      },
+      {
+        "name": "Surgut",
+        "region": "yellow",
+        "x": 587,
+        "y": 352.75
+      },
+      {
+        "name": "Tyumen",
+        "region": "yellow",
+        "x": 515,
+        "y": 406.75
+      },
+      {
+        "name": "Tomsk",
+        "region": "yellow",
+        "x": 693.25,
+        "y": 458.75
+      },
+      {
+        "name": "Novosibirsk",
+        "region": "yellow",
+        "x": 661.75,
+        "y": 501.25
+      },
+      {
+        "name": "Barnaul",
+        "region": "yellow",
+        "x": 665.5,
+        "y": 547.75
+      },
+      {
+        "name": "Omsk",
+        "region": "yellow",
+        "x": 548.75,
+        "y": 489.25
+      },
+      {
+        "name": "Chelyabinsk",
+        "region": "purple",
+        "x": 442,
+        "y": 466.25
+      },
+      {
+        "name": "Ufa",
+        "region": "purple",
+        "x": 368,
+        "y": 476.75
+      },
+      {
+        "name": "Perm",
+        "region": "purple",
+        "x": 422,
+        "y": 347
+      },
+      {
+        "name": "Yekaterinburg",
+        "region": "purple",
+        "x": 439.25,
+        "y": 405
+      },
+      {
+        "name": "Orenburg",
+        "region": "purple",
+        "x": 312.5,
+        "y": 499.25
+      },
+      {
+        "name": "Naberezhnye Chelny",
+        "region": "purple",
+        "x": 356.75,
+        "y": 427.25
+      },
+      {
+        "name": "Samara",
+        "region": "purple",
+        "x": 283,
+        "y": 425.25
+      }
+    ],
+    "connections": [
+      {
+        "nodes": [
+          "Murmansk",
+          "Arkhangelsk"
+        ],
+        "cost": 15
+      },
+      {
+        "nodes": [
+          "Arkhangelsk",
+          "Syktyvkar"
+        ],
+        "cost": 10
+      },
+      {
+        "nodes": [
+          "Syktyvkar",
+          "Surgut"
+        ],
+        "cost": 21
+      },
+      {
+        "nodes": [
+          "Perm",
+          "Syktyvkar"
+        ],
+        "cost": 8
+      },
+      {
+        "nodes": [
+          "Syktyvkar",
+          "Kirov"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Cheboksary",
+          "Ulyanovsk"
+        ],
+        "cost": 4
+      },
+      {
+        "nodes": [
+          "Samara",
+          "Ulyanovsk"
+        ],
+        "cost": 3
+      },
+      {
+        "nodes": [
+          "Ulyanovsk",
+          "Kazan"
+        ],
+        "cost": 3
+      },
+      {
+        "nodes": [
+          "Kazan",
+          "Samara"
+        ],
+        "cost": 4
+      },
+      {
+        "nodes": [
+          "Samara",
+          "Naberezhnye Chelny"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Cheboksary",
+          "Kazan"
+        ],
+        "cost": 2
+      },
+      {
+        "nodes": [
+          "Cheboksary",
+          "Kirov"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Kirov",
+          "Kazan"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Kazan",
+          "Perm"
+        ],
+        "cost": 8
+      },
+      {
+        "nodes": [
+          "Kazan",
+          "Naberezhnye Chelny"
+        ],
+        "cost": 3
+      },
+      {
+        "nodes": [
+          "Naberezhnye Chelny",
+          "Ufa"
+        ],
+        "cost": 4
+      },
+      {
+        "nodes": [
+          "Ufa",
+          "Orenburg"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Orenburg",
+          "Samara"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Orenburg",
+          "Naberezhnye Chelny"
+        ],
+        "cost": 7
+      },
+      {
+        "nodes": [
+          "Ufa",
+          "Chelyabinsk"
+        ],
+        "cost": 8
+      },
+      {
+        "nodes": [
+          "Chelyabinsk",
+          "Yekaterinburg"
+        ],
+        "cost": 3
+      },
+      {
+        "nodes": [
+          "Yekaterinburg",
+          "Perm"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Perm",
+          "Kirov"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Chelyabinsk",
+          "Tyumen"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Tyumen",
+          "Surgut"
+        ],
+        "cost": 10
+      },
+      {
+        "nodes": [
+          "Syktyvkar",
+          "Tyumen"
+        ],
+        "cost": 17
+      },
+      {
+        "nodes": [
+          "Tyumen",
+          "Yekaterinburg"
+        ],
+        "cost": 5
+      },
+      {
+        "nodes": [
+          "Chelyabinsk",
+          "Omsk"
+        ],
+        "cost": 13
+      },
+      {
+        "nodes": [
+          "Omsk",
+          "Tyumen"
+        ],
+        "cost": 9
+      },
+      {
+        "nodes": [
+          "Tyumen",
+          "Tomsk"
+        ],
+        "cost": 19
+      },
+      {
+        "nodes": [
+          "Tomsk",
+          "Surgut"
+        ],
+        "cost": 15
+      },
+      {
+        "nodes": [
+          "Tomsk",
+          "Novosibirsk"
+        ],
+        "cost": 4
+      },
+      {
+        "nodes": [
+          "Novosibirsk",
+          "Barnaul"
+        ],
+        "cost": 4
+      },
+      {
+        "nodes": [
+          "Barnaul",
+          "Omsk"
+        ],
+        "cost": 11
+      },
+      {
+        "nodes": [
+          "Omsk",
+          "Novosibirsk"
+        ],
+        "cost": 10
+      },
+      {
+        "nodes": [
+          "Omsk",
+          "Tomsk"
+        ],
+        "cost": 12
+      },
+      {
+        "nodes": [
+          "Naberezhnye Chelny",
+          "Perm"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Naberezhnye Chelny",
+          "Yekaterinburg"
+        ],
+        "cost": 8
+      },
+      {
+        "nodes": [
+          "Ufa",
+          "Yekaterinburg"
+        ],
+        "cost": 6
+      },
+      {
+        "nodes": [
+          "Tomsk",
+          "Norilsk"
+        ],
+        "cost": 24
+      },
+      {
+        "nodes": [
+          "Norilsk",
+          "Surgut"
+        ],
+        "cost": 19
+      }
+    ],
+    "adjustRatio": [
+      0.25,
+      0.25
+    ],
+    "resupply": [
+      [
+        [
+          2,
+          2,
+          4
+        ],
+        [
+          2,
+          3,
+          4
+        ],
+        [
+          3,
+          4,
+          5
+        ],
+        [
+          4,
+          5,
+          6
+        ],
+        [
+          5,
+          6,
+          7
+        ]
+      ],
+      [
+        [
+          3,
+          4,
+          3
+        ],
+        [
+          3,
+          4,
+          3
+        ],
+        [
+          5,
+          6,
+          4
+        ],
+        [
+          5,
+          7,
+          5
+        ],
+        [
+          7,
+          9,
+          6
+        ]
+      ],
+      [
+        [
+          2,
+          2,
+          3
+        ],
+        [
+          2,
+          2,
+          3
+        ],
+        [
+          3,
+          3,
+          4
+        ],
+        [
+          4,
+          3,
+          5
+        ],
+        [
+          4,
+          5,
+          6
+        ]
+      ],
+      [
+        [
+          1,
+          1,
+          1
+        ],
+        [
+          1,
+          1,
+          1
+        ],
+        [
+          1,
+          2,
+          2
+        ],
+        [
+          2,
+          3,
+          2
+        ],
+        [
+          2,
+          3,
+          3
+        ]
+      ]
+    ],
+    "startingResources": [
+      18,
+      24,
+      0,
+      7
+    ],
+    "mapSpecificRules": "The power plant market is restricted, and the rules for removing old plants are changed.\n",
+    "deckBuild": {
+      "recharged": "plants 6 and 14 are removed from the game. The market has 6 plants (3 current, 3 future) drawn at random from the low plants; the six undrawn low plants sit shuffled on top of the deck. Removal by player count (higher plants only): 2 players remove 6, 3 players remove 8, 4 players remove 4.",
+      "original": "plants 6 and 14 are removed from the game; the market is 3, 4, 5 / 7, 8, 9. Plant 13 goes on top of the deck, then five shuffled cards (plants 10, 11 and the top three of the deck), then the rest, with the Step 3 card on the bottom."
+    },
+    "viewBox": [
+      1465,
+      860
+    ],
+    "playerOrderPosition": [
+      1160,
+      140
+    ],
+    "cityCountPosition": [
+      0,
+      0
+    ],
+    "powerPlantMarketPosition": [
+      745,
+      0
+    ],
+    "actualMarketWidth": 430,
+    "mapPosition": [
+      -10,
+      0
+    ],
+    "buttonsPosition": [
+      1305,
+      0
+    ],
+    "playerBoardsPosition": [
+      1105,
+      200
+    ],
+    "roundInfoPosition": [
+      20,
+      590
+    ],
+    "supplyPosition": [
+      0,
+      720
+    ]
+  },
+  "players": [
+    {
+      "id": 0,
+      "powerPlants": [
+        {
+          "number": 5,
+          "type": 4,
+          "cost": 2,
+          "citiesPowered": 1
+        },
+        {
+          "number": 31,
+          "type": 0,
+          "cost": 3,
+          "citiesPowered": 6
+        },
+        {
+          "number": 25,
+          "type": 0,
+          "cost": 2,
+          "citiesPowered": 5
+        }
+      ],
+      "coalCapacity": 10,
+      "coalLeft": 1,
+      "oilCapacity": 0,
+      "oilLeft": 2,
+      "garbageCapacity": 0,
+      "garbageLeft": 0,
+      "uraniumCapacity": 0,
+      "uraniumLeft": 0,
+      "hybridCapacity": 4,
+      "hybridLeft": 0,
+      "money": 0,
+      "housesLeft": 22,
+      "cities": [
+        {
+          "name": "Chelyabinsk",
+          "position": 0
+        },
+        {
+          "name": "Yekaterinburg",
+          "position": 0
+        },
+        {
+          "name": "Tyumen",
+          "position": 0
+        },
+        {
+          "name": "Ufa",
+          "position": 0
+        },
+        {
+          "name": "Omsk",
+          "position": 0
+        },
+        {
+          "name": "Perm",
+          "position": 1
+        },
+        {
+          "name": "Novosibirsk",
+          "position": 0
+        },
+        {
+          "name": "Tomsk",
+          "position": 0
+        }
+      ],
+      "powerPlantsNotUsed": [
+        31,
+        25
+      ],
+      "availableMoves": null,
+      "lastMove": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504460
+      },
+      "isDropped": false,
+      "isAI": false,
+      "bid": 0,
+      "passed": true,
+      "skipAuction": false,
+      "citiesPowered": 1,
+      "resourcesUsed": [],
+      "totalIncome": 304,
+      "totalSpentCities": 85,
+      "totalSpentConnections": 42,
+      "totalSpentPlants": 61,
+      "totalSpentResources": 166,
+      "usedFreeJump": false,
+      "totalTimeUsed": 7
+    },
+    {
+      "id": 1,
+      "powerPlants": [
+        {
+          "number": 11,
+          "type": 3,
+          "cost": 1,
+          "citiesPowered": 2
+        },
+        {
+          "number": 28,
+          "type": 3,
+          "cost": 1,
+          "citiesPowered": 4
+        },
+        {
+          "number": 46,
+          "type": 4,
+          "cost": 3,
+          "citiesPowered": 7
+        }
+      ],
+      "coalCapacity": 0,
+      "coalLeft": 3,
+      "oilCapacity": 0,
+      "oilLeft": 1,
+      "garbageCapacity": 0,
+      "garbageLeft": 0,
+      "uraniumCapacity": 4,
+      "uraniumLeft": 0,
+      "hybridCapacity": 6,
+      "hybridLeft": 0,
+      "money": 0,
+      "housesLeft": 22,
+      "cities": [
+        {
+          "name": "Cheboksary",
+          "position": 0
+        },
+        {
+          "name": "Kazan",
+          "position": 0
+        },
+        {
+          "name": "Naberezhnye Chelny",
+          "position": 0
+        },
+        {
+          "name": "Samara",
+          "position": 0
+        },
+        {
+          "name": "Ulyanovsk",
+          "position": 1
+        },
+        {
+          "name": "Ufa",
+          "position": 1
+        },
+        {
+          "name": "Kirov",
+          "position": 1
+        }
+      ],
+      "powerPlantsNotUsed": [
+        11,
+        28,
+        46
+      ],
+      "availableMoves": null,
+      "lastMove": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "isDropped": false,
+      "isAI": false,
+      "bid": 0,
+      "passed": true,
+      "skipAuction": false,
+      "citiesPowered": 7,
+      "resourcesUsed": [],
+      "totalIncome": 333,
+      "totalSpentCities": 85,
+      "totalSpentConnections": 21,
+      "totalSpentPlants": 99,
+      "totalSpentResources": 178,
+      "usedFreeJump": false,
+      "totalTimeUsed": 3
+    },
+    {
+      "id": 2,
+      "powerPlants": [
+        {
+          "number": 37,
+          "type": 5,
+          "cost": 0,
+          "citiesPowered": 4
+        },
+        {
+          "number": 42,
+          "type": 0,
+          "cost": 2,
+          "citiesPowered": 6
+        },
+        {
+          "number": 44,
+          "type": 5,
+          "cost": 0,
+          "citiesPowered": 5
+        }
+      ],
+      "coalCapacity": 4,
+      "coalLeft": 2,
+      "oilCapacity": 0,
+      "oilLeft": 0,
+      "garbageCapacity": 0,
+      "garbageLeft": 0,
+      "uraniumCapacity": 0,
+      "uraniumLeft": 0,
+      "hybridCapacity": 0,
+      "hybridLeft": 0,
+      "money": 9,
+      "housesLeft": 22,
+      "cities": [
+        {
+          "name": "Syktyvkar",
+          "position": 0
+        },
+        {
+          "name": "Kirov",
+          "position": 0
+        },
+        {
+          "name": "Perm",
+          "position": 0
+        },
+        {
+          "name": "Ulyanovsk",
+          "position": 0
+        },
+        {
+          "name": "Orenburg",
+          "position": 0
+        },
+        {
+          "name": "Arkhangelsk",
+          "position": 0
+        },
+        {
+          "name": "Murmansk",
+          "position": 0
+        },
+        {
+          "name": "Surgut",
+          "position": 0
+        },
+        {
+          "name": "Samara",
+          "position": 1
+        },
+        {
+          "name": "Kazan",
+          "position": 1
+        },
+        {
+          "name": "Cheboksary",
+          "position": 1
+        },
+        {
+          "name": "Naberezhnye Chelny",
+          "position": 1
+        },
+        {
+          "name": "Yekaterinburg",
+          "position": 1
+        },
+        {
+          "name": "Chelyabinsk",
+          "position": 1
+        },
+        {
+          "name": "Tyumen",
+          "position": 1
+        },
+        {
+          "name": "Ufa",
+          "position": 2
+        },
+        {
+          "name": "Omsk",
+          "position": 1
+        }
+      ],
+      "powerPlantsNotUsed": [
+        42
+      ],
+      "availableMoves": null,
+      "lastMove": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504460
+      },
+      "isDropped": false,
+      "isAI": false,
+      "bid": 0,
+      "passed": true,
+      "skipAuction": false,
+      "citiesPowered": 15,
+      "resourcesUsed": [],
+      "totalIncome": 476,
+      "totalSpentCities": 220,
+      "totalSpentConnections": 111,
+      "totalSpentPlants": 143,
+      "totalSpentResources": 43,
+      "usedFreeJump": false,
+      "totalTimeUsed": 12
+    }
+  ],
+  "playerOrder": [
+    2,
+    0,
+    1
+  ],
+  "currentPlayers": [],
+  "powerPlantsDeck": [],
+  "coalSupply": 18,
+  "oilSupply": 0,
+  "garbageSupply": 0,
+  "uraniumSupply": 0,
+  "coalResupply": [
+    [
+      2,
+      2,
+      4
+    ],
+    [
+      2,
+      3,
+      4
+    ],
+    [
+      3,
+      4,
+      5
+    ],
+    [
+      4,
+      5,
+      6
+    ],
+    [
+      5,
+      6,
+      7
+    ]
+  ],
+  "oilResupply": [
+    [
+      3,
+      4,
+      3
+    ],
+    [
+      3,
+      4,
+      3
+    ],
+    [
+      5,
+      6,
+      4
+    ],
+    [
+      5,
+      7,
+      5
+    ],
+    [
+      7,
+      9,
+      6
+    ]
+  ],
+  "garbageResupply": [
+    [
+      2,
+      2,
+      3
+    ],
+    [
+      2,
+      2,
+      3
+    ],
+    [
+      3,
+      3,
+      4
+    ],
+    [
+      4,
+      3,
+      5
+    ],
+    [
+      4,
+      5,
+      6
+    ]
+  ],
+  "uraniumResupply": [
+    [
+      1,
+      1,
+      1
+    ],
+    [
+      1,
+      1,
+      1
+    ],
+    [
+      1,
+      2,
+      2
+    ],
+    [
+      2,
+      3,
+      2
+    ],
+    [
+      2,
+      3,
+      3
+    ]
+  ],
+  "coalMarket": 0,
+  "oilMarket": 21,
+  "garbageMarket": 24,
+  "uraniumMarket": 12,
+  "coalPrices": [
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    3,
+    3,
+    3,
+    4,
+    4,
+    4,
+    5,
+    5,
+    5,
+    6,
+    6,
+    6,
+    7,
+    7,
+    7,
+    8,
+    8,
+    8
+  ],
+  "oilPrices": [
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    3,
+    3,
+    3,
+    4,
+    4,
+    4,
+    5,
+    5,
+    5,
+    6,
+    6,
+    6,
+    7,
+    7,
+    7,
+    8,
+    8,
+    8
+  ],
+  "garbagePrices": [
+    1,
+    1,
+    1,
+    2,
+    2,
+    2,
+    3,
+    3,
+    3,
+    4,
+    4,
+    4,
+    5,
+    5,
+    5,
+    6,
+    6,
+    6,
+    7,
+    7,
+    7,
+    8,
+    8,
+    8
+  ],
+  "uraniumPrices": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    10,
+    12,
+    14,
+    16
+  ],
+  "actualMarket": [],
+  "futureMarket": [],
+  "highestBidders": [],
+  "auctioningPlayer": 2,
+  "step": 3,
+  "phase": "Game End",
+  "options": {
+    "fastBid": false,
+    "map": "Russia",
+    "variant": "original",
+    "showMoney": false,
+    "useNewRechargedSetup": true,
+    "trackTotalSpent": true,
+    "chooseRegions": false,
+    "chooseColors": false
+  },
+  "log": [
+    {
+      "type": "event",
+      "event": "Game Start!"
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 3,
+        "time": 1788175504439
+      },
+      "simple": "undefined chooses Power Plant 3 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>3</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 3,
+        "time": 1788175504440
+      },
+      "simple": "undefined bids $3.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 4,
+        "time": 1788175504440
+      },
+      "simple": "undefined bids $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 5,
+        "time": 1788175504440
+      },
+      "simple": "undefined bids $5.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504440
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 6,
+        "time": 1788175504440
+      },
+      "simple": "undefined bids $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 7,
+        "time": 1788175504440
+      },
+      "simple": "undefined bids $7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504440
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 7.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 13 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 4,
+        "time": 1788175504441
+      },
+      "simple": "undefined chooses Power Plant 4 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>4</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 4,
+        "time": 1788175504441
+      },
+      "simple": "undefined bids $4.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 5,
+        "time": 1788175504441
+      },
+      "simple": "undefined bids $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504441
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 50 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 5,
+        "time": 1788175504441
+      },
+      "simple": "undefined chooses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>5</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 39 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504441
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504442
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504442
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined buys oil for $2.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504442
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Syktyvkar",
+          "price": 10
+        },
+        "time": 1788175504442
+      },
+      "simple": "undefined builds on Syktyvkar for $10.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Syktyvkar</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Kirov",
+          "price": 16
+        },
+        "time": 1788175504446
+      },
+      "simple": "undefined builds on Kirov for $16.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kirov</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504446
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Cheboksary",
+          "price": 10
+        },
+        "time": 1788175504446
+      },
+      "simple": "undefined builds on Cheboksary for $10.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Cheboksary</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504446
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Chelyabinsk",
+          "price": 10
+        },
+        "time": 1788175504447
+      },
+      "simple": "undefined builds on Chelyabinsk for $10.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Chelyabinsk</b> for <span style=\"color: green\">$10</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504447
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504447
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504447
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504447
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504447
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504447
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504447
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [2, 2, 2, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 50 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 10 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504447
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (7)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 12 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504447
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 8,
+        "time": 1788175504448
+      },
+      "simple": "undefined chooses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>8</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 11 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $3.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$3</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$4</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504448
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504448
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined buys oil for $2.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504448
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Kazan",
+          "price": 12
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined builds on Kazan for $12.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kazan</b> for <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504448
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Yekaterinburg",
+          "price": 13
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined builds on Yekaterinburg for $13.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Yekaterinburg</b> for <span style=\"color: green\">$13</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504448
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Perm",
+          "price": 16
+        },
+        "time": 1788175504448
+      },
+      "simple": "undefined builds on Perm for $16.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Perm</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 8,
+          "resourcesSpent": [
+            "coal",
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined uses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [2, 2, 2, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 39 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 25 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (9)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 18 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys coal for $5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$5</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined buys oil for $2.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tyumen",
+          "price": 15
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined builds on Tyumen for $15.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tyumen</b> for <span style=\"color: green\">$15</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Naberezhnye Chelny",
+          "price": 13
+        },
+        "time": 1788175504449
+      },
+      "simple": "undefined builds on Naberezhnye Chelny for $13.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Naberezhnye Chelny</b> for <span style=\"color: green\">$13</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504449
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Ulyanovsk",
+          "price": 18
+        },
+        "time": 1788175504450
+      },
+      "simple": "undefined builds on Ulyanovsk for $18.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ulyanovsk</b> for <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504450
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504450
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504450
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504450
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504450
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504450
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504450
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [2, 2, 2, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 25 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 38 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 11,
+        "time": 1788175504451
+      },
+      "simple": "undefined chooses Power Plant 11 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>11</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 11,
+        "time": 1788175504451
+      },
+      "simple": "undefined bids $11.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$11</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Bid",
+        "data": 12,
+        "time": 1788175504451
+      },
+      "simple": "undefined bids $12.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 12.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$12</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 42 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (10)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 35 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504451
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504451
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504451
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504451
+      },
+      "simple": "undefined buys oil for $2.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504451
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Ufa",
+          "price": 16
+        },
+        "time": 1788175504451
+      },
+      "simple": "undefined builds on Ufa for $16.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$16</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Samara",
+          "price": 14
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined builds on Samara for $14.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Samara</b> for <span style=\"color: green\">$14</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Orenburg",
+          "price": 19
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined builds on Orenburg for $19.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Orenburg</b> for <span style=\"color: green\">$19</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [2, 2, 2, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 42 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 32 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (12)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 31 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 31,
+        "time": 1788175504452
+      },
+      "simple": "undefined chooses Power Plant 31.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>31</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 31.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$31</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 16 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined buys oil for $2.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Arkhangelsk",
+          "price": 20
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined builds on Arkhangelsk for $20.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Arkhangelsk</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504452
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504452
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [2, 3, 2, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 38 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 19 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 13,
+        "time": 1788175504453
+      },
+      "simple": "undefined chooses Power Plant 13 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>13</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 13,
+        "time": 1788175504453
+      },
+      "simple": "undefined bids $13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$13</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$13</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 27 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (16)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 33 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Omsk",
+          "price": 19
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined builds on Omsk for $19.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Omsk</b> for <span style=\"color: green\">$19</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [2, 3, 2, 0]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 35 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 28 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (18)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 26 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504453
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504453
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Murmansk",
+          "price": 25
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined builds on Murmansk for $25.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Murmansk</b> for <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Surgut",
+          "price": 30
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined builds on Surgut for $30.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Surgut</b> for <span style=\"color: green\">$30</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Starting Step 2, Power Plant 19 discarded."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 36 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [3, 2, 2, 0]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 36 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 15 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (15)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 34 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined buys coal for $6.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$6</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Ulyanovsk",
+          "price": 18
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined builds on Ulyanovsk for $18.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ulyanovsk</b> for <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Samara",
+          "price": 18
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined builds on Samara for $18.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Samara</b> for <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504454
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504454
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 4,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined uses Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>4</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 8,
+          "resourcesSpent": [
+            "coal",
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined uses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [3, 2, 2, 0]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 34 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 46 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (26)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 24 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 28,
+        "time": 1788175504455
+      },
+      "simple": "undefined chooses Power Plant 28.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>28</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 28.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$28</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 4,
+        "time": 1788175504455
+      },
+      "simple": "undefined discards Power Plant 4.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>4</b>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 44 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Kazan",
+          "price": 18
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined builds on Kazan for $18.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kazan</b> for <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504455
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [3, 2, 2, 0]."
+    },
+    {
+      "type": "event",
+      "event": "Putting Power Plant 46 on the bottom of the deck."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 37 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (24)."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504455
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Starting Step 3, Power Plant 27 discarded."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504456
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504456
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504456
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504456
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504456
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Cheboksary",
+          "price": 17
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined builds on Cheboksary for $17.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Cheboksary</b> for <span style=\"color: green\">$17</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Naberezhnye Chelny",
+          "price": 18
+        },
+        "time": 1788175504456
+      },
+      "simple": "undefined builds on Naberezhnye Chelny for $18.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Naberezhnye Chelny</b> for <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [4, 2, 3, 0]."
+    },
+    {
+      "type": "event",
+      "event": "Discarding Power Plant 32."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 34 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 37,
+        "time": 1788175504457
+      },
+      "simple": "undefined chooses Power Plant 37 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>37</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 37,
+        "time": 1788175504457
+      },
+      "simple": "undefined bids $37.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$37</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 37.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$37</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 46 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (33)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 38 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504457
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504457
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 37,
+          "resourcesSpent": [],
+          "citiesPowered": 4
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined uses Power Plant 37.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 31,
+          "resourcesSpent": [
+            "coal",
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 6
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined uses Power Plant 31.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>31</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 8,
+          "resourcesSpent": [
+            "coal",
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined uses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [4, 0, 3, 0]."
+    },
+    {
+      "type": "event",
+      "event": "Discarding Power Plant 34."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 39 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (38)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 25 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 25,
+        "time": 1788175504458
+      },
+      "simple": "undefined chooses Power Plant 25 to initiate an auction.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>25</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Bid",
+        "data": 25,
+        "time": 1788175504458
+      },
+      "simple": "undefined bids $25.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 25.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$25</span>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 42 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys uranium for $1.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "uranium"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys uranium for $2.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>uranium</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined buys oil for $2.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$2</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Ufa",
+          "price": 19
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined builds on Ufa for $19.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$19</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Perm",
+          "price": 20
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined builds on Perm for $20.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Perm</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504458
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Yekaterinburg",
+          "price": 20
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined builds on Yekaterinburg for $20.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Yekaterinburg</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Chelyabinsk",
+          "price": 18
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined builds on Chelyabinsk for $18.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Chelyabinsk</b> for <span style=\"color: green\">$18</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tyumen",
+          "price": 20
+        },
+        "time": 1788175504458
+      },
+      "simple": "undefined builds on Tyumen for $20.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tyumen</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 3,
+          "resourcesSpent": [
+            "oil",
+            "oil"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>3</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 37,
+          "resourcesSpent": [],
+          "citiesPowered": 4
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 37.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 8,
+          "resourcesSpent": [
+            "coal",
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 11,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 2
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 11.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>11</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 28,
+          "resourcesSpent": [
+            "uranium"
+          ],
+          "citiesPowered": 4
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 28.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>28</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [4, 2, 0, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Discarding Power Plant 39."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 50 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 42,
+        "time": 1788175504459
+      },
+      "simple": "undefined chooses Power Plant 42 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>42</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 42,
+        "time": 1788175504459
+      },
+      "simple": "undefined bids $42.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$42</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 42.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$42</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 3,
+        "time": 1788175504459
+      },
+      "simple": "undefined discards Power Plant 3.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>3</b>."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 36 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (36)."
+    },
+    {
+      "type": "event",
+      "event": "Power Plant 35 drawn from the deck."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 46,
+        "time": 1788175504459
+      },
+      "simple": "undefined chooses Power Plant 46.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>46</b>."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 46.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$46</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 8,
+        "time": 1788175504459
+      },
+      "simple": "undefined discards Power Plant 8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>8</b>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Novosibirsk",
+          "price": 20
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined builds on Novosibirsk for $20.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Novosibirsk</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Ufa",
+          "price": 24
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined builds on Ufa for $24.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Ufa</b> for <span style=\"color: green\">$24</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 13,
+          "resourcesSpent": [],
+          "citiesPowered": 1
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 37,
+          "resourcesSpent": [],
+          "citiesPowered": 4
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 37.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>37</b>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "UsePowerPlant",
+        "data": {
+          "powerPlant": 5,
+          "resourcesSpent": [
+            "coal",
+            "coal"
+          ],
+          "citiesPowered": 1
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined uses Power Plant 5.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> uses Power Plant <b>5</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Resupplying resources: [4, 0, 0, 1]."
+    },
+    {
+      "type": "event",
+      "event": "Discarding Power Plant 35."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "ChoosePowerPlant",
+        "data": 44,
+        "time": 1788175504459
+      },
+      "simple": "undefined chooses Power Plant 44 to initiate an auction.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> chooses Power Plant <b>44</b> to initiate an auction."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Bid",
+        "data": 44,
+        "time": 1788175504459
+      },
+      "simple": "undefined bids $44.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> bids <span style=\"color: green\">$44</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "undefined wins the bid and pays 44.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> wins the bid and pays <span style=\"color: green\">$44</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "DiscardPowerPlant",
+        "data": 13,
+        "time": 1788175504459
+      },
+      "simple": "undefined discards Power Plant 13.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> discards Power Plant <b>13</b>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "First pass, removing lowest numbered Power Plant (50)."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $7.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$7</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "oil"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys oil for $1.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>oil</b> for <span style=\"color: green\">$1</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "BuyResource",
+        "data": {
+          "resource": "coal"
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined buys coal for $8.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> buys <b>coal</b> for <span style=\"color: green\">$8</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Kirov",
+          "price": 20
+        },
+        "time": 1788175504459
+      },
+      "simple": "undefined builds on Kirov for $20.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Kirov</b> for <span style=\"color: green\">$20</span>."
+    },
+    {
+      "type": "move",
+      "player": 1,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504459
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: mediumorchid; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Tomsk",
+          "price": 14
+        },
+        "time": 1788175504460
+      },
+      "simple": "undefined builds on Tomsk for $14.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Tomsk</b> for <span style=\"color: green\">$14</span>."
+    },
+    {
+      "type": "move",
+      "player": 0,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504460
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: limegreen; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Build",
+        "data": {
+          "name": "Omsk",
+          "price": 24
+        },
+        "time": 1788175504460
+      },
+      "simple": "undefined builds on Omsk for $24.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> builds on <b>Omsk</b> for <span style=\"color: green\">$24</span>."
+    },
+    {
+      "type": "move",
+      "player": 2,
+      "move": {
+        "name": "Pass",
+        "data": true,
+        "time": 1788175504460
+      },
+      "simple": "undefined passes.",
+      "pretty": "<span style=\"background-color: red; font-weight: bold; padding: 0 3px;\">undefined</span> passes."
+    },
+    {
+      "type": "event",
+      "event": "Game Ended!"
+    }
+  ],
+  "hiddenLog": [],
+  "seed": "replay-russia-fixture",
+  "round": 14,
+  "newTurn": true,
+  "auctionSkips": 2,
+  "citiesToStep2": 7,
+  "citiesToEndGame": 17,
+  "resourceResupply": [
+    "[2, 3, 2, 1]",
+    "[3, 4, 2, 1]",
+    "[4, 3, 3, 1]"
+  ],
+  "paymentTable": [
+    10,
+    22,
+    33,
+    44,
+    54,
+    64,
+    73,
+    82,
+    90,
+    98,
+    105,
+    112,
+    118,
+    124,
+    129,
+    134,
+    138,
+    142,
+    145,
+    148,
+    150,
+    150
+  ],
+  "variant": "original",
+  "minimunBid": 44,
+  "plantDiscountActive": false,
+  "discardSmallestPlant": false,
+  "cardsLeft": 0,
+  "nextCardWeak": false,
+  "card39Bought": false,
+  "knownPowerPlantDeck": [
+    {
+      "number": 3,
+      "type": 1,
+      "cost": 2,
+      "citiesPowered": 1
+    },
+    {
+      "number": 4,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 1
+    },
+    {
+      "number": 5,
+      "type": 4,
+      "cost": 2,
+      "citiesPowered": 1
+    },
+    {
+      "number": 7,
+      "type": 1,
+      "cost": 3,
+      "citiesPowered": 2
+    },
+    {
+      "number": 8,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 2
+    },
+    {
+      "number": 9,
+      "type": 1,
+      "cost": 1,
+      "citiesPowered": 1
+    },
+    {
+      "number": 13,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 1
+    },
+    {
+      "number": 50,
+      "type": 6,
+      "cost": 0,
+      "citiesPowered": 6
+    },
+    {
+      "number": 39,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 6
+    },
+    {
+      "number": 10,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 2
+    },
+    {
+      "number": 12,
+      "type": 4,
+      "cost": 2,
+      "citiesPowered": 2
+    },
+    {
+      "number": 11,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 2
+    },
+    {
+      "number": 25,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 5
+    },
+    {
+      "number": 18,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 2
+    },
+    {
+      "number": 38,
+      "type": 2,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 42,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 6
+    },
+    {
+      "number": 35,
+      "type": 1,
+      "cost": 1,
+      "citiesPowered": 5
+    },
+    {
+      "number": 32,
+      "type": 1,
+      "cost": 3,
+      "citiesPowered": 6
+    },
+    {
+      "number": 31,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 6
+    },
+    {
+      "number": 16,
+      "type": 1,
+      "cost": 2,
+      "citiesPowered": 3
+    },
+    {
+      "number": 19,
+      "type": 2,
+      "cost": 2,
+      "citiesPowered": 3
+    },
+    {
+      "number": 27,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 3
+    },
+    {
+      "number": 33,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 4
+    },
+    {
+      "number": 28,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 4
+    },
+    {
+      "number": 26,
+      "type": 1,
+      "cost": 2,
+      "citiesPowered": 5
+    },
+    {
+      "number": 36,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 15,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 3
+    },
+    {
+      "number": 34,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 5
+    },
+    {
+      "number": 46,
+      "type": 4,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 24,
+      "type": 2,
+      "cost": 2,
+      "citiesPowered": 4
+    },
+    {
+      "number": 44,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 5
+    },
+    {
+      "number": 37,
+      "type": 5,
+      "cost": 0,
+      "citiesPowered": 4
+    },
+    {
+      "number": 99,
+      "type": 7,
+      "cost": 0,
+      "citiesPowered": 6
+    }
+  ],
+  "knownPowerPlantDeckStep3": [
+    {
+      "number": 34,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 5
+    },
+    {
+      "number": 46,
+      "type": 4,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 38,
+      "type": 2,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 39,
+      "type": 3,
+      "cost": 1,
+      "citiesPowered": 6
+    },
+    {
+      "number": 25,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 5
+    },
+    {
+      "number": 42,
+      "type": 0,
+      "cost": 2,
+      "citiesPowered": 6
+    },
+    {
+      "number": 50,
+      "type": 6,
+      "cost": 0,
+      "citiesPowered": 6
+    },
+    {
+      "number": 36,
+      "type": 0,
+      "cost": 3,
+      "citiesPowered": 7
+    },
+    {
+      "number": 35,
+      "type": 1,
+      "cost": 1,
+      "citiesPowered": 5
+    }
+  ],
+  "pendingMarketRefill": false,
+  "chosenResource": "coal"
+}


### PR DESCRIPTION
## Summary

Two bugs in `reconstructState`'s secret-seed prologue (the replay scrubber path) broke replays on maps with non-standard markets. Reproduced live: boardgamers.space game `3-game` (Russia) threw `Wrong argument for the command ChoosePowerPlant` when scrubbing after the Step-3 boundary; every other position/map replayed fine.

### 1. Hardcoded 4+4 market split

The prologue re-seeds the deck from `knownPowerPlantDeck`:

```ts
G.actualMarket = G.powerPlantsDeck.splice(0, 4);
G.futureMarket = G.powerPlantsDeck.splice(0, 4);
```

But **Russia deals a 3+3 market** (China `numPlayers+0`, etc.). For Russia games, plants 13 and 16 landed in the *future market* instead of the *draw deck*, so every draw after that diverged from the real game — the replayed market no longer contained the plant the player chose, and the first `ChoosePowerPlant` past the divergence replayed as illegal.

Fix: take the split sizes from the base state's `actualMarket`/`futureMarket` lengths (built by the same map `setupDeck`, so authoritative for every map even though the seeded contents are not).

### 2. `knownPowerPlantDeckStep3` consumed across replays

`powerPlantDeckAfterStep3` aliased the caller's `knownPowerPlantDeckStep3` array. When the Step-3 card is drawn, `addPowerPlant()` sets `powerPlantsDeck = powerPlantDeckAfterStep3` (same reference) and `shift()`s draws off it — so the **first** replay past the Step-3 boundary permanently shortened the viewer's stored deck, and every later `replayTo` (forward *or* backward) failed on the re-draw of the consumed plant. Fix: `cloneDeep`.

## Tests

New `replay from stripped state (secret seed)` suite over two deterministic `moveAI` fixtures (`RussiaStep3.json`, `ChinaStep3.json` — generated games, fixed seed, no personal data, Russia reaches Step 3):

- ✅ every prefix of a stripped Russia game replays cleanly (catches the 4+4 split)
- ✅ every prefix of a China game replays cleanly (`numPlayers+0`)
- ✅ successive replays past the Step-3 boundary don't consume `knownPowerPlantDeckStep3` (catches the missing `cloneDeep`)

## Verification

- The live broken game (`3-game`, Russia, 350 moves): all 350 prefixes replay cleanly in both directions; `knownPowerPlantDeckStep3` stays intact
- Engine suite: 97 passing / 0 failing (was 94)

## Notes

- Live play is unaffected — only the replay scrubber was broken
- Needs an engine (+ viewer) release to reach players; the platform pins `powergrid-viewer` from the CDN