### PR TITLE
Don't warn about unused power plants when the used ones already cover all cities

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -1148,7 +1148,8 @@ export default class Game extends Vue {
             const player = this.G.players[this.player];
             if (player && player.availableMoves && Object.keys(player.availableMoves).length > 1) {
                 if (this.G.phase == Phase.Bureaucracy && player.powerPlantsNotUsed.length > 0
-                    && Object.keys(player.availableMoves).includes('UsePowerPlant')) {
+                    && Object.keys(player.availableMoves).includes('UsePowerPlant')
+                    && !this.canPowerAllCitiesWithUsedPlants(player)) {
                     this.confirmMessage = 'Are you sure you want to pass? You have unused power plants!';
                     this.confirmVisible = true;
                     return;
@@ -1813,6 +1814,14 @@ export default class Game extends Vue {
                 availableMoves[MoveName.DiscardPowerPlant]!.find((p) => p == powerPlant.number)
             );
         }
+    }
+
+    // Whether the power plants the player has already used this Bureaucracy
+    // phase can cover every city they own — if so, the unused plants are
+    // surplus and passing without them is not worth a warning.
+    canPowerAllCitiesWithUsedPlants(player: Player): boolean {
+        const usedPlants = player.powerPlants.filter((p) => !player.powerPlantsNotUsed.includes(p.number));
+        return usedPlants.reduce((sum, p) => sum + p.citiesPowered, 0) >= player.cities.length;
     }
 
     canPowerAllPlants(player: Player): boolean {


### PR DESCRIPTION
## Context

During the Bureaucracy phase, the viewer showed the confirmation dialog **"Are you sure you want to pass? You have unused power plants!"** whenever the player passed with any plant still unused — even when the plants already used could power every city the player owns. In that situation the unused plants are surplus and passing is clearly intentional, so the warning is just noise.

## Change

`checkPass` now only shows the confirmation when the plants already used this phase **cannot** cover all owned cities:

- New helper `canPowerAllCitiesWithUsedPlants` sums `citiesPowered` over the plants no longer listed in `powerPlantsNotUsed` and compares against `player.cities.length`.
- The existing guards (Bureaucracy phase, plants actually unused, `UsePowerPlant` still available) are unchanged.

So the dialog still fires when skipping a plant would leave cities unpowered, and stays silent when the remaining plants are unnecessary.

## Testing

- `pnpm run prettier-check` ✅ (the touched file)
- `vue-cli-service test:unit` — 26 passing ✅