### PR TITLE
Rules dialog: mention Step 2 also starts when every city is built

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -642,6 +642,11 @@
                                         Starts after building phase where a player has
                                         <strong>{{ G.citiesToStep2 }}</strong> or more cities
                                     </li>
+                                    <li v-if="G.map.name !== 'Middle East'">
+                                        Also starts after a building phase where <strong>every city</strong> has a house
+                                        (all Step 1 slots filled), even if no player reached
+                                        {{ G.citiesToStep2 }}
+                                    </li>
                                     <li><strong>Two</strong> players per city</li>
                                     <li>
                                         Resource Resupply: <strong>{{ G.resourceResupply[1] }}</strong>


### PR DESCRIPTION
## Context

The engine already starts Step 2 after a building phase where **every city has a house** (all Step 1 slots filled), even if no player reached the \`citiesToStep2\` threshold. This matters on small maps — e.g. UK & Ireland with 3 players can have 18 cities in play (6 each), so the printed 7-city threshold may never be reached — but the rule is generic, not map-specific.

However, the in-game rules dialog never mentions it, so players on such maps see Step 2 arrive "for no reason".

## Change

Adds one bullet to the Step 2 section of the rules dialog:

> Also starts after a building phase where **every city** has a house (all Step 1 slots filled), even if no player reached {citiesToStep2}

Guarded with \`v-if="G.map.name !== 'Middle East'"\`, since the engine's fallback excludes Middle East (and Manhattan, which already hides this Step 2 block entirely).

Purely documentation — no engine behavior change.

## Testing

- \`pnpm exec prettier --plugin-search-dir=. --check viewer/src/components/Game.vue\` ✅
- \`vue-cli-service test:unit\` — 26 passing ✅