### PR TITLE
Spell out the UK & Ireland first-house cost in the map rules

### DIFF
--- a/engine/src/maps/ukireland.ts
+++ b/engine/src/maps/ukireland.ts
@@ -302,7 +302,7 @@ export const map: GameMap = {
         'Two networks: Ireland (Green and Orange regions) and Great Britain ' +
         '(Red, Pink, Yellow, Brown) have no sea connection. A player may run ' +
         'one network on each island. Starting a second network on the other ' +
-        'island costs an extra 20 Elektro on top of the normal first-house cost. ' +
+        'island costs an extra 20 Elektro on top of the normal FIRST-house cost($10). ' +
         'Nuclear restriction: a player whose network is entirely in the Republic ' +
         'of Ireland (Green region) cannot bid on or auction a nuclear power plant ' +
         'until they build a city in Scotland, Wales, England, or Northern Ireland. ' +

--- a/engine/src/maps/ukireland.ts
+++ b/engine/src/maps/ukireland.ts
@@ -302,7 +302,7 @@ export const map: GameMap = {
         'Two networks: Ireland (Green and Orange regions) and Great Britain ' +
         '(Red, Pink, Yellow, Brown) have no sea connection. A player may run ' +
         'one network on each island. Starting a second network on the other ' +
-        'island costs an extra 20 Elektro on top of the normal FIRST-house cost($10). ' +
+        'island is only possible on an EMPTY spot and costs an extra 20 Elektro on top of the normal first-house cost($10). ' +
         'Nuclear restriction: a player whose network is entirely in the Republic ' +
         'of Ireland (Green region) cannot bid on or auction a nuclear power plant ' +
         'until they build a city in Scotland, Wales, England, or Northern Ireland. ' +


### PR DESCRIPTION
The UK & Ireland cross-island rule reads:

> Starting a second network on the other island costs an extra 20 Elektro on top of the normal first-house cost.

At the table that leaves you doing the arithmetic from memory, so this names the cost and sets FIRST apart:

> Starting a second network on the other island costs an extra 20 Elektro on top of the normal FIRST-house cost($10).

Requested by Mike after a UK & Ireland game. $10 is the default first slot cost — UK & Ireland sets no `slotCosts` override on any city, so it holds map-wide.

**Text only, one line.** `npm run lint` and `npm test` (97/97) are green, and prettier is clean.

**Rollout note:** `mapSpecificRules` is baked into each game state at `setup()`, so this can only ever show up in *new* games — existing UK & Ireland games keep the old wording no matter what is deployed. Being an engine change it also costs a descriptor duplicate to reach the server at all, so this is worth batching with the next engine release rather than cutting one for a string.