### PR TITLE
Fix crash on hard refresh (TypeError: can't access property "phase", e is null)

### DIFF
--- a/viewer/src/components/Game.vue
+++ b/viewer/src/components/Game.vue
@@ -1080,7 +1080,11 @@ export default class Game extends Vue {
         // scrubber renders reconstructed MID-game states, whose own `ended()` is
         // false however long ago the game finished, so it cannot be asked. See
         // `moneyIsPublic`.
-        if (replaceState && ended(state)) {
+        // `state` is null until the platform posts the first one: launch() mounts
+        // the viewer with `state: null` and the immediate `@Watch('state')` fires
+        // at mount, so this runs once with null (hard refresh / first load) and
+        // must not dereference it.
+        if (replaceState && state && ended(state)) {
             this.gameIsOver = true;
         }
 


### PR DESCRIPTION
## Error

Hard-refreshing a live game (e.g. https://boardgamers.space/game/MHABKH0203) crashes the viewer before the board appears:

```
TypeError: can't access property "phase", e is null
    er powergrid-viewer.umd.min.js  (engine ended(): return e.phase == Phase.GameEnd)
    value                          (replaceState)
    value                          (@Watch('state') handler)
    VueJS
```

Client-side navigation to the same game is fine; only a fresh mount hits it.

## Root cause

- `launch()` mounts the viewer with `state: null` and waits for the platform to post the first state.
- `@Watch('state', { immediate: true })` therefore fires **at mount** with `null`, calling `replaceState(null)`.
- Since #133, `replaceState` unconditionally dereferences the state: `if (replaceState && ended(state))` — and `ended(null)` reads `.phase` on null.

The bug shipped in viewer 2.0.5 and is latent in every release since.

## Fix

Guard the check: `if (replaceState && state && ended(state))`.

## Testing

- `vue-cli-service test:unit` — 26 passing ✅
- Built the UMD bundle (`vue-cli-service build --target lib`) and confirmed the guard is present in the minified output: `a&&e&&Object(me["ended"])(e)&&(this.gameIsOver=!0)` ✅
- Component-mount tests aren't possible in this repo's webpack-4 unit-test setup (same reason `player-order.ts` is a plain util module), hence the bundle-level verification.